### PR TITLE
Clean up HackerNews adapter and use schema from file.

### DIFF
--- a/experiments/browser_based_querying/index.d.ts
+++ b/experiments/browser_based_querying/index.d.ts
@@ -3,3 +3,9 @@ declare module '*.example' {
   const content: string;
   export default content;
 }
+
+// Tell Typescript to interpret imports of .graphql files as strings
+declare module '*.graphql' {
+  const content: string;
+  export default content;
+}

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -9,7 +9,7 @@ import latestStoriesExample from '../../example_queries/latest_stories_with_min_
 import patio11Example from '../../example_queries/patio11_commenting_on_submissions_of_his_blog_posts.example';
 import topStoriesExample from '../../example_queries/top_stories_with_min_points_and_submitter_karma.example';
 
-import { HN_SCHEMA } from './adapter';
+import HN_SCHEMA from './schema.graphql';
 
 const EXAMPLE_OPTIONS: { name: string; value: [string, string] }[] = [
   {

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -10,111 +10,13 @@ import init, {
   executeQuery,
 } from '../../www2/trustfall_wasm.js';
 import { getTopItems, getLatestItems, materializeItem, materializeUser } from './utils';
+import schema from './schema.graphql';
 
-console.log('running wasm init...');
-await init();
-console.log('wasm init complete');
+// We need both of these!
+await init();  // WASM system init.
+initialize();  // Trustfall query system init.
 
-console.log('Query system init...');
-initialize();
-console.log('Query system initialized');
-
-// TODO: This is a copy of schema.graphql, find a better way to include it.
-export const HN_SCHEMA = `
-schema {
-  query: RootSchemaQuery
-}
-directive @filter(op: String!, value: [String!]) on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
-directive @optional on FIELD
-directive @recurse(depth: Int!) on FIELD
-directive @fold on FIELD
-
-type RootSchemaQuery {
-  HackerNewsFrontPage: [HackerNewsItem!]!
-  HackerNewsTop(max: Int): [HackerNewsItem!]!
-  HackerNewsLatestStories(max: Int): [HackerNewsStory!]!
-  HackerNewsUser(name: String!): HackerNewsUser
-}
-
-interface HackerNewsItem {
-  id: Int!
-  unixTime: Int!
-  ownUrl: String!
-}
-
-type HackerNewsJob implements HackerNewsItem {
-  # properties from HackerNewsItem
-  id: Int!
-  unixTime: Int!
-  ownUrl: String!
-
-  # own properties
-  title: String!
-  score: Int!
-  url: String!
-
-  # edges
-  link: Webpage!
-}
-
-type HackerNewsStory implements HackerNewsItem {
-  # properties from HackerNewsItem
-  id: Int!
-  unixTime: Int!
-  ownUrl: String!
-
-  # own properties
-  byUsername: String!
-  score: Int!
-  text: String
-  title: String!
-  url: String
-  commentsCount: Int!
-
-  # edges
-  byUser: HackerNewsUser!
-  comment: [HackerNewsComment!]
-  link: Webpage
-}
-
-type HackerNewsComment implements HackerNewsItem {
-  # properties from HackerNewsItem
-  id: Int!
-  unixTime: Int!
-  ownUrl: String!
-
-  # own properties
-  text: String!
-  byUsername: String!
-
-  # edges
-  byUser: HackerNewsUser!
-  reply: [HackerNewsComment!]
-  parent: HackerNewsItem!  # either a parent comment or the story being commented on
-
-  # not implemented yet
-  # topmostAncestor: HackerNewsItem!  # the ultimate ancestor of this item: a story or job
-}
-
-type HackerNewsUser {
-  id: String!
-  karma: Int!
-  about: String
-  unixCreatedAt: Int!
-
-  # The HackerNews API treats submissions of comments and stories the same way.
-  # The way to get only a user's submitted stories is to use this edge then
-  # apply a type coercion on the \`HackerNewsItem\` vertex on edge endpoint:
-  # \`...on HackerNewsStory\`
-  submitted: [HackerNewsItem!]
-}
-
-interface Webpage {
-  url: String!
-}
-`;
+export const HN_SCHEMA = schema;
 
 Schema.parse(HN_SCHEMA);
 console.log('Schema loaded.');
@@ -454,7 +356,6 @@ function dispatch(e: MessageEvent<AdapterMessage>): void {
       done: rawResult.done,
       value: rawResult.value,
     };
-    console.log('Adapter posting:', result);
     postMessage(result);
     return;
   }

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -10,13 +10,11 @@ import init, {
   executeQuery,
 } from '../../www2/trustfall_wasm.js';
 import { getTopItems, getLatestItems, materializeItem, materializeUser } from './utils';
-import schema from './schema.graphql';
+import HN_SCHEMA from './schema.graphql';
 
 // We need both of these!
 await init();  // WASM system init.
 initialize();  // Trustfall query system init.
-
-export const HN_SCHEMA = schema;
 
 Schema.parse(HN_SCHEMA);
 console.log('Schema loaded.');

--- a/experiments/browser_based_querying/src/hackernews/fetcher.ts
+++ b/experiments/browser_based_querying/src/hackernews/fetcher.ts
@@ -10,7 +10,6 @@ interface ChannelData {
 
 onmessage = function (e): void {
   const data = e.data;
-  console.log('Fetcher received data:', data);
 
   if (data.op === 'channel') {
     const inputChannel = data.data.port;
@@ -23,13 +22,11 @@ onmessage = function (e): void {
 
 function fetchHandler(e: MessageEvent<ChannelData>): void {
   const data = e.data;
-  console.log('Fetcher received channel data:', data);
 
   const sync = new SyncContext(data.sync);
 
   fetch(data.input, data.init)
     .then((response) => {
-      console.log('worker fetch complete:', response.ok, response.status);
       if (!response.ok) {
         console.log('non-ok response:', response.status);
         sync.sendError(`non-ok response: ${response.status}`);

--- a/experiments/browser_based_querying/src/hackernews/utils.ts
+++ b/experiments/browser_based_querying/src/hackernews/utils.ts
@@ -21,7 +21,6 @@ export function materializeItem(fetchPort: MessagePort, itemId: number): HackerN
 
   const result = new TextDecoder().decode(sync.receive());
   const item = JSON.parse(result);
-  console.log('materialized item:', item);
 
   return item;
 }
@@ -43,7 +42,6 @@ export function materializeUser(fetchPort: MessagePort, username: string): unkno
 
   const result = new TextDecoder().decode(sync.receive());
   const user = JSON.parse(result);
-  console.log('materialized user:', user);
 
   return user;
 }
@@ -54,10 +52,8 @@ export function* getTopItems(fetchPort: MessagePort): Generator<HackerNewsItem> 
   const url = 'https://hacker-news.firebaseio.com/v0/topstories.json';
   const fetchOptions = {
     method: 'GET',
-    // "credentials": "omit",
   };
 
-  console.log('posting to fetcher');
   const message = {
     sync: sync.makeSendable(),
     input: url,
@@ -65,12 +61,8 @@ export function* getTopItems(fetchPort: MessagePort): Generator<HackerNewsItem> 
   };
   fetchPort.postMessage(message);
 
-  console.log('waiting (1) for fetcher');
-
   const result = new TextDecoder().decode(sync.receive());
-  console.log('result=', result);
   const storyIds = JSON.parse(result);
-  console.log('storyIds=', storyIds);
 
   for (const id of storyIds) {
     const item = materializeItem(fetchPort, id);
@@ -90,10 +82,8 @@ export function* getLatestItems(fetchPort: MessagePort): Generator<HackerNewsIte
   const url = 'https://hacker-news.firebaseio.com/v0/newstories.json';
   const fetchOptions = {
     method: 'GET',
-    // "credentials": "omit",
   };
 
-  console.log('posting to fetcher');
   const message = {
     sync: sync.makeSendable(),
     input: url,
@@ -101,12 +91,8 @@ export function* getLatestItems(fetchPort: MessagePort): Generator<HackerNewsIte
   };
   fetchPort.postMessage(message);
 
-  console.log('waiting (1) for fetcher');
-
   const result = new TextDecoder().decode(sync.receive());
-  console.log('result=', result);
   const storyIds = JSON.parse(result);
-  console.log('storyIds=', storyIds);
 
   for (const id of storyIds) {
     const item = materializeItem(fetchPort, id);


### PR DESCRIPTION
- Using the `schema.graphql` file for the HackerNews queries.
- Removed verbose logging on almost all happy paths.

I'm also thinking about streamlining the schema names a bit here, they are a bit verbose at the moment. Work for a future PR.