### PR TITLE
Move include/exclude options to top level.

### DIFF
--- a/experiments/browser_based_querying/tsconfig.json
+++ b/experiments/browser_based_querying/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
-    "exclude": ["*.example"],
-    "include": ["src", "index.d.ts"]
-  }
+  },
+  "exclude": ["*.example"],
+  "include": ["src", "index.d.ts"]
 }


### PR DESCRIPTION
It appears that our typescript include/exclude config options were in the wrong scope and were being ignored. They seem to need to be at top level in the tsconfig.json file.
