### PR TITLE
Update page copy on both playground UIs.

### DIFF
--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -42,14 +42,18 @@ export default function HackerNewsPlayground(): JSX.Element {
     () => (
       <Box>
         <Typography variant="h4" component="div">
-          Trustfall in-browser query demo
+          HackerNews API — Trustfall Playground
         </Typography>
         <Typography>
-          Query the HackerNews API directly from your browser with GraphQL, using{' '}
+          Query HackerNews directly from your browser with{' '}
           <a href="https://github.com/obi1kenobi/trustfall" target="_blank" rel="noreferrer">
             Trustfall
           </a>{' '}
           compiled to WebAssembly.
+        </Typography>
+        <Typography>
+          Results are computed one at a time to conserve data and API rate limits.
+          Even so, querying from a mobile data plan is not recommended.
         </Typography>
       </Box>
     ),

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -168,14 +168,19 @@ export default function Rustdoc(): JSX.Element {
     return (
       <Box>
         <Typography variant="h4" component="div">
-          Trustfall in-browser query demo
+          Rust crates — Trustfall Playground
         </Typography>
         <Typography>
-          Query rustdocs directly from your browser with GraphQL, using{' '}
+          Query a crate's rustdoc directly from your browser with{' '}
           <a href="https://github.com/obi1kenobi/trustfall" target="_blank" rel="noreferrer">
             Trustfall
           </a>{' '}
           compiled to WebAssembly.
+        </Typography>
+        <Typography>
+          Selecting a crate downloads a few MB of data;
+          you might not want to do this from a mobile data plan.
+          If your favorite crate is missing, <a href="https://github.com/obi1kenobi/crates-rustdoc/issues/new/choose">let us know</a>!
         </Typography>
         {queryWorker && (
           <Box>

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -178,7 +178,7 @@ export default function Rustdoc(): JSX.Element {
           compiled to WebAssembly.
         </Typography>
         <Typography>
-          Selecting a crate downloads a few MB of data;
+          Selecting a crate downloads a few MB of data, so {' '}
           you might not want to do this from a mobile data plan.
           If your favorite crate is missing, <a href="https://github.com/obi1kenobi/crates-rustdoc/issues/new/choose">let us know</a>!
         </Typography>


### PR DESCRIPTION
HackerNews:
![image](https://user-images.githubusercontent.com/2348618/187808779-40dd6fdf-05eb-4a97-be39-88b518eecc19.png)

Rustdoc:
![image](https://user-images.githubusercontent.com/2348618/187808815-06ff6ff1-e4ed-4f20-812b-24b1088c8471.png)
