### PR TITLE
Move docs explorer into tab pane

### DIFF
--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -4,6 +4,7 @@ import { LoadingButton } from '@mui/lab';
 import {
   Box,
   Button,
+  Drawer,
   FormControl,
   Grid,
   InputLabel,
@@ -125,6 +126,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   const [resultsEditor, setResultsEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(
     null
   );
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const handleExampleQueryChange = useCallback(
     (evt: SelectChangeEvent<string | null>) => {
@@ -309,8 +311,19 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
       <Grid container item xs={11} spacing={2} sx={{ flexWrap: 'nowrap' }}>
         <Grid container item direction="column" xs={7} sx={{ flexWrap: 'nowrap' }}>
           <Grid container item direction="column" xs={8} sx={{ flexWrap: 'nowrap' }}>
-            <Typography variant="overline" component="div">
+            <Typography
+              variant="overline"
+              component="div"
+              sx={{ display: 'flex', justifyContent: 'space-between' }}
+            >
               Query
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => setIsDrawerOpen((prev) => !prev)}
+              >
+                {isDrawerOpen ? "Hide Docs" : "Show Docs"}
+              </Button>
             </Typography>
             <Paper elevation={0} sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
               <div ref={queryEditorRef} css={cssEditor} />
@@ -344,14 +357,16 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             <div ref={resultsEditorRef} css={cssEditor} />
           </Paper>
         </Grid>
-        <Grid container item xs={4} direction="column" sx={{ flexWrap: 'nowrap' }}>
-          <Typography variant="h6" component="div">
-            Documentation Explorer
-          </Typography>
-          <Box sx={{ maxHeight: '85vh', overflowY: 'overlay', overflowX: 'hidden', mt: 2 }}>
-            <SimpleDocExplorer schema={schema} />
+        <Drawer variant="persistent" open={isDrawerOpen} anchor="right">
+          <Box sx={{ p: 2 }}>
+            <Typography variant="h6" component="div">
+              Documentation Explorer
+            </Typography>
+            <Box sx={{ maxHeight: '85vh', overflowY: 'overlay', overflowX: 'hidden', mt: 2 }}>
+              <SimpleDocExplorer schema={schema} />
+            </Box>
           </Box>
-        </Grid>
+        </Drawer>
       </Grid>
     </Grid>
   );

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -321,6 +321,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
               onClick={() => onQueryNextResult()}
               disabled={!hasMore || Boolean(disabled)}
               loading={loading}
+              sx={{mr: 2}}
             >
               {hasMore ? 'More!' : 'No more results'}
             </LoadingButton>

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -342,7 +342,13 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           </FormControl>
         </div>
       </Grid>
-      <Grid container item xs={11} spacing={2} sx={{ flexWrap: 'nowrap' }}>
+      <Grid
+        container
+        item
+        xs={11}
+        spacing={2}
+        sx={{ flexShrink: 1, flexWrap: 'nowrap', overflowY: 'hidden' }}
+      >
         <Grid container item direction="column" xs={7} sx={{ flexWrap: 'nowrap' }}>
           <Grid container item direction="column" xs={8} sx={{ flexWrap: 'nowrap' }}>
             {/* Use padding to align query section with results */}
@@ -377,10 +383,17 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
               <div ref={resultsEditorRef} css={cssEditor} />
             </Paper>
           </TabPanel>
-          <TabPanel selected={selectedTab === 'docs'}>
-            <Box sx={{ maxHeight: '85vh', overflowY: 'overlay', overflowX: 'hidden' }}>
-              <SimpleDocExplorer schema={schema} />
-            </Box>
+          <TabPanel
+            selected={selectedTab === 'docs'}
+            sx={{
+              display: selectedTab ==='docs' ? 'flex' : 'none',
+              flexDirection: 'column',
+              flex: 1,
+              overflowY: 'hidden',
+              overflowX: 'hidden',
+            }}
+          >
+            <SimpleDocExplorer schema={schema} />
           </TabPanel>
         </Grid>
       </Grid>

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -347,7 +347,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         item
         xs={11}
         spacing={2}
-        sx={{ flexShrink: 1, flexWrap: 'nowrap', overflowY: 'hidden' }}
+        sx={{ flexWrap: 'nowrap', overflowY: 'hidden' }}
       >
         <Grid container item direction="column" xs={7} sx={{ flexWrap: 'nowrap' }}>
           <Grid container item direction="column" xs={8} sx={{ flexWrap: 'nowrap' }}>
@@ -388,7 +388,6 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             sx={{
               display: selectedTab ==='docs' ? 'flex' : 'none',
               flexDirection: 'column',
-              flex: 1,
               overflowY: 'hidden',
               overflowX: 'hidden',
             }}

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -3,8 +3,6 @@ import { css } from '@emotion/react';
 import { LoadingButton } from '@mui/lab';
 import {
   Box,
-  Button,
-  Drawer,
   FormControl,
   Grid,
   InputLabel,
@@ -12,6 +10,8 @@ import {
   Paper,
   Select,
   SelectChangeEvent,
+  Tabs,
+  Tab,
   Typography,
   Theme,
   SxProps,
@@ -71,6 +71,23 @@ window.MonacoEnvironment = {
   },
 };
 
+type ResultsTab = 'results' | 'docs';
+
+interface TabPanelProps {
+  selected: boolean;
+  children: React.ReactNode;
+  sx?: SxProps;
+}
+
+function TabPanel(props: TabPanelProps): JSX.Element {
+  const { selected, children, sx } = props;
+  return (
+    <Box sx={sx} hidden={!selected}>
+      {children}
+    </Box>
+  );
+}
+
 interface TrustfallPlaygroundProps {
   results: object[] | null;
   loading: boolean;
@@ -126,7 +143,11 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   const [resultsEditor, setResultsEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(
     null
   );
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [selectedTab, setSelectedTab] = useState<ResultsTab>('results');
+
+  const handleTabChange = useCallback((_evt: React.SyntheticEvent, value: ResultsTab) => {
+    setSelectedTab(value);
+  }, []);
 
   const handleExampleQueryChange = useCallback(
     (evt: SelectChangeEvent<string | null>) => {
@@ -145,6 +166,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
     const vars = varsEditor.getValue();
 
     onQuery(query, vars);
+    setSelectedTab('results');
   }, [queryEditor, varsEditor, onQuery]);
 
   useEffect(() => {
@@ -280,17 +302,29 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         <div css={{ display: 'flex', alignItems: 'center', margin: 10 }}>
           <Tooltip title={disabled ? disabled : ''} placement="bottom">
             <span>
-              <Button
+              <LoadingButton
                 size="small"
                 onClick={() => handleQuery()}
                 variant="contained"
                 sx={{ mr: 2 }}
                 disabled={Boolean(disabled)}
+                loading={loading}
               >
                 Run query!
-              </Button>
+              </LoadingButton>
             </span>
           </Tooltip>
+          {onQueryNextResult && results != null && (
+            <LoadingButton
+              size="small"
+              variant="outlined"
+              onClick={() => onQueryNextResult()}
+              disabled={!hasMore || Boolean(disabled)}
+              loading={loading}
+            >
+              {hasMore ? 'More!' : 'No more results'}
+            </LoadingButton>
+          )}
           <FormControl size="small" sx={{ minWidth: 300 }}>
             <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
             <Select
@@ -311,19 +345,9 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
       <Grid container item xs={11} spacing={2} sx={{ flexWrap: 'nowrap' }}>
         <Grid container item direction="column" xs={7} sx={{ flexWrap: 'nowrap' }}>
           <Grid container item direction="column" xs={8} sx={{ flexWrap: 'nowrap' }}>
-            <Typography
-              variant="overline"
-              component="div"
-            >
+            {/* Use padding to align query section with results */}
+            <Typography variant="overline" component="div" sx={{ pt: '1.5rem' }}>
               Query
-              <Button
-                variant="text"
-                size="small"
-                onClick={() => setIsDrawerOpen((prev) => !prev)}
-                sx={{ml: 2}}
-              >
-                {isDrawerOpen ? "Hide Docs" : "Show Docs"}
-              </Button>
             </Typography>
             <Paper elevation={0} sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
               <div ref={queryEditorRef} css={cssEditor} />
@@ -339,34 +363,26 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           </Grid>
         </Grid>
         <Grid container item xs={5} direction="column" sx={{ flexWrap: 'nowrap' }}>
-          <Typography variant="overline" component="div">
-            Results{' '}
-            {onQueryNextResult && results != null && (
-              <LoadingButton
-                size="small"
-                variant="outlined"
-                onClick={() => onQueryNextResult()}
-                disabled={!hasMore || Boolean(disabled)}
-                loading={loading}
-              >
-                {hasMore ? 'More!' : 'No more results'}
-              </LoadingButton>
-            )}
-          </Typography>
-          <Paper elevation={0} sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
-            <div ref={resultsEditorRef} css={cssEditor} />
-          </Paper>
-        </Grid>
-        <Drawer variant="persistent" open={isDrawerOpen} anchor="right">
-          <Box sx={{ p: 2 }}>
-            <Typography variant="h6" component="div">
-              Documentation Explorer
-            </Typography>
-            <Box sx={{ maxHeight: '85vh', overflowY: 'overlay', overflowX: 'hidden', mt: 2 }}>
+          <Box>
+            <Tabs value={selectedTab} onChange={handleTabChange} sx={{ pb: 1 }}>
+              <Tab value="results" label="Results" />
+              <Tab value="docs" label="Docs" />
+            </Tabs>
+          </Box>
+          <TabPanel
+            selected={selectedTab === 'results'}
+            sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}
+          >
+            <Paper elevation={0}>
+              <div ref={resultsEditorRef} css={cssEditor} />
+            </Paper>
+          </TabPanel>
+          <TabPanel selected={selectedTab === 'docs'}>
+            <Box sx={{ maxHeight: '85vh', overflowY: 'overlay', overflowX: 'hidden' }}>
               <SimpleDocExplorer schema={schema} />
             </Box>
-          </Box>
-        </Drawer>
+          </TabPanel>
+        </Grid>
       </Grid>
     </Grid>
   );

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -314,13 +314,13 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             <Typography
               variant="overline"
               component="div"
-              sx={{ display: 'flex', justifyContent: 'space-between' }}
             >
               Query
               <Button
-                variant="outlined"
+                variant="text"
                 size="small"
                 onClick={() => setIsDrawerOpen((prev) => !prev)}
+                sx={{ml: 2}}
               >
                 {isDrawerOpen ? "Hide Docs" : "Show Docs"}
               </Button>

--- a/experiments/browser_based_querying/src/components/DocExplorer.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer.tsx
@@ -93,6 +93,7 @@ export function DocExplorer(props: DocExplorerProps) {
       key={navItem.name}
       direction="column"
       spacing={1}
+      sx={{overflowY: 'auto', overflowX: 'hidden', flexWrap: 'nowrap'}}
     >
       <Grid container item direction="row" alignItems="center">
         <Grid item>

--- a/experiments/browser_based_querying/src/components/DocExplorer.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer.tsx
@@ -46,7 +46,7 @@ export function DocExplorer(props: DocExplorerProps) {
     schema: schemaFromContext,
     validationErrors,
   } = useSchemaContext({ nonNull: true });
-  const { explorerNavStack, hide, pop, showSearch } = useExplorerContext({
+  const { explorerNavStack, pop, showSearch } = useExplorerContext({
     nonNull: true,
   });
 
@@ -108,7 +108,7 @@ export function DocExplorer(props: DocExplorerProps) {
           </Button>
         </Grid>
         <Grid item>
-          <Typography variant="body1" color="dimgray">
+          <Typography variant="body1" color="dimgray" sx={{textAlign: 'center'}}>
             {navItem.name}
           </Typography>
         </Grid>
@@ -124,7 +124,9 @@ export function DocExplorer(props: DocExplorerProps) {
           )}
         </Grid>
         <Grid item container direction="column">
-          {content}
+          <Typography>
+            {content}
+          </Typography>
         </Grid>
       </Grid>
     </Grid>

--- a/experiments/browser_based_querying/src/components/DocExplorer/SchemaDoc.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer/SchemaDoc.tsx
@@ -35,7 +35,7 @@ export default function SchemaDoc() {
         }
       />
       <div className="doc-category">
-        <Typography fontWeight="bold">root types</Typography>
+        <Typography fontWeight="bold">Root Types</Typography>
         {queryType ? (
           <div className="doc-category-item">
             <Typography display="inline">query: </Typography>

--- a/experiments/browser_based_querying/src/components/DocExplorer/SearchBox.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer/SearchBox.tsx
@@ -9,7 +9,7 @@
  *  Adapted from https://github.com/graphql/graphiql
  */
 import ClearIcon from '@mui/icons-material/Clear';
-import { Grid, TextField } from '@mui/material';
+import { TextField } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import SearchIcon from '@mui/icons-material/Search';
 import InputAdornment from '@mui/material/InputAdornment';

--- a/experiments/browser_based_querying/src/components/DocExplorer/SearchBox.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer/SearchBox.tsx
@@ -76,6 +76,7 @@ export default class SearchBox extends React.Component<SearchBoxProps, SearchBox
             </InputAdornment>
           ),
         }}
+        fullWidth
       />
     );
   }

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -197,7 +197,7 @@ export default function Rustdoc(): JSX.Element {
       <Grid item xs={1}>
         {header}
       </Grid>
-      <Grid container direction="column" item xs={11}>
+      <Grid container direction="column" item xs={11} sx={{flexShrink: 1, overflowY: 'hidden'}}>
         {queryWorker && <Playground queryWorker={queryWorker} disabled={disabledMessage} />}
       </Grid>
     </Grid>


### PR DESCRIPTION
The reasoning behind this approach is that the docs exist to help you write a query, and therefore can replace the results pane. Tabs are the perfect UI primitive to accomplish this. Running a query will automatically select the results pane.

![image](https://user-images.githubusercontent.com/1556995/187805797-0e9ccb82-809e-40ae-836c-484921cdae5f.png)

![image](https://user-images.githubusercontent.com/1556995/187805826-fe56be95-d998-48a2-8acc-3f98494c08f8.png)

Some finagling was required to get the pane to scroll appropriately.
![image](https://user-images.githubusercontent.com/1556995/187805850-c303a1dc-bc26-4f3c-8ccb-dc54236f6f16.png)

This warranted moving the "More!" button next to the Run Query button, which honestly makes more sense.
