### PR TITLE
Fix remaining console errors

### DIFF
--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -66,8 +66,19 @@ const disableGutterConfig: monaco.editor.IStandaloneEditorConstructionOptions = 
 };
 
 window.MonacoEnvironment = {
-  getWorker() {
-    return new Worker(new URL('monaco-graphql/dist/graphql.worker.js', import.meta.url));
+  getWorker(_workerId: string, label: string) {
+    switch (label) {
+      case 'graphql':
+        return new Worker(new URL('monaco-graphql/dist/graphql.worker.js', import.meta.url));
+      case 'json':
+        return new Worker(
+          new URL('monaco-editor/esm/vs/language/json/json.worker', import.meta.url)
+        );
+      case 'editorWorkerService':
+        return new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url));
+      default:
+        throw new Error(`No known worker for label ${label}`);
+    }
   },
 };
 
@@ -247,19 +258,19 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         ...disableGutterConfig,
       });
       const resultsEditor = monaco.editor.create(resultsEditorRef.current, {
-          language: 'json',
-          value: '',
-          minimap: {
-            enabled: false,
-          },
-          readOnly: true,
-          automaticLayout: true,
-          ...disableGutterConfig,
-        })
+        language: 'json',
+        value: '',
+        minimap: {
+          enabled: false,
+        },
+        readOnly: true,
+        automaticLayout: true,
+        ...disableGutterConfig,
+      });
 
-      queryEditor.getModel()?.updateOptions({ tabSize: 2 })
-      varsEditor.getModel()?.updateOptions({ tabSize: 2 })
-      resultsEditor.getModel()?.updateOptions({ tabSize: 2 })
+      queryEditor.getModel()?.updateOptions({ tabSize: 2 });
+      varsEditor.getModel()?.updateOptions({ tabSize: 2 });
+      resultsEditor.getModel()?.updateOptions({ tabSize: 2 });
       setQueryEditor(queryEditor);
       setVarsEditor(varsEditor);
       setResultsEditor(resultsEditor);
@@ -345,7 +356,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
             <Select
               labelId="example-query-label"
-              value={exampleQuery ? exampleQuery.name : ""}
+              value={exampleQuery ? exampleQuery.name : ''}
               label="Load an Example Query..."
               onChange={handleExampleQueryChange}
             >

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -345,7 +345,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
             <Select
               labelId="example-query-label"
-              value={exampleQuery ? exampleQuery.name : null}
+              value={exampleQuery ? exampleQuery.name : ""}
               label="Load an Example Query..."
               onChange={handleExampleQueryChange}
             >

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -10,13 +10,14 @@ import {
   initialize,
   executeQuery,
 } from '../../www2/trustfall_wasm';
+import debug from "../utils/debug";
 import { getTopItems, getLatestItems, materializeItem, materializeUser } from './utils';
 import HN_SCHEMA from './schema.graphql';
 
 initialize(); // Trustfall query system init.
 
 const SCHEMA = Schema.parse(HN_SCHEMA);
-console.log('Schema loaded.');
+debug('Schema loaded.');
 
 postMessage('ready');
 
@@ -445,7 +446,7 @@ type AdapterMessage =
 function dispatch(e: MessageEvent<AdapterMessage>): void {
   const payload = e.data;
 
-  console.log('Adapter received message:', payload);
+  debug('Adapter received message:', payload);
   if (payload.op === 'init') {
     return;
   }

--- a/experiments/browser_based_querying/src/hackernews/fetcher.ts
+++ b/experiments/browser_based_querying/src/hackernews/fetcher.ts
@@ -1,3 +1,4 @@
+import debug from "../utils/debug";
 import { SendableSyncContext, SyncContext } from '../sync';
 
 interface ChannelData {
@@ -25,10 +26,11 @@ function fetchHandler(e: MessageEvent<ChannelData>): void {
 
   const sync = new SyncContext(data.sync);
 
+  debug('Fetcher received message:', data);
   fetch(data.input, data.init)
     .then((response) => {
       if (!response.ok) {
-        console.log('non-ok response:', response.status);
+        debug('non-ok response:', response.status);
         sync.sendError(`non-ok response: ${response.status}`);
       } else {
         response
@@ -38,13 +40,13 @@ function fetchHandler(e: MessageEvent<ChannelData>): void {
             sync.send(new Uint8Array(buffer));
           })
           .catch((reason) => {
-            console.log('blob error:', response.status, reason);
+            debug('blob error:', response.status, reason);
             sync.sendError(`blob error: ${reason}`);
           });
       }
     })
     .catch((reason) => {
-      console.log('fetch error:', reason);
+      debug('fetch error:', reason);
       sync.sendError(`fetch error: ${reason}`);
     });
 }

--- a/experiments/browser_based_querying/src/utils/debug.ts
+++ b/experiments/browser_based_querying/src/utils/debug.ts
@@ -1,3 +1,3 @@
 export default function debug(...outputs: unknown[]): void {
-    console.debug("[Trustfall] ", ...outputs);
+    console.debug("[Trustfall]", ...outputs);
 }

--- a/experiments/browser_based_querying/src/utils/debug.ts
+++ b/experiments/browser_based_querying/src/utils/debug.ts
@@ -1,0 +1,3 @@
+export default function debug(...outputs: unknown[]): void {
+    console.debug("[Trustfall] ", ...outputs);
+}


### PR DESCRIPTION
* Use `""` as default for `Select` widget instead of `null`
* Supply the correct worker to Monaco depending on the label provided (e.g., `"json"` vs `"graphql"`)
* Use new `console.debug` instead of `console.log` to avoid cluttering the console.