### PR TITLE
Fix docs explorer content font

### DIFF
--- a/experiments/browser_based_querying/src/components/DocExplorer.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer.tsx
@@ -124,7 +124,9 @@ export function DocExplorer(props: DocExplorerProps) {
           )}
         </Grid>
         <Grid item container direction="column">
-          {content}
+          <Typography>
+            {content}
+          </Typography>
         </Grid>
       </Grid>
     </Grid>


### PR DESCRIPTION
The `Typography` component from material provides the correct font settings.