### PR TITLE
Fix playground error bug

### DIFF
--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -122,18 +122,18 @@ export default function Rustdoc(): JSX.Element {
 
   const disabledMessage = useMemo(() => {
     if (!asyncLoadedCrate) {
-      return 'First select a crate to query against'
+      return 'First select a crate to query against';
     }
 
     if (asyncLoadedCrate.status === 'pending') {
-      return 'Loading crate info...'
+      return 'Loading crate info...';
     }
 
     if (asyncLoadedCrate.status === 'error') {
-      return 'Error loading crate, please try again'
+      return 'Error loading crate, please try again';
     }
 
-    return null
+    return null;
   }, [asyncLoadedCrate]);
 
   useEffect(() => {
@@ -198,12 +198,7 @@ export default function Rustdoc(): JSX.Element {
         {header}
       </Grid>
       <Grid container direction="column" item xs={11}>
-        {queryWorker && (
-          <Playground
-            queryWorker={queryWorker}
-            disabled={disabledMessage}
-          />
-        )}
+        {queryWorker && <Playground queryWorker={queryWorker} disabled={disabledMessage} />}
       </Grid>
     </Grid>
   );

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -57,9 +57,10 @@ function Playground(props: PlaygroundProps): JSX.Element {
     switch (msg.type) {
       case 'query-ready':
         setResults(msg.results);
+        setError(null);
         break;
       case 'query-error':
-        setError(msg.message);
+        setError(`Error: ${msg.message}`);
         break;
     }
     setLoading(false);

--- a/experiments/browser_based_querying/src/rustdoc/queryWorker.ts
+++ b/experiments/browser_based_querying/src/rustdoc/queryWorker.ts
@@ -25,7 +25,7 @@ function dispatch(evt: MessageEvent<RustdocWorkerMessage>) {
         const results = runQuery(crateInfo, msg.query, msg.vars);
         send({ type: 'query-ready', results });
       } catch (message) {
-        throw new Error(message as string);
+        send({ type: 'query-error', message: message as string })
       }
       break;
 

--- a/experiments/browser_based_querying/src/rustdoc/queryWorker.ts
+++ b/experiments/browser_based_querying/src/rustdoc/queryWorker.ts
@@ -25,7 +25,7 @@ function dispatch(evt: MessageEvent<RustdocWorkerMessage>) {
         const results = runQuery(crateInfo, msg.query, msg.vars);
         send({ type: 'query-ready', results });
       } catch (message) {
-        send({ type: 'query-error', message: message as string })
+        send({ type: 'query-error', message: message as string });
       }
       break;
 


### PR DESCRIPTION
Silly mistake: I forgot to clear the error state, so the playground would get stuck after showing an error.