### PR TITLE
Support deep linking to crates in rust demo

### DIFF
--- a/experiments/browser_based_querying/src/rustdoc/Playground.tsx
+++ b/experiments/browser_based_querying/src/rustdoc/Playground.tsx
@@ -199,7 +199,7 @@ export default function Rustdoc(): JSX.Element {
   }, [handleWorkerMessage, queryWorker]);
 
   const header = useMemo(() => {
-    const selectedCrateOption = CRATE_OPTIONS.find((option) => option.value === selectedCrate);
+    const selectedCrateOption = CRATE_OPTIONS.find((option) => option.value === selectedCrate) ?? null;
     return (
       <Box>
         <Typography variant="h4" component="div">

--- a/experiments/browser_based_querying/src/rustdoc/queryWorker.ts
+++ b/experiments/browser_based_querying/src/rustdoc/queryWorker.ts
@@ -52,3 +52,4 @@ function dispatch(evt: MessageEvent<RustdocWorkerMessage>) {
 }
 
 onmessage = dispatch;
+send({ type: 'ready' })

--- a/experiments/browser_based_querying/src/rustdoc/types.ts
+++ b/experiments/browser_based_querying/src/rustdoc/types.ts
@@ -25,4 +25,7 @@ export type RustdocWorkerResponse =
   | {
       type: 'query-error';
       message: string;
-    };
+    }
+  | {
+      type: 'ready';
+    }


### PR DESCRIPTION
Getting the crate into the URL was the easy part thanks to [use-query-params](https://www.npmjs.com/package/use-query-params), but this introduced a race condition as we would attempt to load the crate before the worker was ready.  I updated the worker to fire a `ready` event so that we only send the load request after the worker was ready.