### PR TITLE
fix: Clear results on running of query

### DIFF
--- a/experiments/browser_based_querying/src/App.tsx
+++ b/experiments/browser_based_querying/src/App.tsx
@@ -121,6 +121,7 @@ export default function App(): JSX.Element {
 
     setHasMore(true);
     setNextResult({ status: 'pending' });
+    setResults(null);
 
     queryWorker.postMessage({
       op: 'query',
@@ -254,6 +255,8 @@ export default function App(): JSX.Element {
     if (resultsEditor) {
       if (nextResult && nextResult.status === 'error') {
         resultsEditor.setValue(nextResult.error);
+      } else if (results == null && nextResult && nextResult.status === 'pending') {
+        resultsEditor.setValue('Loading...');
       } else if (results == null) {
         resultsEditor.setValue('Run a query on the left to see results here.');
       } else {


### PR DESCRIPTION
Since I forgot to clear `results` when the "Run Query" button is pressed, the results get appended to the current results. I also updated to render "Loading..." in the results window while fetching those first results.