### PR TITLE
Moving some of the statement management to a reducer

### DIFF
--- a/experiments/browser_based_querying/src/App.tsx
+++ b/experiments/browser_based_querying/src/App.tsx
@@ -93,7 +93,7 @@ type State = {
   ready: boolean /* Enables query running button */;
   hasMore: boolean /* Has more results that can be fetched */;
   results: object[] | null /* List of results corresponding to the the current query */;
-  isLoading: boolean /* Query execution is pending */;
+  isLoading: boolean /* Query is being executed */;
   /* null if no error, otherwise set to error message that can be displayed. */
   errMessage: string | null;
 };

--- a/experiments/browser_based_querying/src/App.tsx
+++ b/experiments/browser_based_querying/src/App.tsx
@@ -81,8 +81,8 @@ const EXAMPLE_OPTIONS: { name: string; value: [string, string] }[] = [
 type QueryMessageEvent = MessageEvent<{ done: boolean; value: object }>;
 
 type Action =
-  | { type: 'APP_INITIALIZED' }
-  | { type: 'QUIT' }
+  | { type: 'ALLOW_QUERY_EXECUTION' } /* OK to execute a query */
+  | { type: 'FORBID_QUERY_EXECUTION' }
   | { type: 'INVALID_VARS_JSON'; errMessage: string }
   | { type: 'FETCH_NEW_EXECUTE' } /* New execution of query start */
   | { type: 'FETCH_CONTINUE_EXECUTE' } /* Continuing execution of an existing query */
@@ -100,12 +100,12 @@ type State = {
 
 const queryStateReducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case 'APP_INITIALIZED':
+    case 'ALLOW_QUERY_EXECUTION':
       return {
         ...state,
         ready: true,
       };
-    case 'QUIT':
+    case 'FORBID_QUERY_EXECUTION':
       return {
         ...state,
         ready: false,
@@ -346,7 +346,7 @@ export default function App(): JSX.Element {
         queryWorker.removeEventListener('message', awaitInitConfirmation);
         queryWorker.addEventListener('message', handleQueryMessage);
         queryWorker.addEventListener('error', handleQueryError);
-        dispatchState({ type: 'APP_INITIALIZED' });
+        dispatchState({ type: 'ALLOW_QUERY_EXECUTION' });
       } else {
         throw new Error(`Unexpected message: ${data}`);
       }
@@ -356,7 +356,7 @@ export default function App(): JSX.Element {
     return () => {
       queryWorker.removeEventListener('message', handleQueryMessage);
       queryWorker.removeEventListener('message', awaitInitConfirmation);
-      dispatchState({ type: 'QUIT' });
+      dispatchState({ type: 'FORBID_QUERY_EXECUTION' });
     };
   }, [fetcherWorker, queryWorker]);
 

--- a/experiments/browser_based_querying/src/types.ts
+++ b/experiments/browser_based_querying/src/types.ts
@@ -1,4 +1,0 @@
-export type AsyncValue<T, E = string> =
-  | { status: 'pending' }
-  | { status: 'ready'; value: T }
-  | { status: 'error'; error: E };


### PR DESCRIPTION
This PR moves some of the statement management to use a reducer.

Just got started with ts/react, so there might be a good reason not to change
to the given state representation or a better representation available.
