### PR TITLE
Render error message for Safari

### DIFF
--- a/experiments/browser_based_querying/package-lock.json
+++ b/experiments/browser_based_querying/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/lab": "^5.0.0-alpha.92",
         "@mui/material": "^5.8.0",
         "core-js": "^3.22.5",
+        "detect-browser": "^5.3.0",
         "graphiql": "^1.11.5",
         "monaco-editor": "^0.20.0",
         "monaco-graphql": "^1.1.2",
@@ -2698,6 +2699,11 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
@@ -8808,6 +8814,11 @@
     "destroy": {
       "version": "1.2.0",
       "dev": true
+    },
+    "detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "detect-node": {
       "version": "2.1.0",

--- a/experiments/browser_based_querying/package.json
+++ b/experiments/browser_based_querying/package.json
@@ -34,6 +34,7 @@
     "@mui/lab": "^5.0.0-alpha.92",
     "@mui/material": "^5.8.0",
     "core-js": "^3.22.5",
+    "detect-browser": "^5.3.0",
     "graphiql": "^1.11.5",
     "monaco-editor": "^0.20.0",
     "monaco-graphql": "^1.1.2",

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -225,7 +225,7 @@ export default function HackerNewsPlayground(): JSX.Element {
               >
                 open issue
               </Link>{' '}
-              in the Webkit engine, this demo does not work in the Safari browser.
+              in the Webkit engine, this demo does not work in Safari.
             </p>
             <p>Please use a supported browser, such as Firefox or Chrome.</p>
           </Typography>

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -213,7 +213,7 @@ export default function HackerNewsPlayground(): JSX.Element {
     return (
       <PlaygroundNonIdealState>
         <Box>
-          <WebAssetOff sx={{ fontSize: '100px' }} />
+          <WebAssetOff sx={{ fontSize: '100px', mb: 2 }} />
           <Typography variant="h5">Safari is not supported</Typography>
           <Typography variant="body1">
             <p>

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useState, useEffect, useMemo } from 'react';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { buildSchema } from 'graphql';
-import { Box, Typography, CircularProgress, Grid } from '@mui/material';
+import { Box, Link, Typography, CircularProgress, Grid } from '@mui/material';
+import { WebAssetOff } from '@mui/icons-material';
+import { detect } from 'detect-browser';
 
 import { AsyncValue } from '../types';
 import parseExample from '../utils/parseExample';
@@ -14,6 +16,8 @@ import commentsPriorDiscussionSameStory from '../../example_queries/hackernews/c
 import commentsWithTwoAuthorReplies from '../../example_queries/hackernews/comments_with_two_more_author_replies.example';
 
 import HN_SCHEMA from './schema.graphql';
+
+const BROWSER = detect();
 
 const EXAMPLE_OPTIONS: { name: string; value: [string, string] }[] = [
   {
@@ -45,6 +49,21 @@ const EXAMPLE_OPTIONS: { name: string; value: [string, string] }[] = [
     value: parseExample(commentsWithTwoAuthorReplies),
   },
 ];
+
+function PlaygroundNonIdealState(props: { children: React.ReactNode }): JSX.Element {
+  const { children } = props;
+  return (
+    <Grid
+      container
+      direction="column"
+      height="95vh"
+      width="98vw"
+      sx={{ alignItems: 'center', justifyContent: 'space-around' }}
+    >
+      <Box sx={{ textAlign: 'center' }}>{children}</Box>
+    </Grid>
+  );
+}
 
 type QueryMessageEvent = MessageEvent<{ done: boolean; value: object }>;
 
@@ -190,22 +209,41 @@ export default function HackerNewsPlayground(): JSX.Element {
     };
   }, [fetcherWorker, queryWorker, handleQueryMessage, handleQueryError]);
 
+  if (BROWSER && BROWSER.name === 'safari') {
+    return (
+      <PlaygroundNonIdealState>
+        <Box>
+          <WebAssetOff sx={{ fontSize: '100px' }} />
+          <Typography variant="h5">Safari is not supported</Typography>
+          <Typography variant="body1">
+            <p>
+              Due to an{' '}
+              <Link
+                href="https://bugs.webkit.org/show_bug.cgi?id=238442"
+                target="_blank"
+                rel="noreferrer"
+              >
+                open issue
+              </Link>{' '}
+              in the Webkit engine, this demo does not work in the Safari browser.
+            </p>
+            <p>Please use a supported browser, such as Firefox or Chrome.</p>
+          </Typography>
+        </Box>
+      </PlaygroundNonIdealState>
+    );
+  }
+
   if (!ready) {
     return (
-      <Grid
-        container
-        direction="column"
-        height="95vh"
-        width="98vw"
-        sx={{ alignItems: 'center', justifyContent: 'space-around' }}
-      >
-        <Box sx={{ textAlign: 'center' }}>
+      <PlaygroundNonIdealState>
+        <Box>
           <CircularProgress size="150px" sx={{ mb: 2 }} />
           <Box>
             <Typography variant="h5">Preparing playground...</Typography>
           </Box>
         </Box>
-      </Grid>
+      </PlaygroundNonIdealState>
     );
   }
 

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -225,7 +225,7 @@ export default function HackerNewsPlayground(): JSX.Element {
               >
                 open issue
               </Link>{' '}
-              in the Webkit engine, this demo does not work in Safari.
+              in the WebKit engine, this demo does not work in Safari.
             </p>
             <p>Please use a supported browser, such as Firefox or Chrome.</p>
           </Typography>


### PR DESCRIPTION
This error only shows for the HackerNews demo, since it relies on passing around `SharedArrayBuffer` instances.