### PR TITLE
Rename "Docs" tab to "Schema"

### DIFF
--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -71,7 +71,7 @@ window.MonacoEnvironment = {
   },
 };
 
-type ResultsTab = 'results' | 'docs';
+type ResultsTab = 'results' | 'schema';
 
 interface TabPanelProps {
   selected: boolean;
@@ -382,7 +382,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           <Box>
             <Tabs value={selectedTab} onChange={handleTabChange} sx={{ pb: 1 }}>
               <Tab value="results" label="Results" />
-              <Tab value="docs" label="Docs" />
+              <Tab value="schema" label="Schema" />
             </Tabs>
           </Box>
           <TabPanel
@@ -394,9 +394,9 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             </Paper>
           </TabPanel>
           <TabPanel
-            selected={selectedTab === 'docs'}
+            selected={selectedTab === 'schema'}
             sx={{
-              display: selectedTab === 'docs' ? 'flex' : 'none',
+              display: selectedTab === 'schema' ? 'flex' : 'none',
               flexDirection: 'column',
               overflowY: 'hidden',
               overflowX: 'hidden',


### PR DESCRIPTION
The reasoning here is that "Docs" implies that it will inform the user on how to write queries, when in fact it only surfaces the schema. This leaves open the opportunity to add an actual "Docs" pane in the future!