### PR TITLE
Improve styling around "Show More" button

### DIFF
--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -55,11 +55,11 @@ const cssEditor = css`
 const sxEditorBorder: SxProps = {
   border: '1px solid #aaa',
   borderRadius: '5px',
-}
+};
 
 const sxEditorPadding: SxProps = {
   padding: '3px',
-}
+};
 
 const sxEditorContainer: SxProps = {
   ...sxEditorBorder,
@@ -371,7 +371,7 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   const moreButton = useMemo(() => {
     if (onQueryNextResult && results != null) {
       return (
-        <Box sx={{...sxEditorPadding, borderBottom: '1px solid #aaa'}}>
+        <Box sx={{ ...sxEditorPadding, borderBottom: '1px solid #aaa' }}>
           <Grid item sx={{ mt: 1, mb: 1, textAlign: 'center' }}>
             <LoadingButton
               size="small"

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -52,10 +52,18 @@ const cssEditor = css`
   height: calc(100% - 3px);
 `;
 
-const sxEditorContainer: SxProps = {
+const sxEditorBorder: SxProps = {
   border: '1px solid #aaa',
   borderRadius: '5px',
+}
+
+const sxEditorPadding: SxProps = {
   padding: '3px',
+}
+
+const sxEditorContainer: SxProps = {
+  ...sxEditorBorder,
+  ...sxEditorPadding,
 };
 
 // Disable editor gutters entirely
@@ -363,18 +371,20 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
   const moreButton = useMemo(() => {
     if (onQueryNextResult && results != null) {
       return (
-        <Grid item sx={{ mt: 1, mb: 1, textAlign: 'center' }}>
-          <LoadingButton
-            size="small"
-            variant="outlined"
-            onClick={() => onQueryNextResult()}
-            disabled={!hasMore || Boolean(disabled)}
-            loading={loading}
-            sx={{ mr: 2 }}
-          >
-            {hasMore ? 'Fetch another result' : 'No more results'}
-          </LoadingButton>
-        </Grid>
+        <Box sx={{...sxEditorPadding, borderBottom: '1px solid #aaa'}}>
+          <Grid item sx={{ mt: 1, mb: 1, textAlign: 'center' }}>
+            <LoadingButton
+              size="small"
+              variant="outlined"
+              onClick={() => onQueryNextResult()}
+              disabled={!hasMore || Boolean(disabled)}
+              loading={loading}
+              sx={{ mr: 2 }}
+            >
+              {hasMore ? 'Fetch another result' : 'No more results'}
+            </LoadingButton>
+          </Grid>
+        </Box>
       );
     }
 
@@ -423,10 +433,16 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
             sx={{ flexGrow: 1 }}
           >
             <Box
-              sx={{ height: '100%', display: 'flex', flexDirection: 'column', flexWrap: 'nowrap' }}
+              sx={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                flexWrap: 'nowrap',
+                ...sxEditorBorder,
+              }}
             >
               {moreButton}
-              <Box sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
+              <Box sx={{ flexGrow: 1, position: 'relative', ...sxEditorPadding }}>
                 <Paper elevation={0}>
                   <OutPortal node={resultsPortalNode} />
                 </Paper>
@@ -502,10 +518,16 @@ export default function TrustfallPlayground(props: TrustfallPlaygroundProps): JS
         </TabPanel>
         <TabPanel selected={selectedTab === 'results'} sx={{ flexGrow: 1 }}>
           <Box
-            sx={{ height: '100%', display: 'flex', flexDirection: 'column', flexWrap: 'nowrap' }}
+            sx={{
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              flexWrap: 'nowrap',
+              ...sxEditorBorder,
+            }}
           >
             {moreButton}
-            <Box sx={{ flexGrow: 1, position: 'relative', ...sxEditorContainer }}>
+            <Box sx={{ flexGrow: 1, position: 'relative', ...sxEditorPadding }}>
               <Paper elevation={0}>
                 <OutPortal node={resultsPortalNode} />
               </Paper>

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -109,7 +109,7 @@ function* linksInAboutPage(
   aboutHtml: string | null
 ): IterableIterator<Vertex> {
   if (aboutHtml) {
-    let processedLinks: Record<string, boolean> = {};
+    const processedLinks: Record<string, boolean> = {};
 
     const matches1 = aboutHtml.matchAll(/<a [^>]*href="([^"]+)"[^>]*>/g);
     for (const match of matches1) {


### PR DESCRIPTION
This moves the editor border styles so that it encapsulates the 'Show More' button, which looks better since it maintains alignment with the rest of the editors.

## Screenshot
<img width="1722" alt="image" src="https://user-images.githubusercontent.com/1556995/193165083-1e838e31-e118-4eb3-97f4-4df9debf0708.png">
