### PR TITLE
Support mobile layout

### DIFF
--- a/experiments/browser_based_querying/package-lock.json
+++ b/experiments/browser_based_querying/package-lock.json
@@ -21,6 +21,7 @@
         "monaco-graphql": "^1.1.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-reverse-portal": "^2.1.1",
         "react-router-dom": "^6.3.0",
         "use-query-params": "^2.0.0"
       },
@@ -5638,6 +5639,15 @@
       "version": "18.2.0",
       "license": "MIT"
     },
+    "node_modules/react-reverse-portal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-reverse-portal/-/react-reverse-portal-2.1.1.tgz",
+      "integrity": "sha512-FzuVLYEigKPB0NuMNLWymCgVp+P1h1MY57fQxhmY22idzz6El1rsXK5+bQ+wXvEa0smUtqTDcpM77epnXDV9wg==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -10653,6 +10663,12 @@
     },
     "react-is": {
       "version": "18.2.0"
+    },
+    "react-reverse-portal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-reverse-portal/-/react-reverse-portal-2.1.1.tgz",
+      "integrity": "sha512-FzuVLYEigKPB0NuMNLWymCgVp+P1h1MY57fQxhmY22idzz6El1rsXK5+bQ+wXvEa0smUtqTDcpM77epnXDV9wg==",
+      "requires": {}
     },
     "react-router": {
       "version": "6.3.0",

--- a/experiments/browser_based_querying/package.json
+++ b/experiments/browser_based_querying/package.json
@@ -40,6 +40,7 @@
     "monaco-graphql": "^1.1.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-reverse-portal": "^2.1.1",
     "react-router-dom": "^6.3.0",
     "use-query-params": "^2.0.0"
   },

--- a/experiments/browser_based_querying/src/App.tsx
+++ b/experiments/browser_based_querying/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { CircularProgress } from '@mui/material';
+import { CircularProgress, CssBaseline } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { QueryParamProvider } from 'use-query-params';
 import { QueryFragmentAdapter } from './QueryFragmentAdapter';
 
@@ -8,28 +9,47 @@ const HackerNewsPlayground = lazy(() => import('./hackernews/Playground'));
 const RustdocPlayground = lazy(() => import('./rustdoc/Playground'));
 
 export default function App() {
+  const theme = createTheme({
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          "html, body": {
+            overflow: 'hidden', height: '100%',
+          },
+          main: {
+              height: "100%",
+              overflowY: "auto",
+              position: "relative",
+          },
+        },
+      },
+    },
+  });
   return (
-    <BrowserRouter>
-      <QueryParamProvider adapter={QueryFragmentAdapter}>
-        <Routes>
-          <Route
-            path="/hackernews"
-            element={
-              <Suspense fallback={<CircularProgress />}>
-                <HackerNewsPlayground />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/rustdoc"
-            element={
-              <Suspense fallback={<CircularProgress />}>
-                <RustdocPlayground />
-              </Suspense>
-            }
-          />
-        </Routes>
-      </QueryParamProvider>
-    </BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <QueryParamProvider adapter={QueryFragmentAdapter}>
+          <Routes>
+            <Route
+              path="/hackernews"
+              element={
+                <Suspense fallback={<CircularProgress />}>
+                  <HackerNewsPlayground />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/rustdoc"
+              element={
+                <Suspense fallback={<CircularProgress />}>
+                  <RustdocPlayground />
+                </Suspense>
+              }
+            />
+          </Routes>
+        </QueryParamProvider>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { LoadingButton } from '@mui/lab';
 import {
@@ -74,7 +74,7 @@ const enableGutterConfig: monaco.editor.IStandaloneEditorConstructionOptions = {
   folding: true,
   lineDecorationsWidth: 5,
   lineNumbersMinChars: 2,
-}
+};
 
 window.MonacoEnvironment = {
   getWorker(_workerId: string, label: string) {
@@ -235,7 +235,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           minimap: {
             enabled: false,
           },
-          automaticLayout: true
+          automaticLayout: true,
         },
         {
           storageService: {
@@ -482,11 +482,11 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
     if (!queryEditor) return;
 
     if (isMdUp) {
-      queryEditor.updateOptions(enableGutterConfig)
+      queryEditor.updateOptions(enableGutterConfig);
     } else {
       queryEditor.updateOptions(disableGutterConfig);
     }
-  }, [isMdUp, queryEditor])
+  }, [isMdUp, queryEditor]);
 
   return (
     <Grid
@@ -499,7 +499,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
       <Grid item md={1}>
         {header}
         <Grid container item direction="row" spacing={0} sx={{ alignItems: 'center' }}>
-          <Grid item sx={{ mr: '10px' }}>
+          <Grid item sx={{ mt: 1, mr: '10px' }}>
             <Tooltip title={disabledMessage} placement="bottom">
               <span>
                 <LoadingButton
@@ -516,7 +516,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             </Tooltip>
           </Grid>
           {onQueryNextResult && results != null && (
-            <Grid item sx={{ mr: '10px' }}>
+            <Grid item sx={{ mt: 1, mr: '10px' }}>
               <LoadingButton
                 size="small"
                 variant="outlined"
@@ -529,7 +529,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
               </LoadingButton>
             </Grid>
           )}
-          <Grid item sx={{ mr: '10px' }}>
+          <Grid item sx={{ mt: 1, mr: '10px' }}>
             <FormControl size="small" sx={{ minWidth: 300 }}>
               <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
               <Select

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -404,8 +404,10 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   );
 
   // TODO: For some reason, portal only renders after resize window (probably need to trigger relayout manually)
-  const mdDownContent = useMemo(
-    () => (
+  const mdDownContent = useMemo(() => {
+    const isQueryRelatedTab = selectedTab === 'query' || selectedTab === 'vars';
+    const tabColor = isQueryRelatedTab ? 'secondary' : 'primary';
+    return (
       <Grid
         container
         item
@@ -415,7 +417,13 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         sx={{ flexGrow: '1 !important', flexWrap: 'nowrap', overflowY: 'hidden' }}
       >
         <Box>
-          <Tabs value={selectedTab} onChange={handleTabChange} sx={{ pb: 1 }}>
+          <Tabs
+            value={selectedTab}
+            onChange={handleTabChange}
+            textColor={tabColor}
+            indicatorColor={tabColor}
+            sx={{ pb: 1 }}
+          >
             <Tab value="query" label="Query" />
             <Tab value="vars" label="Variables" />
             <Tab value="results" label="Results" />
@@ -459,9 +467,8 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           <SimpleDocExplorer schema={schema} />
         </TabPanel>
       </Grid>
-    ),
-    [handleTabChange, selectedTab, schema, queryPortalNode, varsPortalNode, resultsPortalNode]
-  );
+    );
+  }, [handleTabChange, selectedTab, schema, queryPortalNode, varsPortalNode, resultsPortalNode]);
 
   return (
     <Grid

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -16,6 +16,7 @@ import {
   Theme,
   SxProps,
   Tooltip,
+  useMediaQuery,
 } from '@mui/material';
 import { GraphQLSchema } from 'graphql';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
@@ -323,55 +324,61 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
 
   return (
     <Grid container item direction="column" sx={{ flexWrap: 'nowrap', ...(sx ?? {}) }}>
-      <Grid item xs={1}>
+      <Grid item md={1}>
         {header}
-        <div css={{ display: 'flex', alignItems: 'center', margin: 10 }}>
-          <Tooltip title={disabledMessage} placement="bottom">
-            <span>
+        <Grid container item direction="row" sx={{ alignItems: 'center' }}>
+          <Grid item sx={{ margin: "10px" }}>
+            <Tooltip title={disabledMessage} placement="bottom">
+              <span>
+                <LoadingButton
+                  size="small"
+                  onClick={() => handleQuery()}
+                  variant="contained"
+                  sx={{ mr: 2 }}
+                  disabled={Boolean(disabled) || noQuery}
+                  loading={loading}
+                >
+                  Run query!
+                </LoadingButton>
+              </span>
+            </Tooltip>
+          </Grid>
+          {onQueryNextResult && results != null && (
+            <Grid item sx={{ margin: "10px" }}>
               <LoadingButton
                 size="small"
-                onClick={() => handleQuery()}
-                variant="contained"
-                sx={{ mr: 2 }}
-                disabled={Boolean(disabled) || noQuery}
+                variant="outlined"
+                onClick={() => onQueryNextResult()}
+                disabled={!hasMore || Boolean(disabled)}
                 loading={loading}
+                sx={{ mr: 2 }}
               >
-                Run query!
+                {hasMore ? 'More!' : 'No more results'}
               </LoadingButton>
-            </span>
-          </Tooltip>
-          {onQueryNextResult && results != null && (
-            <LoadingButton
-              size="small"
-              variant="outlined"
-              onClick={() => onQueryNextResult()}
-              disabled={!hasMore || Boolean(disabled)}
-              loading={loading}
-              sx={{ mr: 2 }}
-            >
-              {hasMore ? 'More!' : 'No more results'}
-            </LoadingButton>
+            </Grid>
           )}
-          <FormControl size="small" sx={{ minWidth: 300 }}>
-            <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
-            <Select
-              labelId="example-query-label"
-              value={exampleQuery ? exampleQuery.name : ''}
-              label="Load an Example Query..."
-              onChange={handleExampleQueryChange}
-            >
-              {exampleQueries.map((option) => (
-                <MenuItem key={option.name} value={option.name}>
-                  {option.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </div>
+          <Grid item sx={{ margin: "10px" }}>
+            <FormControl size="small" sx={{ minWidth: 300 }}>
+              <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
+              <Select
+                labelId="example-query-label"
+                value={exampleQuery ? exampleQuery.name : ''}
+                label="Load an Example Query..."
+                onChange={handleExampleQueryChange}
+              >
+                {exampleQueries.map((option) => (
+                  <MenuItem key={option.name} value={option.name}>
+                    {option.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
       </Grid>
-      <Grid container item xs={11} spacing={2} sx={{ flexWrap: 'nowrap', overflowY: 'hidden' }}>
-        <Grid container item direction="column" xs={7} sx={{ flexWrap: 'nowrap' }}>
-          <Grid container item direction="column" xs={8} sx={{ flexWrap: 'nowrap' }}>
+      <Grid container item md={11} spacing={2} sx={{ flexWrap: 'nowrap', overflowY: 'hidden' }}>
+        <Grid container item direction="column" md={7} sx={{ flexWrap: 'nowrap' }}>
+          <Grid container item direction="column" md={8} sx={{ flexWrap: 'nowrap' }}>
             {/* Use padding to align query section with results */}
             <Typography variant="overline" component="div" sx={{ pt: '1.5rem' }}>
               Query
@@ -380,7 +387,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
               <div ref={queryEditorRef} css={cssEditor} />
             </Paper>
           </Grid>
-          <Grid container item direction="column" xs={4} sx={{ flexWrap: 'nowrap' }}>
+          <Grid container item direction="column" md={4} sx={{ flexWrap: 'nowrap' }}>
             <Typography variant="overline" component="div" sx={{ mt: 1 }}>
               Variables
             </Typography>
@@ -389,7 +396,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             </Paper>
           </Grid>
         </Grid>
-        <Grid container item xs={5} direction="column" sx={{ flexWrap: 'nowrap' }}>
+        <Grid container item md={5} direction="column" sx={{ flexWrap: 'nowrap' }}>
           <Box>
             <Tabs value={selectedTab} onChange={handleTabChange} sx={{ pb: 1 }}>
               <Tab value="results" label="Results" />

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -481,7 +481,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
       <Grid item md={1}>
         {header}
         <Grid container item direction="row" spacing={0} sx={{ alignItems: 'center' }}>
-          <Grid item sx={{ margin: '10px' }}>
+          <Grid item sx={{ mr: '10px' }}>
             <Tooltip title={disabledMessage} placement="bottom">
               <span>
                 <LoadingButton
@@ -498,7 +498,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             </Tooltip>
           </Grid>
           {onQueryNextResult && results != null && (
-            <Grid item sx={{ margin: '10px' }}>
+            <Grid item sx={{ mr: '10px' }}>
               <LoadingButton
                 size="small"
                 variant="outlined"
@@ -511,7 +511,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
               </LoadingButton>
             </Grid>
           )}
-          <Grid item sx={{ margin: '10px' }}>
+          <Grid item sx={{ mr: '10px' }}>
             <FormControl size="small" sx={{ minWidth: 300 }}>
               <InputLabel id="example-query-label">Load an Example Query...</InputLabel>
               <Select

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -266,6 +266,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         minimap: {
           enabled: false,
         },
+        wordWrap: 'on',
         readOnly: true,
         automaticLayout: true,
         ...disableGutterConfig,
@@ -330,13 +331,13 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
     switch (selectedTab) {
       case 'query':
         queryEditor.layout();
-        return
+        return;
       case 'vars':
         varsEditor.layout();
-        return
+        return;
       case 'results':
         resultsEditor.layout();
-        return
+        return;
     }
   }, [queryEditor, varsEditor, resultsEditor, selectedTab]);
 
@@ -405,7 +406,14 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   // TODO: For some reason, portal only renders after resize window (probably need to trigger relayout manually)
   const mdDownContent = useMemo(
     () => (
-      <Grid container item xs={11} spacing={0} direction="column" sx={{ flexWrap: 'nowrap' }}>
+      <Grid
+        container
+        item
+        xs={11}
+        spacing={0}
+        direction="column"
+        sx={{ flexGrow: '1 !important', flexWrap: 'nowrap', overflowY: 'hidden' }}
+      >
         <Box>
           <Tabs value={selectedTab} onChange={handleTabChange} sx={{ pb: 1 }}>
             <Tab value="query" label="Query" />
@@ -416,7 +424,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         </Box>
         <TabPanel
           selected={selectedTab === 'query'}
-          sx={{ height: '100%', position: 'relative', ...sxEditorContainer }}
+          sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}
         >
           <Paper elevation={0}>
             <OutPortal node={queryPortalNode} />
@@ -424,7 +432,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         </TabPanel>
         <TabPanel
           selected={selectedTab === 'vars'}
-          sx={{ height: '100%', position: 'relative', ...sxEditorContainer }}
+          sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}
         >
           <Paper elevation={0}>
             <OutPortal node={varsPortalNode} />
@@ -432,7 +440,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         </TabPanel>
         <TabPanel
           selected={selectedTab === 'results'}
-          sx={{ height: '100%', position: 'relative', ...sxEditorContainer }}
+          sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}
         >
           <Paper elevation={0}>
             <OutPortal node={resultsPortalNode} />
@@ -443,7 +451,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           sx={{
             display: selectedTab === 'schema' ? 'flex' : 'none',
             flexDirection: 'column',
-            height: '100%',
+            flexGrow: 1,
             overflowY: 'hidden',
             overflowX: 'hidden',
           }}
@@ -456,7 +464,13 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   );
 
   return (
-    <Grid container item direction="column" spacing={0} sx={{ padding: '10px', flexWrap: 'nowrap', ...sx }}>
+    <Grid
+      container
+      item
+      direction="column"
+      spacing={0}
+      sx={{ padding: '10px', flexWrap: 'nowrap', ...sx }}
+    >
       <Grid item md={1}>
         {header}
         <Grid container item direction="row" spacing={0} sx={{ alignItems: 'center' }}>

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -18,6 +18,7 @@ import {
   Tooltip,
   useMediaQuery,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { GraphQLSchema } from 'graphql';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { initializeMode } from 'monaco-graphql/esm/initializeMode';
@@ -155,6 +156,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   const [resultsEditor, setResultsEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(
     null
   );
+  const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [selectedTab, setSelectedTab] = useState<ResultsTab>('results');
 
   const noQuery = encodedQuery === '';
@@ -190,6 +192,9 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
     const query = queryEditor.getValue();
     const vars = varsEditor.getValue();
 
+    if (tabsContainerRef.current) {
+      tabsContainerRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
     onQuery(query, vars);
     setSelectedTab('results');
   }, [queryEditor, varsEditor, onQuery]);
@@ -322,11 +327,14 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
     }
   }, [results, resultsEditor, loading, error]);
 
+  const theme = useTheme();
+  const mdUp = useMediaQuery(theme.breakpoints.up('md'));
+
   return (
-    <Grid container item direction="column" sx={{ flexWrap: 'nowrap', ...(sx ?? {}) }}>
+    <Grid container item direction="column" sx={{ flexWrap: 'nowrap', ...(mdUp ? sx ?? {} : {}) }}>
       <Grid item md={1}>
         {header}
-        <Grid container item direction="row" sx={{ alignItems: 'center' }}>
+        <Grid container item direction="row" sx={{ position: 'sticky', top: 0, alignItems: 'center' }}>
           <Grid item sx={{ margin: "10px" }}>
             <Tooltip title={disabledMessage} placement="bottom">
               <span>
@@ -376,14 +384,14 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           </Grid>
         </Grid>
       </Grid>
-      <Grid container item md={11} spacing={2} sx={{ flexWrap: 'nowrap', overflowY: 'hidden' }}>
+      <Grid container item md={11} spacing={2} sx={mdUp ? { flexWrap: 'nowrap', overflowY: 'hidden' } : {}}>
         <Grid container item direction="column" md={7} sx={{ flexWrap: 'nowrap' }}>
           <Grid container item direction="column" md={8} sx={{ flexWrap: 'nowrap' }}>
             {/* Use padding to align query section with results */}
-            <Typography variant="overline" component="div" sx={{ pt: '1.5rem' }}>
+            <Typography variant="overline" component="div" sx={[{ pt: '1.5rem' }, false]}>
               Query
             </Typography>
-            <Paper elevation={0} sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
+            <Paper elevation={0} sx={[{ flexGrow: 1, position: 'relative', ...sxEditorContainer }, !mdUp && {minHeight: '200px'}]}>
               <div ref={queryEditorRef} css={cssEditor} />
             </Paper>
           </Grid>
@@ -391,12 +399,12 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             <Typography variant="overline" component="div" sx={{ mt: 1 }}>
               Variables
             </Typography>
-            <Paper elevation={0} sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
+            <Paper elevation={0} sx={[{ flexGrow: 1, position: 'relative', ...sxEditorContainer }, !mdUp && {minHeight: '150px'}]}>
               <div ref={varsEditorRef} css={cssEditor} />
             </Paper>
           </Grid>
         </Grid>
-        <Grid container item md={5} direction="column" sx={{ flexWrap: 'nowrap' }}>
+        <Grid container item md={5} direction="column" sx={[{ flexWrap: 'nowrap' }, !mdUp && { height: "100vh" }]} ref={tabsContainerRef}>
           <Box>
             <Tabs value={selectedTab} onChange={handleTabChange} sx={{ pb: 1 }}>
               <Tab value="results" label="Results" />
@@ -407,7 +415,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             selected={selectedTab === 'results'}
             sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}
           >
-            <Paper elevation={0}>
+            <Paper elevation={0} sx={{minHeight: "250px"}}>
               <div ref={resultsEditorRef} css={cssEditor} />
             </Paper>
           </TabPanel>

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -68,6 +68,14 @@ const disableGutterConfig: monaco.editor.IStandaloneEditorConstructionOptions = 
   lineNumbersMinChars: 0,
 };
 
+const enableGutterConfig: monaco.editor.IStandaloneEditorConstructionOptions = {
+  lineNumbers: 'on',
+  glyphMargin: true,
+  folding: true,
+  lineDecorationsWidth: 5,
+  lineNumbersMinChars: 2,
+}
+
 window.MonacoEnvironment = {
   getWorker(_workerId: string, label: string) {
     switch (label) {
@@ -227,7 +235,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
           minimap: {
             enabled: false,
           },
-          automaticLayout: true,
+          automaticLayout: true
         },
         {
           storageService: {
@@ -469,6 +477,16 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
       </Grid>
     );
   }, [handleTabChange, selectedTab, schema, queryPortalNode, varsPortalNode, resultsPortalNode]);
+
+  useEffect(() => {
+    if (!queryEditor) return;
+
+    if (isMdUp) {
+      queryEditor.updateOptions(enableGutterConfig)
+    } else {
+      queryEditor.updateOptions(disableGutterConfig);
+    }
+  }, [isMdUp, queryEditor])
 
   return (
     <Grid

--- a/experiments/browser_based_querying/src/components/DocExplorer/SearchBox.tsx
+++ b/experiments/browser_based_querying/src/components/DocExplorer/SearchBox.tsx
@@ -57,6 +57,7 @@ export default class SearchBox extends React.Component<SearchBoxProps, SearchBox
         label={this.props.placeholder}
         type="text"
         aria-label={this.props.placeholder}
+        size="small"
         InputProps={{
           startAdornment: (
             <InputAdornment position="start">

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -258,7 +258,7 @@ export default function HackerNewsPlayground(): JSX.Element {
       exampleQueries={EXAMPLE_OPTIONS}
       onQuery={runQuery}
       onQueryNextResult={queryNextResult}
-      sx={{ height: '99vh', width: '98vw' }}
+      sx={{ height: '99vh', width: '100vw' }}
     />
   );
 }

--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -258,7 +258,7 @@ export default function HackerNewsPlayground(): JSX.Element {
       exampleQueries={EXAMPLE_OPTIONS}
       onQuery={runQuery}
       onQueryNextResult={queryNextResult}
-      sx={{ height: '97vh', width: '98vw' }}
+      sx={{ height: '99vh', width: '98vw' }}
     />
   );
 }

--- a/experiments/browser_based_querying/src/hackernews/fetcher.ts
+++ b/experiments/browser_based_querying/src/hackernews/fetcher.ts
@@ -1,4 +1,4 @@
-import debug from "../utils/debug";
+import debug from '../utils/debug';
 import { SendableSyncContext, SyncContext } from '../sync';
 
 interface ChannelData {

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -200,16 +200,16 @@ export default function Rustdoc(): JSX.Element {
           Rust crates — Trustfall Playground
         </Typography>
         <Typography>
-          Query a crate's rustdoc directly from your browser with{' '}
+          Query a crate&apos;s rustdoc directly from your browser with{' '}
           <a href="https://github.com/obi1kenobi/trustfall" target="_blank" rel="noreferrer">
             Trustfall
           </a>{' '}
           compiled to WebAssembly.
         </Typography>
         <Typography>
-          Selecting a crate downloads a few MB of data, so {' '}
-          you might not want to do this from a mobile data plan.
-          If your favorite crate is missing, <a href="https://github.com/obi1kenobi/crates-rustdoc/issues/new/choose">let us know</a>!
+          Selecting a crate downloads a few MB of data, so you might not want to do this from a
+          mobile data plan. If your favorite crate is missing,{' '}
+          <a href="https://github.com/obi1kenobi/crates-rustdoc/issues/new/choose">let us know</a>!
         </Typography>
         {queryWorker && (
           <Box>
@@ -227,11 +227,25 @@ export default function Rustdoc(): JSX.Element {
   }, [queryWorker, handleCrateChange]);
 
   return (
-    <Grid container direction="column" spacing={0} height="98vh" width="98vw" sx={{ flexWrap: 'nowrap' }}>
+    <Grid
+      container
+      direction="column"
+      spacing={0}
+      height="98vh"
+      width="100vw"
+      sx={{ flexWrap: 'nowrap' }}
+    >
       <Grid item xs={1} sx={{ pt: 1, pl: 1, pr: 1 }}>
         {header}
       </Grid>
-      <Grid container direction="column" item xs={11} spacing={0} sx={{flexShrink: 1, overflowY: 'hidden'}}>
+      <Grid
+        container
+        direction="column"
+        item
+        xs={11}
+        spacing={0}
+        sx={{ flexShrink: 1, overflowY: 'hidden' }}
+      >
         {queryWorker && <Playground queryWorker={queryWorker} disabled={disabledMessage} />}
       </Grid>
     </Grid>

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -227,8 +227,8 @@ export default function Rustdoc(): JSX.Element {
   }, [queryWorker, handleCrateChange]);
 
   return (
-    <Grid container direction="column" height="97vh" width="98vw" sx={{ flexWrap: 'nowrap' }}>
-      <Grid item xs={1}>
+    <Grid container direction="column" spacing={0} height="97vh" width="98vw" sx={{ flexWrap: 'nowrap' }}>
+      <Grid item xs={1} sx={{ padding: '10px' }}>
         {header}
       </Grid>
       <Grid container direction="column" item xs={11} sx={{flexShrink: 1, overflowY: 'hidden'}}>

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -231,7 +231,7 @@ export default function Rustdoc(): JSX.Element {
       container
       direction="column"
       spacing={0}
-      height="98vh"
+      height="99vh"
       width="100vw"
       sx={{ flexWrap: 'nowrap' }}
     >

--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -227,11 +227,11 @@ export default function Rustdoc(): JSX.Element {
   }, [queryWorker, handleCrateChange]);
 
   return (
-    <Grid container direction="column" spacing={0} height="97vh" width="98vw" sx={{ flexWrap: 'nowrap' }}>
-      <Grid item xs={1} sx={{ padding: '10px' }}>
+    <Grid container direction="column" spacing={0} height="98vh" width="98vw" sx={{ flexWrap: 'nowrap' }}>
+      <Grid item xs={1} sx={{ pt: 1, pl: 1, pr: 1 }}>
         {header}
       </Grid>
-      <Grid container direction="column" item xs={11} sx={{flexShrink: 1, overflowY: 'hidden'}}>
+      <Grid container direction="column" item xs={11} spacing={0} sx={{flexShrink: 1, overflowY: 'hidden'}}>
         {queryWorker && <Playground queryWorker={queryWorker} disabled={disabledMessage} />}
       </Grid>
     </Grid>


### PR DESCRIPTION
This PR adds support for a mobile-friendly layout, arranging all editors into a tab-based layout for extra-small and small devices. This was tricky to accomplish, as switching between layouts naively would cause the editors to unmount and lose all their state. Fortunately, the fantastic [react-reverse-portal](https://github.com/httptoolkit/react-reverse-portal) library allows us to render the editors in portals, which are then seamlessly moved around the DOM without forcing re-renders or remounts around layout breakpoints.

## Screenshots
<img width="605" alt="image" src="https://user-images.githubusercontent.com/1556995/191138776-e0e409bd-5eb8-4315-a163-24fbcc5f788b.png">

<img width="609" alt="image" src="https://user-images.githubusercontent.com/1556995/191138789-62af2f59-ff1b-46bf-b520-e9e4806b7359.png">
