### PR TITLE
Support storing query and vars state in URL

### DIFF
--- a/experiments/browser_based_querying/.eslintrc.json
+++ b/experiments/browser_based_querying/.eslintrc.json
@@ -13,7 +13,12 @@
   "rules": {
     "@typescript-eslint/no-var-requires": 0,
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error", {
+        "varsIgnorePattern": "^_"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/experiments/browser_based_querying/package-lock.json
+++ b/experiments/browser_based_querying/package-lock.json
@@ -20,7 +20,8 @@
         "monaco-graphql": "^1.1.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
-        "react-router-dom": "^6.3.0"
+        "react-router-dom": "^6.3.0",
+        "use-query-params": "^2.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.6",
@@ -5967,6 +5968,11 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/serialize-query-params": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.1.tgz",
+      "integrity": "sha512-MCw3M1sc0N0vTxsXfInqogI7Cygsnlv4Vdy1Sc+QAN50bpteYCIQRRS3FXT/mcCKOLxCR8ohLg29WmeOEXyjmw=="
+    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "dev": true,
@@ -6620,6 +6626,18 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-query-params": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.0.0.tgz",
+      "integrity": "sha512-7485Qjf2WKivnhylt6iB645Ba1+gMdNHIDwq3EpOZHPruj8V0HzlnnTNL3FKM+30VAmhzTKtaqL151W3yVl+Ag==",
+      "dependencies": {
+        "serialize-query-params": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -10840,6 +10858,11 @@
         "randombytes": "^2.1.0"
       }
     },
+    "serialize-query-params": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.1.tgz",
+      "integrity": "sha512-MCw3M1sc0N0vTxsXfInqogI7Cygsnlv4Vdy1Sc+QAN50bpteYCIQRRS3FXT/mcCKOLxCR8ohLg29WmeOEXyjmw=="
+    },
     "serve-index": {
       "version": "1.9.1",
       "dev": true,
@@ -11248,6 +11271,14 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "use-query-params": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.0.0.tgz",
+      "integrity": "sha512-7485Qjf2WKivnhylt6iB645Ba1+gMdNHIDwq3EpOZHPruj8V0HzlnnTNL3FKM+30VAmhzTKtaqL151W3yVl+Ag==",
+      "requires": {
+        "serialize-query-params": "^2.0.0"
       }
     },
     "util-deprecate": {

--- a/experiments/browser_based_querying/package.json
+++ b/experiments/browser_based_querying/package.json
@@ -38,7 +38,8 @@
     "monaco-graphql": "^1.1.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "use-query-params": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/experiments/browser_based_querying/src/App.tsx
+++ b/experiments/browser_based_querying/src/App.tsx
@@ -1,6 +1,8 @@
 import { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CircularProgress } from '@mui/material';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 const HackerNewsPlayground = lazy(() => import('./hackernews/Playground'));
 const RustdocPlayground = lazy(() => import('./rustdoc/Playground'));
@@ -8,24 +10,26 @@ const RustdocPlayground = lazy(() => import('./rustdoc/Playground'));
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route
-          path="/hackernews"
-          element={
-            <Suspense fallback={<CircularProgress />}>
-              <HackerNewsPlayground />
-            </Suspense>
-          }
-        />
-        <Route
-          path="/rustdoc"
-          element={
-            <Suspense fallback={<CircularProgress />}>
-              <RustdocPlayground />
-            </Suspense>
-          }
-        />
-      </Routes>
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <Routes>
+          <Route
+            path="/hackernews"
+            element={
+              <Suspense fallback={<CircularProgress />}>
+                <HackerNewsPlayground />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/rustdoc"
+            element={
+              <Suspense fallback={<CircularProgress />}>
+                <RustdocPlayground />
+              </Suspense>
+            }
+          />
+        </Routes>
+      </QueryParamProvider>
     </BrowserRouter>
   );
 }

--- a/experiments/browser_based_querying/src/App.tsx
+++ b/experiments/browser_based_querying/src/App.tsx
@@ -2,7 +2,7 @@ import { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CircularProgress } from '@mui/material';
 import { QueryParamProvider } from 'use-query-params';
-import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+import { QueryFragmentAdapter } from './QueryFragmentAdapter';
 
 const HackerNewsPlayground = lazy(() => import('./hackernews/Playground'));
 const RustdocPlayground = lazy(() => import('./rustdoc/Playground'));
@@ -10,7 +10,7 @@ const RustdocPlayground = lazy(() => import('./rustdoc/Playground'));
 export default function App() {
   return (
     <BrowserRouter>
-      <QueryParamProvider adapter={ReactRouter6Adapter}>
+      <QueryParamProvider adapter={QueryFragmentAdapter}>
         <Routes>
           <Route
             path="/hackernews"

--- a/experiments/browser_based_querying/src/QueryFragmentAdapter.tsx
+++ b/experiments/browser_based_querying/src/QueryFragmentAdapter.tsx
@@ -1,17 +1,12 @@
 import { useNavigate, useLocation } from 'react-router';
-import {
-  QueryParamAdapter,
-  QueryParamAdapterComponent,
-} from 'use-query-params';
+import { QueryParamAdapter, QueryParamAdapterComponent } from 'use-query-params';
 
 /**
  * Query Param Adapter for use-query-params that uses URL fragments
  * instead of query params, which allows us to bypass query param length limits,
  * since fragments are not sent to the server.
  */
-export const QueryFragmentAdapter: QueryParamAdapterComponent = ({
-  children,
-}) => {
+export const QueryFragmentAdapter: QueryParamAdapterComponent = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -31,7 +26,7 @@ export const QueryFragmentAdapter: QueryParamAdapterComponent = ({
     get location() {
       return {
         ...location,
-        search: location.hash.slice(1),  // Remove leading '#'
+        search: location.hash.slice(1), // Remove leading '#'
       };
     },
   };

--- a/experiments/browser_based_querying/src/QueryFragmentAdapter.tsx
+++ b/experiments/browser_based_querying/src/QueryFragmentAdapter.tsx
@@ -1,0 +1,40 @@
+import { useNavigate, useLocation } from 'react-router';
+import {
+  QueryParamAdapter,
+  QueryParamAdapterComponent,
+} from 'use-query-params';
+
+/**
+ * Query Param Adapter for use-query-params that uses URL fragments
+ * instead of query params, which allows us to bypass query param length limits,
+ * since fragments are not sent to the server.
+ */
+export const QueryFragmentAdapter: QueryParamAdapterComponent = ({
+  children,
+}) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const adapter: QueryParamAdapter = {
+    replace(location) {
+      navigate(`#${location.search ?? '?'}`, {
+        replace: true,
+        state: location.state,
+      });
+    },
+    push(location) {
+      navigate(`#${location.search ?? '?'}`, {
+        replace: false,
+        state: location.state,
+      });
+    },
+    get location() {
+      return {
+        ...location,
+        search: location.hash.slice(1),  // Remove leading '#'
+      };
+    },
+  };
+
+  return children(adapter);
+};

--- a/experiments/browser_based_querying/src/components/DocExplorer.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer.tsx
@@ -77,7 +77,6 @@ export function DocExplorer(props: DocExplorerProps) {
     content = <FieldDoc />;
   }
 
-  console.log(explorerNavStack);
 
   const shouldSearchBoxAppear =
     explorerNavStack.length === 1 || (isType(navItem.def) && 'getFields' in navItem.def);


### PR DESCRIPTION
This PR uses the fantastic `use-query-params` library to persist the query and vars strings in the URL, which makes our demos shareable! Since we are storing entire encoded queries in the URL, we can quickly run into URL length limits if we use the default functionality of storing data as query params. Fortunately, `use-query-params` allows us to specify a custom `QueryParamAdapter` that lets us convert to using hash fragments instead, which are not sent to the server!