### PR TITLE
Add the transform directive to all schemas.

### DIFF
--- a/demo-feeds/src/feeds.graphql
+++ b/demo-feeds/src/feeds.graphql
@@ -23,6 +23,12 @@ directive @recurse(
     """
     depth: Int!
 ) on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
 
 type RootSchemaQuery {
     Feed: [Feed!]!

--- a/demo-hackernews/hackernews.graphql
+++ b/demo-hackernews/hackernews.graphql
@@ -23,6 +23,12 @@ directive @recurse(
     """
     depth: Int!
 ) on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
 
 type RootSchemaQuery {
     FrontPage: [Item!]!

--- a/demo-hytradboi/schema.graphql
+++ b/demo-hytradboi/schema.graphql
@@ -23,6 +23,12 @@ directive @recurse(
     """
     depth: Int!
 ) on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
 
 type RootSchemaQuery {
     MostDownloadedCrates: [Crate!]!

--- a/demo-metar/src/metar_weather.graphql
+++ b/demo-metar/src/metar_weather.graphql
@@ -23,6 +23,12 @@ directive @recurse(
     """
     depth: Int!
 ) on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
 
 type RootSchemaQuery {
     MetarReport: [MetarReport]

--- a/experiments/browser_based_querying/.gitignore
+++ b/experiments/browser_based_querying/.gitignore
@@ -2,3 +2,4 @@ trustfall_wasm.tar.gz
 **/node_modules
 **/www
 **/__pycache__
+**/dist

--- a/experiments/browser_based_querying/src/hackernews/schema.graphql
+++ b/experiments/browser_based_querying/src/hackernews/schema.graphql
@@ -7,6 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
+directive @transform(op: String!) on FIELD
 
 type RootSchemaQuery {
   HackerNewsFrontPage: [HackerNewsItem!]!

--- a/experiments/browser_based_querying/src/hackernews/schema.graphql
+++ b/experiments/browser_based_querying/src/hackernews/schema.graphql
@@ -1,13 +1,42 @@
 schema {
   query: RootSchemaQuery
 }
-directive @filter(op: String!, value: [String!]) on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @filter(
+  """
+  Name of the filter operation to perform.
+  """
+  op: String!
+  """
+  List of string operands for the operator.
+  """
+  value: [String!]
+) on FIELD | INLINE_FRAGMENT
+directive @tag(
+  """
+  Name to apply to the given property field.
+  """
+  name: String
+) on FIELD
+directive @output(
+  """
+  What to designate the output field generated from this property field.
+  """
+  name: String
+) on FIELD
 directive @optional on FIELD
-directive @recurse(depth: Int!) on FIELD
-directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @recurse(
+  """
+  Recurse up to this many times on this edge. A depth of 1 produces the current
+  vertex and its immediate neighbors along the given edge.
+  """
+  depth: Int!
+) on FIELD
+directive @transform(
+  """
+  Name of the transformation operation to perform.
+  """
+  op: String!
+) on FIELD
 
 type RootSchemaQuery {
   HackerNewsFrontPage: [HackerNewsItem!]!

--- a/experiments/trustfall_rustdoc/src/rustdoc_schema.graphql
+++ b/experiments/trustfall_rustdoc/src/rustdoc_schema.graphql
@@ -1,12 +1,42 @@
 schema {
   query: RootSchemaQuery
 }
-directive @filter(op: String!, value: [String!]) on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @filter(
+  """
+  Name of the filter operation to perform.
+  """
+  op: String!
+  """
+  List of string operands for the operator.
+  """
+  value: [String!]
+) on FIELD | INLINE_FRAGMENT
+directive @tag(
+  """
+  Name to apply to the given property field.
+  """
+  name: String
+) on FIELD
+directive @output(
+  """
+  What to designate the output field generated from this property field.
+  """
+  name: String
+) on FIELD
 directive @optional on FIELD
-directive @recurse(depth: Int!) on FIELD
-directive @fold on FIELD
+directive @recurse(
+  """
+  Recurse up to this many times on this edge. A depth of 1 produces the current
+  vertex and its immediate neighbors along the given edge.
+  """
+  depth: Int!
+) on FIELD
+directive @transform(
+  """
+  Name of the transformation operation to perform.
+  """
+  op: String!
+) on FIELD
 
 type RootSchemaQuery {
   Crate: Crate!

--- a/pytrustfall/numbers.graphql
+++ b/pytrustfall/numbers.graphql
@@ -1,12 +1,34 @@
 schema {
     query: RootSchemaQuery
 }
-directive @filter(op: String!, value: [String!]) on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @filter(
+    """Name of the filter operation to perform."""
+    op: String!
+    """List of string operands for the operator."""
+    value: [String!]
+) on FIELD | INLINE_FRAGMENT
+directive @tag(
+    """Name to apply to the given property field."""
+    name: String
+) on FIELD
+directive @output(
+    """What to designate the output field generated from this property field."""
+    name: String
+) on FIELD
 directive @optional on FIELD
-directive @recurse(depth: Int!) on FIELD
-directive @fold on FIELD
+directive @recurse(
+    """
+    Recurse up to this many times on this edge. A depth of 1 produces the current
+    vertex and its immediate neighbors along the given edge.
+    """
+    depth: Int!
+) on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
 
 type RootSchemaQuery {
     Number(max: Int!): [Number!]

--- a/trustfall_core/src/resources/schemas/filesystem.graphql
+++ b/trustfall_core/src/resources/schemas/filesystem.graphql
@@ -7,6 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
+directive @transform(op: String!) on FIELD
 
 type RootSchemaQuery {
     OriginDirectory: [Directory]

--- a/trustfall_core/src/resources/schemas/nullables.graphql
+++ b/trustfall_core/src/resources/schemas/nullables.graphql
@@ -7,6 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
+directive @transform(op: String!) on FIELD
 
 type RootSchemaQuery {
     MainType: MainType

--- a/trustfall_core/src/resources/schemas/numbers.graphql
+++ b/trustfall_core/src/resources/schemas/numbers.graphql
@@ -7,6 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
+directive @transform(op: String!) on FIELD
 
 type RootSchemaQuery {
     Number(min: Int = 0, max: Int!): [Number!]

--- a/trustfall_core/src/resources/schemas/recurses.graphql
+++ b/trustfall_core/src/resources/schemas/recurses.graphql
@@ -7,6 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
+directive @transform(op: String!) on FIELD
 
 type RootSchemaQuery {
     Base: Base


### PR DESCRIPTION
Should fix the web editor bug where `@transform` isn't recognized but queries that use it run fine. The web editor parses based on what's in the schema file, so adding `@transform` to the schema file will make it happy.