### PR TITLE
Fix bug with setting results

### DIFF
--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -173,11 +173,15 @@ export default function HackerNewsPlayground(): JSX.Element {
 
   // Set results
   useEffect(() => {
-    if (nextResult && nextResult.status === 'ready' && nextResult.value != null) {
+    if (nextResult && nextResult.status === 'ready') {
       const nextValue = nextResult.value;
       setResults((prevResults) => {
-        const prevValue = prevResults ? prevResults : [];
-        return [...prevValue, nextValue];
+        const prevValue = prevResults ?? [];
+        if (nextValue != null) {
+          return [...prevValue, nextValue];
+        } else {
+          return prevValue;
+        }
       });
     } else if (nextResult == null || nextResult.status === 'error') {
       setResults(null);


### PR DESCRIPTION
If a query returns no results, correctly set the results list to `[]` so that we actually render results.

<img width="540" alt="image" src="https://user-images.githubusercontent.com/1556995/192166071-a1f85d3c-e5ef-4227-bc63-bbc64fc5498e.png">
