### PR TITLE
Implement unlimited-depth directly-optimal recursion.

### DIFF
--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -83,7 +83,7 @@ where
     }
 }
 
-fn perform_coercion<'query, DataToken>(
+pub(super) fn perform_coercion<'query, DataToken>(
     adapter: &RefCell<impl Adapter<'query, DataToken = DataToken> + 'query>,
     query: &InterpretedQuery,
     vertex: &IRVertex,

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -997,7 +997,7 @@ fn expand_edge<'query, DataToken: Clone + Debug + 'query>(
     iterator: Box<dyn Iterator<Item = DataContext<DataToken>> + 'query>,
 ) -> Box<dyn Iterator<Item = DataContext<DataToken>> + 'query> {
     let expanded_iterator = if let Some(recursive) = &edge.recursive {
-        expand_recursive_edge(
+        super::recurse::expand_recursive_edge(
             adapter.clone(),
             query,
             component,
@@ -1098,7 +1098,7 @@ fn perform_entry_into_new_vertex<'query, DataToken: Clone + Debug + 'query>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn expand_recursive_edge<'query, DataToken: Clone + Debug + 'query>(
+fn expand_recursive_edge2<'query, DataToken: Clone + Debug + 'query>(
     adapter: Rc<RefCell<impl Adapter<'query, DataToken = DataToken> + 'query>>,
     query: &InterpretedQuery,
     component: &IRQueryComponent,

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod execution;
 mod filtering;
 pub mod macros;
+mod recurse;
 pub mod replay;
 pub mod trace;
 

--- a/trustfall_core/src/interpreter/recurse.rs
+++ b/trustfall_core/src/interpreter/recurse.rs
@@ -1,0 +1,427 @@
+#![allow(dead_code)]
+use std::{cell::RefCell, collections::VecDeque, fmt::Debug, num::NonZeroUsize, rc::Rc, sync::Arc};
+
+use crate::ir::{EdgeParameters, Eid, IRQueryComponent, IRVertex, Recursive};
+
+use super::{execution::perform_coercion, Adapter, DataContext, InterpretedQuery};
+
+type NeighborsBundle<'token, Token> = Box<
+    dyn Iterator<Item = (DataContext<Token>, Box<dyn Iterator<Item = Token> + 'token>)> + 'token,
+>;
+
+/// Arguments for the project_neighbors() calls.
+pub(super) struct RecursiveEdgeData<'a> {
+    initial_type_name: Arc<str>,
+    type_name_after_first_step: Arc<str>,
+    edge_name: Arc<str>,
+    parameters: Option<Arc<EdgeParameters>>,
+    recursive_info: Recursive,
+    query_hint: InterpretedQuery,
+    expanding_from: &'a IRVertex,
+    expanding_to: &'a IRVertex,
+    edge_hint: Eid,
+}
+
+impl<'a> RecursiveEdgeData<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        initial_type_name: Arc<str>,
+        type_name_after_first_step: Arc<str>,
+        edge_name: Arc<str>,
+        parameters: Option<Arc<EdgeParameters>>,
+        recursive_info: Recursive,
+        query_hint: InterpretedQuery,
+        expanding_from: &'a IRVertex,
+        expanding_to: &'a IRVertex,
+        edge_hint: Eid,
+    ) -> Self {
+        Self {
+            initial_type_name,
+            type_name_after_first_step,
+            edge_name,
+            parameters,
+            recursive_info,
+            query_hint,
+            expanding_from,
+            expanding_to,
+            edge_hint,
+        }
+    }
+
+    fn expand_initial_edge<'token, AdapterT: Adapter<'token> + 'token>(
+        &self,
+        adapter: &RefCell<AdapterT>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<AdapterT::DataToken>> + 'token>,
+    ) -> NeighborsBundle<'token, AdapterT::DataToken> {
+        adapter.borrow_mut().project_neighbors(
+            data_contexts,
+            self.initial_type_name.clone(),
+            self.edge_name.clone(),
+            self.parameters.clone(),
+            self.query_hint.clone(),
+            self.expanding_from.vid,
+            self.edge_hint,
+        )
+    }
+
+    fn expand_edge<'token, AdapterT: Adapter<'token> + 'token>(
+        &self,
+        adapter: &RefCell<AdapterT>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<AdapterT::DataToken>> + 'token>,
+    ) -> NeighborsBundle<'token, AdapterT::DataToken> {
+        let edge_endpoint_type = self
+            .expanding_to
+            .coerced_from_type
+            .as_ref()
+            .unwrap_or(&self.expanding_to.type_name);
+
+        let (traversal_from_type, expansion_base_iterator) =
+            if let Some(coerce_to) = self.recursive_info.coerce_to.as_ref() {
+                (
+                    coerce_to.clone(),
+                    perform_coercion(
+                        adapter,
+                        &self.query_hint,
+                        self.expanding_to,
+                        edge_endpoint_type.clone(),
+                        coerce_to.clone(),
+                        data_contexts,
+                    ),
+                )
+            } else {
+                (self.expanding_from.type_name.clone(), data_contexts)
+            };
+
+        adapter.borrow_mut().project_neighbors(
+            expansion_base_iterator,
+            traversal_from_type,
+            self.edge_name.clone(),
+            self.parameters.clone(),
+            self.query_hint.clone(),
+            self.expanding_from.vid,
+            self.edge_hint,
+        )
+    }
+}
+
+pub(super) struct RecurseStack<'query, 'token, AdapterT>
+where
+    AdapterT: Adapter<'token> + 'token,
+{
+    adapter: Rc<RefCell<AdapterT>>,
+    starting_contexts: Box<dyn Iterator<Item = DataContext<AdapterT::DataToken>>>,
+
+    /// Recursive neighbor expansion args.
+    edge_data: RecursiveEdgeData<'query>,
+
+    /// The maximum depth of the recursion; None means unbounded i.e. "as long as there's data."
+    max_depth: Option<NonZeroUsize>,
+
+    /// Data structures that keep track of data at each recursion level.
+    levels: Vec<RcBundleReader<'token, AdapterT::DataToken>>,
+
+    /// Queue to ensure elements are returned in correct order.
+    reorder_queue: VecDeque<DataContext<AdapterT::DataToken>>,
+
+    /// Largest index which is guaranteed to have data which
+    /// we can peek() without advancing the parent level's iterator.
+    next_from: usize,
+}
+
+impl<'query, 'token, AdapterT> RecurseStack<'query, 'token, AdapterT>
+where
+    AdapterT: Adapter<'token> + 'token,
+{
+    pub(super) fn new(
+        adapter: Rc<RefCell<AdapterT>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<AdapterT::DataToken>>>,
+        edge_data: RecursiveEdgeData<'query>,
+        max_depth: Option<NonZeroUsize>,
+    ) -> Self {
+        let levels = vec![
+
+            // RcBundleReader::new(a.nei(a.root())),
+        ];
+        Self {
+            starting_contexts: data_contexts,
+            levels,
+            adapter,
+            edge_data,
+            max_depth,
+            reorder_queue: VecDeque::new(),
+            next_from: 0,
+        }
+    }
+
+    fn increase_recursion_depth(&mut self) {
+        let last_recursion_layer = RcBundleReader::clone(
+            self.levels
+                .last()
+                .as_ref()
+                .expect("no recursion levels found"),
+        );
+        let new_recursion_layer = RcBundleReader::new(
+            self.edge_data
+                .expand_edge(self.adapter.as_ref(), Box::new(last_recursion_layer)),
+        );
+        self.levels.push(new_recursion_layer);
+    }
+
+    /// The context value is about to be produced from the Iterator::next() method.
+    /// Ensure elements are produced in the correct order: if there are other contexts
+    /// that need to be produced first, queue this context and return one from the queue instead.
+    fn reorder_output(
+        &mut self,
+        level: usize,
+        ctx: DataContext<AdapterT::DataToken>,
+    ) -> DataContext<AdapterT::DataToken> {
+        let mut returned_ctx = ctx;
+
+        if level > 0 {
+            while self.levels[level].total_pulls() > self.levels[level - 1].total_prepared() {
+                // N.B.: Do not reorder these lines!
+                //       Lots of tricky interactions through Rc<RefCell<...>> here.
+                //
+                // This level has pulled more elements than the last level prepared for us.
+                // This usually happens when batching is used: the adapter impl requests multiple
+                // elements from upstream before yielding its own results.
+                //
+                // In this case, we have to do some work to reorder the tokens into
+                // their proper order:
+                // - We get an "unprepared" token from the previous level.
+                // - We recursively reorder tokens on the previous level.
+                // - We queue the token we were going to return.
+                //   It's tempting to move this line to earlier, but it will mess up
+                //   the recursive step!
+                // - The token from the recursive step is our next candidate token to return.
+                //
+                // We keep looping until we've processed and correctly reordered all the tokens
+                // that were not previously "prepared" due to the batching.
+                let last_level_ctx = self.levels[level - 1]
+                    .pop_passed_unprepared()
+                    .expect("there was no unprepared token but the count said there should be");
+                let next_ctx = self.reorder_output(level - 1, last_level_ctx);
+                self.reorder_queue.push_back(returned_ctx);
+                returned_ctx = next_ctx;
+            }
+        }
+
+        returned_ctx
+    }
+}
+
+pub(super) struct BundleReader<'token, Token>
+where
+    Token: Clone + Debug + 'token,
+{
+    inner: NeighborsBundle<'token, Token>,
+
+    /// The source context and neighbors that we're in the middle of expanding.
+    source: Option<DataContext<Token>>,
+    buffer: Box<dyn Iterator<Item = Token> + 'token>,
+
+    /// Number of times pulled buffers from the bundle
+    total_pulls: usize,
+
+    /// Number of outputs so far
+    total_prepared: usize,
+
+    /// Items already seen (and probably recorded as outputs), but not yet pulled from next().
+    prepared: VecDeque<DataContext<Token>>,
+
+    /// Items pulled from next() without being prepared first. This can happen with batching.
+    passed_unprepared: VecDeque<DataContext<Token>>,
+}
+
+impl<'token, Token> Debug for BundleReader<'token, Token>
+where
+    Token: Debug + Clone + 'token,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BundleReader")
+            .field("inner", &"<elided>")
+            .field("source", &self.source)
+            .field("buffer", &"<elided>")
+            .field("total_pulls", &self.total_pulls)
+            .field("total_prepared", &self.total_prepared)
+            .field("prepared", &self.prepared)
+            .field("passed_unprepared", &self.passed_unprepared)
+            .finish()
+    }
+}
+
+impl<'token, Token> BundleReader<'token, Token>
+where
+    Token: Clone + Debug + 'token,
+{
+    pub(super) fn new(bundle: NeighborsBundle<'token, Token>) -> Self {
+        Self {
+            inner: bundle,
+            source: None,
+            buffer: Box::new(std::iter::empty()),
+            total_pulls: 0,
+            total_prepared: 0,
+            prepared: Default::default(),
+            passed_unprepared: Default::default(),
+        }
+    }
+
+    pub(super) fn pop_passed_unprepared(&mut self) -> Option<DataContext<Token>> {
+        let maybe_token = self.passed_unprepared.pop_front();
+        if maybe_token.is_some() {
+            self.total_prepared += 1;
+        }
+        maybe_token
+    }
+
+    /// Prepare while not pulling more than specified from the bundle,
+    /// i.e. from the parent level of the recursion.
+    pub(super) fn prepare(&mut self, mut pull_limit: usize) -> Option<DataContext<Token>> {
+        loop {
+            let maybe_token = self.pop_passed_unprepared();
+            if maybe_token.is_some() {
+                return maybe_token;
+            }
+
+            if let Some(token) = self.buffer.next() {
+                let neighbor_ctx = self
+                    .source
+                    .as_ref()
+                    .expect("no source for existing buffer")
+                    .split_and_move_to_token(Some(token));
+                self.prepared.push_back(neighbor_ctx.clone());
+                self.total_prepared += 1;
+                return Some(neighbor_ctx);
+            }
+
+            if pull_limit == 0 {
+                return None;
+            }
+            if let Some((new_source, new_buffer)) = self.inner.next() {
+                self.total_pulls += 1;
+                self.source = Some(new_source);
+                self.buffer = new_buffer;
+            } else {
+                return None;
+            }
+            pull_limit -= 1;
+        }
+    }
+
+    pub(super) fn total_prepared(&self) -> usize {
+        self.total_prepared
+    }
+
+    pub(super) fn total_pulls(&self) -> usize {
+        self.total_pulls
+    }
+}
+
+impl<'token, Token> Iterator for BundleReader<'token, Token>
+where
+    Token: Clone + Debug + 'token,
+{
+    type Item = DataContext<Token>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let maybe_token = self.prepared.pop_front();
+            if maybe_token.is_some() {
+                // We found a prepared element, return it.
+                return maybe_token;
+            }
+
+            // If the adapter isn't using batching, then the next() call here will always be None
+            // because any elements from the buffer were processed in a prior prepare().
+            //
+            // If the adapter is using batching, we might end up pulling from the buffer here,
+            // so we'll also have to put those items back in the queue for prepare().
+            // If we forgot to do that, those intermediate nodes in the recursion would not
+            // be included in the recursive expansion of the edge.
+            let maybe_token = self.buffer.next();
+            if let Some(token) = maybe_token {
+                let neighbor_ctx = self
+                    .source
+                    .as_ref()
+                    .expect("no source for existing buffer")
+                    .split_and_move_to_token(Some(token));
+                self.passed_unprepared.push_back(neighbor_ctx.clone());
+                return Some(neighbor_ctx);
+            }
+
+            if let Some((new_source, new_buffer)) = self.inner.next() {
+                self.total_pulls += 1;
+                self.source = Some(new_source);
+                self.buffer = new_buffer;
+            } else {
+                // No more data.
+                return None;
+            }
+        }
+    }
+}
+
+/// Iterator with interior mutability. You can have two references to
+/// it and call next() on either, just not at the same time.
+#[derive(Debug, Clone)]
+pub(super) struct RcBundleReader<'token, Token>
+where
+    Token: Clone + Debug + 'token,
+{
+    inner: Rc<RefCell<BundleReader<'token, Token>>>,
+}
+
+impl<'token, Token> RcBundleReader<'token, Token>
+where
+    Token: Clone + Debug + 'token,
+{
+    pub(super) fn new(bundle: NeighborsBundle<'token, Token>) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(BundleReader::new(bundle))),
+        }
+    }
+
+    pub(super) fn pop_passed_unprepared(&mut self) -> Option<DataContext<Token>> {
+        self.inner.as_ref().borrow_mut().pop_passed_unprepared()
+    }
+
+    pub(super) fn prepare(&mut self, pull_limit: usize) -> Option<DataContext<Token>> {
+        self.inner.as_ref().borrow_mut().prepare(pull_limit)
+    }
+
+    pub(super) fn total_prepared(&self) -> usize {
+        self.inner.as_ref().borrow().total_prepared
+    }
+
+    pub(super) fn total_pulls(&self) -> usize {
+        self.inner.as_ref().borrow().total_pulls
+    }
+}
+
+impl<'token, Token: Debug + Clone + 'token> Iterator for RcBundleReader<'token, Token> {
+    type Item = DataContext<Token>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.as_ref().borrow_mut().next()
+    }
+}
+
+// This is the current "expand an edge recursively" interface in execution.rs.
+// Any replacement recursion logic will need to plug into this function,
+// which execution.rs will call.
+#[allow(clippy::too_many_arguments)]
+#[allow(unused_variables)]
+pub(super) fn expand_recursive_edge<'query, DataToken: Clone + Debug + 'query>(
+    adapter: Rc<RefCell<impl Adapter<'query, DataToken = DataToken> + 'query>>,
+    query: &InterpretedQuery,
+    component: &IRQueryComponent,
+    expanding_from: &IRVertex,
+    expanding_to: &IRVertex,
+    edge_id: Eid,
+    edge_name: &Arc<str>,
+    edge_parameters: &Option<Arc<EdgeParameters>>,
+    recursive: &Recursive,
+    iterator: Box<dyn Iterator<Item = DataContext<DataToken>> + 'query>,
+) -> Box<dyn Iterator<Item = DataContext<DataToken>> + 'query> {
+    todo!()
+}

--- a/trustfall_core/src/interpreter/recurse.rs
+++ b/trustfall_core/src/interpreter/recurse.rs
@@ -261,7 +261,20 @@ where
             self.next_from -= 1;
         }
 
-        None
+        // If we've reached this point, then all the active neighbor iterators
+        // at all recursion levels have run dry. We'll prepare an element from
+        // the top-level of the recursion and allow it to pull from the parent.
+        debug_assert_eq!(self.next_from, 0);
+        let maybe_ctx = self
+            .levels
+            .first_mut()
+            .expect("first level of recursion must exist")
+            .prepare(1);
+        if maybe_ctx.is_some() {
+            self.next_from += 1;
+        }
+
+        maybe_ctx
     }
 }
 

--- a/trustfall_core/src/resources/test_data/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -10,262 +10,161 @@ TestInterpreterOutputTrace(
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
-        parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(CanCoerceToType(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ), false)),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
-        parent_opid: Some(Opid(4)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
-        parent_opid: Some(Opid(2)),
+        parent_opid: Some(Opid(12)),
         content: AdvanceInputIterator,
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        parent_opid: Some(Opid(12)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
-        )),
+        ))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        ))),
+        parent_opid: Some(Opid(15)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
-        parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        )),
+        ), false)),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        ))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
-        parent_opid: Some(Opid(19)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(21): TraceOp(
         opid: Opid(21),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(20)),
+        content: AdvanceInputIterator,
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+        parent_opid: Some(Opid(20)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
+        )),
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
-        parent_opid: Some(Opid(22)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
       ),
       Opid(24): TraceOp(
         opid: Opid(24),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        )),
+        parent_opid: Some(Opid(23)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        ), false)),
-      ),
-      Opid(26): TraceOp(
-        opid: Opid(26),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(27): TraceOp(
-        opid: Opid(27),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        )),
-      ),
-      Opid(28): TraceOp(
-        opid: Opid(28),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        ), false)),
-      ),
-      Opid(29): TraceOp(
-        opid: Opid(29),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(30): TraceOp(
-        opid: Opid(30),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -273,9 +172,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(31): TraceOp(
-        opid: Opid(31),
-        parent_opid: Some(Opid(5)),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -283,9 +182,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(32): TraceOp(
-        opid: Opid(32),
-        parent_opid: Some(Opid(6)),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -294,9 +193,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(33): TraceOp(
-        opid: Opid(33),
-        parent_opid: Some(Opid(6)),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -305,9 +204,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(34): TraceOp(
-        opid: Opid(34),
-        parent_opid: Some(Opid(7)),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -319,9 +218,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(35): TraceOp(
-        opid: Opid(35),
-        parent_opid: Some(Opid(7)),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -333,24 +232,59 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(0))),
       ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(34)),
+        content: AdvanceInputIterator,
+      ),
       Opid(36): TraceOp(
         opid: Opid(36),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(34)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
       ),
       Opid(37): TraceOp(
         opid: Opid(37),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(34)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
       ),
       Opid(38): TraceOp(
         opid: Opid(38),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(37)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -360,7 +294,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -370,7 +304,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(41): TraceOp(
         opid: Opid(41),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -381,7 +315,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -392,7 +326,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(43): TraceOp(
         opid: Opid(43),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -406,7 +340,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -420,210 +354,52 @@ TestInterpreterOutputTrace(
       ),
       Opid(45): TraceOp(
         opid: Opid(45),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(46): TraceOp(
         opid: Opid(46),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(48): TraceOp(
         opid: Opid(48),
-        parent_opid: Some(Opid(22)),
+        parent_opid: Some(Opid(37)),
         content: OutputIteratorExhausted,
       ),
       Opid(49): TraceOp(
         opid: Opid(49),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(23)),
+        content: OutputIteratorExhausted,
       ),
       Opid(50): TraceOp(
         opid: Opid(50),
-        parent_opid: Some(Opid(19)),
+        parent_opid: Some(Opid(15)),
         content: OutputIteratorExhausted,
       ),
       Opid(51): TraceOp(
         opid: Opid(51),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
       ),
       Opid(52): TraceOp(
         opid: Opid(52),
-        parent_opid: Some(Opid(16)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
       ),
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(54): TraceOp(
-        opid: Opid(54),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
-      ),
-      Opid(55): TraceOp(
-        opid: Opid(55),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(56): TraceOp(
-        opid: Opid(56),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        ))),
-      ),
-      Opid(57): TraceOp(
-        opid: Opid(57),
-        parent_opid: Some(Opid(56)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
-      ),
-      Opid(58): TraceOp(
-        opid: Opid(58),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(59): TraceOp(
-        opid: Opid(59),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(60): TraceOp(
-        opid: Opid(60),
-        parent_opid: Some(Opid(59)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(61): TraceOp(
-        opid: Opid(61),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(62): TraceOp(
-        opid: Opid(62),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(63): TraceOp(
-        opid: Opid(63),
-        parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(64): TraceOp(
-        opid: Opid(64),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(65): TraceOp(
-        opid: Opid(65),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -631,14 +407,44 @@ TestInterpreterOutputTrace(
           },
         ), false)),
       ),
-      Opid(66): TraceOp(
-        opid: Opid(66),
-        parent_opid: Some(Opid(5)),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(67): TraceOp(
-        opid: Opid(67),
-        parent_opid: Some(Opid(5)),
+      Opid(55): TraceOp(
+        opid: Opid(55),
+        parent_opid: Some(Opid(12)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(56): TraceOp(
+        opid: Opid(56),
+        parent_opid: Some(Opid(12)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(58): TraceOp(
+        opid: Opid(58),
+        parent_opid: Some(Opid(57)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(59): TraceOp(
+        opid: Opid(59),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -646,9 +452,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(68): TraceOp(
-        opid: Opid(68),
-        parent_opid: Some(Opid(5)),
+      Opid(60): TraceOp(
+        opid: Opid(60),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -656,9 +462,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(69): TraceOp(
-        opid: Opid(69),
-        parent_opid: Some(Opid(6)),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -667,9 +473,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(70): TraceOp(
-        opid: Opid(70),
-        parent_opid: Some(Opid(6)),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -678,9 +484,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(71): TraceOp(
-        opid: Opid(71),
-        parent_opid: Some(Opid(7)),
+      Opid(63): TraceOp(
+        opid: Opid(63),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -692,9 +498,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(72): TraceOp(
-        opid: Opid(72),
-        parent_opid: Some(Opid(7)),
+      Opid(64): TraceOp(
+        opid: Opid(64),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -706,24 +512,54 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(1))),
       ),
-      Opid(73): TraceOp(
-        opid: Opid(73),
-        parent_opid: Some(Opid(7)),
+      Opid(65): TraceOp(
+        opid: Opid(65),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(74): TraceOp(
-        opid: Opid(74),
-        parent_opid: Some(Opid(6)),
+      Opid(66): TraceOp(
+        opid: Opid(66),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(75): TraceOp(
-        opid: Opid(75),
-        parent_opid: Some(Opid(5)),
+      Opid(67): TraceOp(
+        opid: Opid(67),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(76): TraceOp(
-        opid: Opid(76),
-        parent_opid: Some(Opid(5)),
+      Opid(68): TraceOp(
+        opid: Opid(68),
+        parent_opid: Some(Opid(20)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(69): TraceOp(
+        opid: Opid(69),
+        parent_opid: Some(Opid(20)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(70): TraceOp(
+        opid: Opid(70),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(71): TraceOp(
+        opid: Opid(71),
+        parent_opid: Some(Opid(70)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(72): TraceOp(
+        opid: Opid(72),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -731,9 +567,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(77): TraceOp(
-        opid: Opid(77),
-        parent_opid: Some(Opid(5)),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -741,9 +577,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(78): TraceOp(
-        opid: Opid(78),
-        parent_opid: Some(Opid(6)),
+      Opid(74): TraceOp(
+        opid: Opid(74),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -752,9 +588,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(79): TraceOp(
-        opid: Opid(79),
-        parent_opid: Some(Opid(6)),
+      Opid(75): TraceOp(
+        opid: Opid(75),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -763,9 +599,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(80): TraceOp(
-        opid: Opid(80),
-        parent_opid: Some(Opid(7)),
+      Opid(76): TraceOp(
+        opid: Opid(76),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -777,9 +613,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(81): TraceOp(
-        opid: Opid(81),
-        parent_opid: Some(Opid(7)),
+      Opid(77): TraceOp(
+        opid: Opid(77),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -791,24 +627,56 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(1))),
       ),
+      Opid(78): TraceOp(
+        opid: Opid(78),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(79): TraceOp(
+        opid: Opid(79),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(80): TraceOp(
+        opid: Opid(80),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(81): TraceOp(
+        opid: Opid(81),
+        parent_opid: Some(Opid(34)),
+        content: AdvanceInputIterator,
+      ),
       Opid(82): TraceOp(
         opid: Opid(82),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(34)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
       ),
       Opid(83): TraceOp(
         opid: Opid(83),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(34)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(83)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
       ),
       Opid(85): TraceOp(
         opid: Opid(85),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -820,7 +688,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(86): TraceOp(
         opid: Opid(86),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -832,289 +700,157 @@ TestInterpreterOutputTrace(
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(88): TraceOp(
         opid: Opid(88),
-        parent_opid: Some(Opid(62)),
+        parent_opid: Some(Opid(83)),
         content: OutputIteratorExhausted,
       ),
       Opid(89): TraceOp(
         opid: Opid(89),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(70)),
+        content: OutputIteratorExhausted,
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
-        parent_opid: Some(Opid(59)),
+        parent_opid: Some(Opid(57)),
         content: OutputIteratorExhausted,
       ),
       Opid(91): TraceOp(
         opid: Opid(91),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
       ),
       Opid(92): TraceOp(
         opid: Opid(92),
-        parent_opid: Some(Opid(56)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
       ),
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: YieldFrom(CanCoerceToType(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ), true)),
       ),
       Opid(94): TraceOp(
         opid: Opid(94),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        )),
       ),
       Opid(95): TraceOp(
         opid: Opid(95),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
           },
-        )),
+        ), Int64(2))),
       ),
       Opid(96): TraceOp(
         opid: Opid(96),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
           },
-        ))),
+          values: [
+            Int64(2),
+          ],
+        )),
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
-        parent_opid: Some(Opid(96)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+          values: [
+            Int64(2),
+          ],
+        ), Int64(2))),
       ),
       Opid(98): TraceOp(
         opid: Opid(98),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        ))),
+        content: AdvanceInputIterator,
       ),
       Opid(100): TraceOp(
         opid: Opid(100),
-        parent_opid: Some(Opid(99)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(101): TraceOp(
         opid: Opid(101),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(12)),
+        content: AdvanceInputIterator,
       ),
       Opid(102): TraceOp(
         opid: Opid(102),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
+        parent_opid: Some(Opid(12)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
+        )),
       ),
       Opid(103): TraceOp(
         opid: Opid(103),
-        parent_opid: Some(Opid(102)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
       ),
       Opid(104): TraceOp(
         opid: Opid(104),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        )),
+        parent_opid: Some(Opid(103)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(105): TraceOp(
         opid: Opid(105),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
-        ), true)),
+        )),
       ),
       Opid(106): TraceOp(
         opid: Opid(106),
-        parent_opid: Some(Opid(6)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(107): TraceOp(
-        opid: Opid(107),
-        parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-        ), Int64(2))),
-      ),
-      Opid(108): TraceOp(
-        opid: Opid(108),
-        parent_opid: Some(Opid(7)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-          values: [
-            Int64(2),
-          ],
-        )),
-      ),
-      Opid(109): TraceOp(
-        opid: Opid(109),
-        parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-          values: [
-            Int64(2),
-          ],
-        ), Int64(2))),
-      ),
-      Opid(110): TraceOp(
-        opid: Opid(110),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(111): TraceOp(
-        opid: Opid(111),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(112): TraceOp(
-        opid: Opid(112),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(113): TraceOp(
-        opid: Opid(113),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(114): TraceOp(
-        opid: Opid(114),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1122,9 +858,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(115): TraceOp(
-        opid: Opid(115),
-        parent_opid: Some(Opid(6)),
+      Opid(107): TraceOp(
+        opid: Opid(107),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1133,9 +869,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(116): TraceOp(
-        opid: Opid(116),
-        parent_opid: Some(Opid(6)),
+      Opid(108): TraceOp(
+        opid: Opid(108),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1144,9 +880,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(117): TraceOp(
-        opid: Opid(117),
-        parent_opid: Some(Opid(7)),
+      Opid(109): TraceOp(
+        opid: Opid(109),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1158,9 +894,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(118): TraceOp(
-        opid: Opid(118),
-        parent_opid: Some(Opid(7)),
+      Opid(110): TraceOp(
+        opid: Opid(110),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1172,24 +908,90 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(2))),
       ),
+      Opid(111): TraceOp(
+        opid: Opid(111),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(112): TraceOp(
+        opid: Opid(112),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(113): TraceOp(
+        opid: Opid(113),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(114): TraceOp(
+        opid: Opid(114),
+        parent_opid: Some(Opid(20)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(115): TraceOp(
+        opid: Opid(115),
+        parent_opid: Some(Opid(20)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(116): TraceOp(
+        opid: Opid(116),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(117): TraceOp(
+        opid: Opid(117),
+        parent_opid: Some(Opid(116)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(118): TraceOp(
+        opid: Opid(118),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
       Opid(119): TraceOp(
         opid: Opid(119),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(CanCoerceToType(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ), false)),
       ),
       Opid(120): TraceOp(
         opid: Opid(120),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(34)),
         content: AdvanceInputIterator,
       ),
       Opid(122): TraceOp(
         opid: Opid(122),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(34)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1201,24 +1003,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(123): TraceOp(
         opid: Opid(123),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        parent_opid: Some(Opid(34)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
-        ), false)),
+        ))),
       ),
       Opid(124): TraceOp(
         opid: Opid(124),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(123)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(125): TraceOp(
         opid: Opid(125),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1228,7 +1030,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(126): TraceOp(
         opid: Opid(126),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1238,7 +1040,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(127): TraceOp(
         opid: Opid(127),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1249,7 +1051,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(128): TraceOp(
         opid: Opid(128),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1260,7 +1062,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(129): TraceOp(
         opid: Opid(129),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1274,7 +1076,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(130): TraceOp(
         opid: Opid(130),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1288,221 +1090,52 @@ TestInterpreterOutputTrace(
       ),
       Opid(131): TraceOp(
         opid: Opid(131),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(132): TraceOp(
         opid: Opid(132),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(133): TraceOp(
         opid: Opid(133),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(134): TraceOp(
         opid: Opid(134),
-        parent_opid: Some(Opid(102)),
+        parent_opid: Some(Opid(123)),
         content: OutputIteratorExhausted,
       ),
       Opid(135): TraceOp(
         opid: Opid(135),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(116)),
+        content: OutputIteratorExhausted,
       ),
       Opid(136): TraceOp(
         opid: Opid(136),
-        parent_opid: Some(Opid(99)),
+        parent_opid: Some(Opid(103)),
         content: OutputIteratorExhausted,
       ),
       Opid(137): TraceOp(
         opid: Opid(137),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
       ),
       Opid(138): TraceOp(
         opid: Opid(138),
-        parent_opid: Some(Opid(96)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
       ),
       Opid(139): TraceOp(
         opid: Opid(139),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(140): TraceOp(
-        opid: Opid(140),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
-      ),
-      Opid(141): TraceOp(
-        opid: Opid(141),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(142): TraceOp(
-        opid: Opid(142),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        ))),
-      ),
-      Opid(143): TraceOp(
-        opid: Opid(143),
-        parent_opid: Some(Opid(142)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(144): TraceOp(
-        opid: Opid(144),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(145): TraceOp(
-        opid: Opid(145),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(146): TraceOp(
-        opid: Opid(146),
-        parent_opid: Some(Opid(145)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(147): TraceOp(
-        opid: Opid(147),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(148): TraceOp(
-        opid: Opid(148),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(149): TraceOp(
-        opid: Opid(149),
-        parent_opid: Some(Opid(148)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(150): TraceOp(
-        opid: Opid(150),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(151): TraceOp(
-        opid: Opid(151),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1510,9 +1143,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(152): TraceOp(
-        opid: Opid(152),
-        parent_opid: Some(Opid(6)),
+      Opid(140): TraceOp(
+        opid: Opid(140),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1521,9 +1154,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(153): TraceOp(
-        opid: Opid(153),
-        parent_opid: Some(Opid(6)),
+      Opid(141): TraceOp(
+        opid: Opid(141),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1532,9 +1165,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(154): TraceOp(
-        opid: Opid(154),
-        parent_opid: Some(Opid(7)),
+      Opid(142): TraceOp(
+        opid: Opid(142),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1546,9 +1179,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(155): TraceOp(
-        opid: Opid(155),
-        parent_opid: Some(Opid(7)),
+      Opid(143): TraceOp(
+        opid: Opid(143),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1560,24 +1193,56 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(3))),
       ),
-      Opid(156): TraceOp(
-        opid: Opid(156),
-        parent_opid: Some(Opid(7)),
+      Opid(144): TraceOp(
+        opid: Opid(144),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(157): TraceOp(
-        opid: Opid(157),
-        parent_opid: Some(Opid(6)),
+      Opid(145): TraceOp(
+        opid: Opid(145),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(158): TraceOp(
-        opid: Opid(158),
-        parent_opid: Some(Opid(5)),
+      Opid(146): TraceOp(
+        opid: Opid(146),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(159): TraceOp(
-        opid: Opid(159),
-        parent_opid: Some(Opid(5)),
+      Opid(147): TraceOp(
+        opid: Opid(147),
+        parent_opid: Some(Opid(12)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(148): TraceOp(
+        opid: Opid(148),
+        parent_opid: Some(Opid(12)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(149): TraceOp(
+        opid: Opid(149),
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(150): TraceOp(
+        opid: Opid(150),
+        parent_opid: Some(Opid(149)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(151): TraceOp(
+        opid: Opid(151),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1587,9 +1252,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(160): TraceOp(
-        opid: Opid(160),
-        parent_opid: Some(Opid(5)),
+      Opid(152): TraceOp(
+        opid: Opid(152),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1599,14 +1264,48 @@ TestInterpreterOutputTrace(
           },
         ), false)),
       ),
-      Opid(161): TraceOp(
-        opid: Opid(161),
-        parent_opid: Some(Opid(5)),
+      Opid(153): TraceOp(
+        opid: Opid(153),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(162): TraceOp(
-        opid: Opid(162),
-        parent_opid: Some(Opid(5)),
+      Opid(154): TraceOp(
+        opid: Opid(154),
+        parent_opid: Some(Opid(20)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(155): TraceOp(
+        opid: Opid(155),
+        parent_opid: Some(Opid(20)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(156): TraceOp(
+        opid: Opid(156),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(157): TraceOp(
+        opid: Opid(157),
+        parent_opid: Some(Opid(156)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(158): TraceOp(
+        opid: Opid(158),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1614,9 +1313,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(163): TraceOp(
-        opid: Opid(163),
-        parent_opid: Some(Opid(5)),
+      Opid(159): TraceOp(
+        opid: Opid(159),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1624,9 +1323,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(164): TraceOp(
-        opid: Opid(164),
-        parent_opid: Some(Opid(6)),
+      Opid(160): TraceOp(
+        opid: Opid(160),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1635,9 +1334,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(165): TraceOp(
-        opid: Opid(165),
-        parent_opid: Some(Opid(6)),
+      Opid(161): TraceOp(
+        opid: Opid(161),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1646,9 +1345,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(166): TraceOp(
-        opid: Opid(166),
-        parent_opid: Some(Opid(7)),
+      Opid(162): TraceOp(
+        opid: Opid(162),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1660,9 +1359,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(167): TraceOp(
-        opid: Opid(167),
-        parent_opid: Some(Opid(7)),
+      Opid(163): TraceOp(
+        opid: Opid(163),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1674,24 +1373,57 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(3))),
       ),
+      Opid(164): TraceOp(
+        opid: Opid(164),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(165): TraceOp(
+        opid: Opid(165),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(166): TraceOp(
+        opid: Opid(166),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(167): TraceOp(
+        opid: Opid(167),
+        parent_opid: Some(Opid(34)),
+        content: AdvanceInputIterator,
+      ),
       Opid(168): TraceOp(
         opid: Opid(168),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(34)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
       ),
       Opid(169): TraceOp(
         opid: Opid(169),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(34)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
       ),
       Opid(170): TraceOp(
         opid: Opid(170),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(169)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
       ),
       Opid(171): TraceOp(
         opid: Opid(171),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1704,7 +1436,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(172): TraceOp(
         opid: Opid(172),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1717,48 +1449,33 @@ TestInterpreterOutputTrace(
       ),
       Opid(173): TraceOp(
         opid: Opid(173),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(174): TraceOp(
         opid: Opid(174),
-        parent_opid: Some(Opid(148)),
+        parent_opid: Some(Opid(169)),
         content: OutputIteratorExhausted,
       ),
       Opid(175): TraceOp(
         opid: Opid(175),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(156)),
+        content: OutputIteratorExhausted,
       ),
       Opid(176): TraceOp(
         opid: Opid(176),
-        parent_opid: Some(Opid(145)),
+        parent_opid: Some(Opid(149)),
         content: OutputIteratorExhausted,
       ),
       Opid(177): TraceOp(
         opid: Opid(177),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(178): TraceOp(
-        opid: Opid(178),
-        parent_opid: Some(Opid(142)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(179): TraceOp(
-        opid: Opid(179),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(180): TraceOp(
-        opid: Opid(180),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(181): TraceOp(
-        opid: Opid(181),
+      Opid(178): TraceOp(
+        opid: Opid(178),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
@@ -1771,195 +1488,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(182): TraceOp(
-        opid: Opid(182),
+      Opid(179): TraceOp(
+        opid: Opid(179),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(183): TraceOp(
-        opid: Opid(183),
-        parent_opid: Some(Opid(182)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(184): TraceOp(
-        opid: Opid(184),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(185): TraceOp(
-        opid: Opid(185),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(186): TraceOp(
-        opid: Opid(186),
-        parent_opid: Some(Opid(185)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(187): TraceOp(
-        opid: Opid(187),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(188): TraceOp(
-        opid: Opid(188),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(189): TraceOp(
-        opid: Opid(189),
-        parent_opid: Some(Opid(188)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(190): TraceOp(
-        opid: Opid(190),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(191): TraceOp(
-        opid: Opid(191),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1971,14 +1502,52 @@ TestInterpreterOutputTrace(
           },
         ), false)),
       ),
-      Opid(192): TraceOp(
-        opid: Opid(192),
-        parent_opid: Some(Opid(5)),
+      Opid(180): TraceOp(
+        opid: Opid(180),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(193): TraceOp(
-        opid: Opid(193),
-        parent_opid: Some(Opid(5)),
+      Opid(181): TraceOp(
+        opid: Opid(181),
+        parent_opid: Some(Opid(12)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(182): TraceOp(
+        opid: Opid(182),
+        parent_opid: Some(Opid(12)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(183): TraceOp(
+        opid: Opid(183),
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(184): TraceOp(
+        opid: Opid(184),
+        parent_opid: Some(Opid(183)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(185): TraceOp(
+        opid: Opid(185),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1988,9 +1557,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(194): TraceOp(
-        opid: Opid(194),
-        parent_opid: Some(Opid(5)),
+      Opid(186): TraceOp(
+        opid: Opid(186),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2000,9 +1569,9 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(195): TraceOp(
-        opid: Opid(195),
-        parent_opid: Some(Opid(6)),
+      Opid(187): TraceOp(
+        opid: Opid(187),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2013,9 +1582,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(196): TraceOp(
-        opid: Opid(196),
-        parent_opid: Some(Opid(6)),
+      Opid(188): TraceOp(
+        opid: Opid(188),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2026,9 +1595,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(197): TraceOp(
-        opid: Opid(197),
-        parent_opid: Some(Opid(7)),
+      Opid(189): TraceOp(
+        opid: Opid(189),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -2044,9 +1613,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(198): TraceOp(
-        opid: Opid(198),
-        parent_opid: Some(Opid(7)),
+      Opid(190): TraceOp(
+        opid: Opid(190),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -2062,24 +1631,101 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(4))),
       ),
+      Opid(191): TraceOp(
+        opid: Opid(191),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(192): TraceOp(
+        opid: Opid(192),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(193): TraceOp(
+        opid: Opid(193),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(194): TraceOp(
+        opid: Opid(194),
+        parent_opid: Some(Opid(20)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(195): TraceOp(
+        opid: Opid(195),
+        parent_opid: Some(Opid(20)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(196): TraceOp(
+        opid: Opid(196),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(197): TraceOp(
+        opid: Opid(197),
+        parent_opid: Some(Opid(196)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(198): TraceOp(
+        opid: Opid(198),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
       Opid(199): TraceOp(
         opid: Opid(199),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(CanCoerceToType(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), false)),
       ),
       Opid(200): TraceOp(
         opid: Opid(200),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(201): TraceOp(
         opid: Opid(201),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(34)),
         content: AdvanceInputIterator,
       ),
       Opid(202): TraceOp(
         opid: Opid(202),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(34)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2094,8 +1740,8 @@ TestInterpreterOutputTrace(
       ),
       Opid(203): TraceOp(
         opid: Opid(203),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        parent_opid: Some(Opid(34)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2105,16 +1751,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
-        ), false)),
+        ))),
       ),
       Opid(204): TraceOp(
         opid: Opid(204),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(203)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(205): TraceOp(
         opid: Opid(205),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -2126,7 +1772,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(206): TraceOp(
         opid: Opid(206),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -2138,7 +1784,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(207): TraceOp(
         opid: Opid(207),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -2151,7 +1797,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(208): TraceOp(
         opid: Opid(208),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -2164,7 +1810,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(209): TraceOp(
         opid: Opid(209),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -2182,7 +1828,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(210): TraceOp(
         opid: Opid(210),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -2200,112 +1846,67 @@ TestInterpreterOutputTrace(
       ),
       Opid(211): TraceOp(
         opid: Opid(211),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(212): TraceOp(
         opid: Opid(212),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(213): TraceOp(
         opid: Opid(213),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(214): TraceOp(
         opid: Opid(214),
-        parent_opid: Some(Opid(188)),
+        parent_opid: Some(Opid(203)),
         content: OutputIteratorExhausted,
       ),
       Opid(215): TraceOp(
         opid: Opid(215),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(196)),
+        content: OutputIteratorExhausted,
       ),
       Opid(216): TraceOp(
         opid: Opid(216),
-        parent_opid: Some(Opid(185)),
+        parent_opid: Some(Opid(183)),
         content: OutputIteratorExhausted,
       ),
       Opid(217): TraceOp(
         opid: Opid(217),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(218): TraceOp(
         opid: Opid(218),
-        parent_opid: Some(Opid(182)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
       ),
       Opid(219): TraceOp(
         opid: Opid(219),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: OutputIteratorExhausted,
       ),
       Opid(220): TraceOp(
         opid: Opid(220),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
       ),
       Opid(221): TraceOp(
         opid: Opid(221),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
       ),
       Opid(222): TraceOp(
         opid: Opid(222),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
       ),
       Opid(223): TraceOp(
         opid: Opid(223),
-        parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(224): TraceOp(
-        opid: Opid(224),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(225): TraceOp(
-        opid: Opid(225),
         parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(226): TraceOp(
-        opid: Opid(226),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(227): TraceOp(
-        opid: Opid(227),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(228): TraceOp(
-        opid: Opid(228),
-        parent_opid: Some(Opid(5)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(229): TraceOp(
-        opid: Opid(229),
-        parent_opid: Some(Opid(6)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(230): TraceOp(
-        opid: Opid(230),
-        parent_opid: Some(Opid(6)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(231): TraceOp(
-        opid: Opid(231),
-        parent_opid: Some(Opid(7)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(232): TraceOp(
-        opid: Opid(232),
-        parent_opid: Some(Opid(7)),
         content: OutputIteratorExhausted,
       ),
     },

--- a/trustfall_core/src/resources/test_data/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/recurse_and_traverse.trace.ron
@@ -10,269 +10,53 @@ TestInterpreterOutputTrace(
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ProjectProperty(Vid(2), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(11): TraceOp(
-        opid: Opid(11),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(12): TraceOp(
-        opid: Opid(12),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(13): TraceOp(
-        opid: Opid(13),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(14): TraceOp(
-        opid: Opid(14),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(15): TraceOp(
-        opid: Opid(15),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(16): TraceOp(
-        opid: Opid(16),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(17): TraceOp(
-        opid: Opid(17),
+      Opid(11): TraceOp(
+        opid: Opid(11),
         parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(18): TraceOp(
-        opid: Opid(18),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(19): TraceOp(
-        opid: Opid(19),
-        parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(20): TraceOp(
-        opid: Opid(20),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(21): TraceOp(
-        opid: Opid(21),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(22): TraceOp(
-        opid: Opid(22),
-        parent_opid: Some(Opid(21)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(23): TraceOp(
-        opid: Opid(23),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(24): TraceOp(
-        opid: Opid(24),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(25): TraceOp(
-        opid: Opid(25),
-        parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(26): TraceOp(
-        opid: Opid(26),
-        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -287,9 +71,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(27): TraceOp(
-        opid: Opid(27),
-        parent_opid: Some(Opid(5)),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -304,16 +88,16 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(28): TraceOp(
-        opid: Opid(28),
-        parent_opid: Some(Opid(27)),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(29): TraceOp(
-        opid: Opid(29),
-        parent_opid: Some(Opid(6)),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -331,9 +115,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(30): TraceOp(
-        opid: Opid(30),
-        parent_opid: Some(Opid(6)),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -351,9 +135,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(31): TraceOp(
-        opid: Opid(31),
-        parent_opid: Some(Opid(7)),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -374,9 +158,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(32): TraceOp(
-        opid: Opid(32),
-        parent_opid: Some(Opid(7)),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -397,9 +181,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(4))),
       ),
-      Opid(33): TraceOp(
-        opid: Opid(33),
-        parent_opid: Some(Opid(8)),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -421,9 +205,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(34): TraceOp(
-        opid: Opid(34),
-        parent_opid: Some(Opid(8)),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -445,31 +229,31 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(4))),
       ),
-      Opid(35): TraceOp(
-        opid: Opid(35),
-        parent_opid: Some(Opid(8)),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(36): TraceOp(
-        opid: Opid(36),
-        parent_opid: Some(Opid(7)),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(37): TraceOp(
-        opid: Opid(37),
-        parent_opid: Some(Opid(6)),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(38): TraceOp(
-        opid: Opid(38),
-        parent_opid: Some(Opid(27)),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
-      Opid(39): TraceOp(
-        opid: Opid(39),
-        parent_opid: Some(Opid(6)),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -487,9 +271,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(40): TraceOp(
-        opid: Opid(40),
-        parent_opid: Some(Opid(6)),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -507,9 +291,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(41): TraceOp(
-        opid: Opid(41),
-        parent_opid: Some(Opid(7)),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -530,9 +314,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(42): TraceOp(
-        opid: Opid(42),
-        parent_opid: Some(Opid(7)),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -553,9 +337,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(8))),
       ),
-      Opid(43): TraceOp(
-        opid: Opid(43),
-        parent_opid: Some(Opid(8)),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -577,9 +361,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(44): TraceOp(
-        opid: Opid(44),
-        parent_opid: Some(Opid(8)),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -601,32 +385,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(4))),
       ),
-      Opid(45): TraceOp(
-        opid: Opid(45),
-        parent_opid: Some(Opid(8)),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(46): TraceOp(
-        opid: Opid(46),
-        parent_opid: Some(Opid(7)),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(47): TraceOp(
-        opid: Opid(47),
-        parent_opid: Some(Opid(6)),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(48): TraceOp(
-        opid: Opid(48),
-        parent_opid: Some(Opid(27)),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
       ),
-      Opid(49): TraceOp(
-        opid: Opid(49),
-        parent_opid: Some(Opid(6)),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -645,9 +429,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(50): TraceOp(
-        opid: Opid(50),
-        parent_opid: Some(Opid(6)),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -666,9 +450,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(51): TraceOp(
-        opid: Opid(51),
-        parent_opid: Some(Opid(7)),
+      Opid(36): TraceOp(
+        opid: Opid(36),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(12, [
             2,
@@ -691,9 +475,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(52): TraceOp(
-        opid: Opid(52),
-        parent_opid: Some(Opid(7)),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(12, [
             2,
@@ -716,9 +500,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(12))),
       ),
-      Opid(53): TraceOp(
-        opid: Opid(53),
-        parent_opid: Some(Opid(8)),
+      Opid(38): TraceOp(
+        opid: Opid(38),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -741,9 +525,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(54): TraceOp(
-        opid: Opid(54),
-        parent_opid: Some(Opid(8)),
+      Opid(39): TraceOp(
+        opid: Opid(39),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -766,34 +550,77 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(4))),
       ),
-      Opid(55): TraceOp(
-        opid: Opid(55),
-        parent_opid: Some(Opid(8)),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(56): TraceOp(
-        opid: Opid(56),
-        parent_opid: Some(Opid(7)),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(57): TraceOp(
-        opid: Opid(57),
-        parent_opid: Some(Opid(6)),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(58): TraceOp(
-        opid: Opid(58),
-        parent_opid: Some(Opid(27)),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(12)),
         content: OutputIteratorExhausted,
       ),
-      Opid(59): TraceOp(
-        opid: Opid(59),
-        parent_opid: Some(Opid(5)),
+      Opid(44): TraceOp(
+        opid: Opid(44),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(60): TraceOp(
-        opid: Opid(60),
-        parent_opid: Some(Opid(5)),
+      Opid(45): TraceOp(
+        opid: Opid(45),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(45)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(47): TraceOp(
+        opid: Opid(47),
+        parent_opid: Some(Opid(45)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(48): TraceOp(
+        opid: Opid(48),
+        parent_opid: Some(Opid(45)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(49): TraceOp(
+        opid: Opid(49),
+        parent_opid: Some(Opid(48)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(50): TraceOp(
+        opid: Opid(50),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -804,9 +631,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(61): TraceOp(
-        opid: Opid(61),
-        parent_opid: Some(Opid(5)),
+      Opid(51): TraceOp(
+        opid: Opid(51),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -817,17 +644,17 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(62): TraceOp(
-        opid: Opid(62),
-        parent_opid: Some(Opid(61)),
+      Opid(52): TraceOp(
+        opid: Opid(52),
+        parent_opid: Some(Opid(51)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
       ),
-      Opid(63): TraceOp(
-        opid: Opid(63),
-        parent_opid: Some(Opid(6)),
+      Opid(53): TraceOp(
+        opid: Opid(53),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -844,9 +671,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(64): TraceOp(
-        opid: Opid(64),
-        parent_opid: Some(Opid(6)),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -863,9 +690,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(65): TraceOp(
-        opid: Opid(65),
-        parent_opid: Some(Opid(7)),
+      Opid(55): TraceOp(
+        opid: Opid(55),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(10, [
             2,
@@ -886,9 +713,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(66): TraceOp(
-        opid: Opid(66),
-        parent_opid: Some(Opid(7)),
+      Opid(56): TraceOp(
+        opid: Opid(56),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(10, [
             2,
@@ -909,9 +736,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(10))),
       ),
-      Opid(67): TraceOp(
-        opid: Opid(67),
-        parent_opid: Some(Opid(8)),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -930,9 +757,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(68): TraceOp(
-        opid: Opid(68),
-        parent_opid: Some(Opid(8)),
+      Opid(58): TraceOp(
+        opid: Opid(58),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -951,32 +778,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(5))),
       ),
-      Opid(69): TraceOp(
-        opid: Opid(69),
-        parent_opid: Some(Opid(8)),
+      Opid(59): TraceOp(
+        opid: Opid(59),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(70): TraceOp(
-        opid: Opid(70),
-        parent_opid: Some(Opid(7)),
+      Opid(60): TraceOp(
+        opid: Opid(60),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(71): TraceOp(
-        opid: Opid(71),
-        parent_opid: Some(Opid(6)),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(72): TraceOp(
-        opid: Opid(72),
-        parent_opid: Some(Opid(61)),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(51)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
       ),
-      Opid(73): TraceOp(
-        opid: Opid(73),
-        parent_opid: Some(Opid(6)),
+      Opid(63): TraceOp(
+        opid: Opid(63),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -993,9 +820,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(74): TraceOp(
-        opid: Opid(74),
-        parent_opid: Some(Opid(6)),
+      Opid(64): TraceOp(
+        opid: Opid(64),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1012,9 +839,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(75): TraceOp(
-        opid: Opid(75),
-        parent_opid: Some(Opid(7)),
+      Opid(65): TraceOp(
+        opid: Opid(65),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(15, [
             3,
@@ -1035,9 +862,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(76): TraceOp(
-        opid: Opid(76),
-        parent_opid: Some(Opid(7)),
+      Opid(66): TraceOp(
+        opid: Opid(66),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(15, [
             3,
@@ -1058,9 +885,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(15))),
       ),
-      Opid(77): TraceOp(
-        opid: Opid(77),
-        parent_opid: Some(Opid(8)),
+      Opid(67): TraceOp(
+        opid: Opid(67),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1079,9 +906,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(78): TraceOp(
-        opid: Opid(78),
-        parent_opid: Some(Opid(8)),
+      Opid(68): TraceOp(
+        opid: Opid(68),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1100,34 +927,76 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(5))),
       ),
-      Opid(79): TraceOp(
-        opid: Opid(79),
-        parent_opid: Some(Opid(8)),
+      Opid(69): TraceOp(
+        opid: Opid(69),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(80): TraceOp(
-        opid: Opid(80),
-        parent_opid: Some(Opid(7)),
+      Opid(70): TraceOp(
+        opid: Opid(70),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(81): TraceOp(
-        opid: Opid(81),
-        parent_opid: Some(Opid(6)),
+      Opid(71): TraceOp(
+        opid: Opid(71),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(82): TraceOp(
-        opid: Opid(82),
-        parent_opid: Some(Opid(61)),
+      Opid(72): TraceOp(
+        opid: Opid(72),
+        parent_opid: Some(Opid(51)),
         content: OutputIteratorExhausted,
       ),
-      Opid(83): TraceOp(
-        opid: Opid(83),
-        parent_opid: Some(Opid(5)),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(84): TraceOp(
-        opid: Opid(84),
-        parent_opid: Some(Opid(5)),
+      Opid(74): TraceOp(
+        opid: Opid(74),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(75): TraceOp(
+        opid: Opid(75),
+        parent_opid: Some(Opid(74)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(76): TraceOp(
+        opid: Opid(76),
+        parent_opid: Some(Opid(74)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(77): TraceOp(
+        opid: Opid(77),
+        parent_opid: Some(Opid(74)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(78): TraceOp(
+        opid: Opid(78),
+        parent_opid: Some(Opid(77)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(79): TraceOp(
+        opid: Opid(79),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1144,9 +1013,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(85): TraceOp(
-        opid: Opid(85),
-        parent_opid: Some(Opid(5)),
+      Opid(80): TraceOp(
+        opid: Opid(80),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1163,17 +1032,17 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(86): TraceOp(
-        opid: Opid(86),
-        parent_opid: Some(Opid(85)),
+      Opid(81): TraceOp(
+        opid: Opid(81),
+        parent_opid: Some(Opid(80)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
       ),
-      Opid(87): TraceOp(
-        opid: Opid(87),
-        parent_opid: Some(Opid(6)),
+      Opid(82): TraceOp(
+        opid: Opid(82),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1193,9 +1062,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(88): TraceOp(
-        opid: Opid(88),
-        parent_opid: Some(Opid(6)),
+      Opid(83): TraceOp(
+        opid: Opid(83),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1215,9 +1084,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(89): TraceOp(
-        opid: Opid(89),
-        parent_opid: Some(Opid(7)),
+      Opid(84): TraceOp(
+        opid: Opid(84),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1240,113 +1109,113 @@ TestInterpreterOutputTrace(
             Int64(4),
           ],
         )),
+      ),
+      Opid(85): TraceOp(
+        opid: Opid(85),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+            Vid(3): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+        ), Int64(6))),
+      ),
+      Opid(86): TraceOp(
+        opid: Opid(86),
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+            Vid(3): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+          values: [
+            Int64(4),
+            Int64(6),
+          ],
+        )),
+      ),
+      Opid(87): TraceOp(
+        opid: Opid(87),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+            Vid(3): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+          values: [
+            Int64(4),
+            Int64(6),
+          ],
+        ), Int64(6))),
+      ),
+      Opid(88): TraceOp(
+        opid: Opid(88),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(89): TraceOp(
+        opid: Opid(89),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
-        parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-            Vid(2): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
-            Vid(3): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
-          },
-          values: [
-            Int64(4),
-          ],
-        ), Int64(6))),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(91): TraceOp(
         opid: Opid(91),
-        parent_opid: Some(Opid(8)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-            Vid(2): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
-            Vid(3): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
-          },
-          values: [
-            Int64(4),
-            Int64(6),
-          ],
-        )),
-      ),
-      Opid(92): TraceOp(
-        opid: Opid(92),
-        parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-            Vid(2): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
-            Vid(3): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
-          },
-          values: [
-            Int64(4),
-            Int64(6),
-          ],
-        ), Int64(6))),
-      ),
-      Opid(93): TraceOp(
-        opid: Opid(93),
-        parent_opid: Some(Opid(8)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(94): TraceOp(
-        opid: Opid(94),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(95): TraceOp(
-        opid: Opid(95),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(96): TraceOp(
-        opid: Opid(96),
-        parent_opid: Some(Opid(85)),
+        parent_opid: Some(Opid(80)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
       ),
-      Opid(97): TraceOp(
-        opid: Opid(97),
-        parent_opid: Some(Opid(6)),
+      Opid(92): TraceOp(
+        opid: Opid(92),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1366,9 +1235,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(98): TraceOp(
-        opid: Opid(98),
-        parent_opid: Some(Opid(6)),
+      Opid(93): TraceOp(
+        opid: Opid(93),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1388,9 +1257,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(99): TraceOp(
-        opid: Opid(99),
-        parent_opid: Some(Opid(7)),
+      Opid(94): TraceOp(
+        opid: Opid(94),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(12, [
             2,
@@ -1414,9 +1283,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(100): TraceOp(
-        opid: Opid(100),
-        parent_opid: Some(Opid(7)),
+      Opid(95): TraceOp(
+        opid: Opid(95),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(12, [
             2,
@@ -1440,9 +1309,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(12))),
       ),
-      Opid(101): TraceOp(
-        opid: Opid(101),
-        parent_opid: Some(Opid(8)),
+      Opid(96): TraceOp(
+        opid: Opid(96),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1467,9 +1336,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(102): TraceOp(
-        opid: Opid(102),
-        parent_opid: Some(Opid(8)),
+      Opid(97): TraceOp(
+        opid: Opid(97),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1494,32 +1363,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
-      Opid(103): TraceOp(
-        opid: Opid(103),
-        parent_opid: Some(Opid(8)),
+      Opid(98): TraceOp(
+        opid: Opid(98),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(104): TraceOp(
-        opid: Opid(104),
-        parent_opid: Some(Opid(7)),
+      Opid(99): TraceOp(
+        opid: Opid(99),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(105): TraceOp(
-        opid: Opid(105),
-        parent_opid: Some(Opid(6)),
+      Opid(100): TraceOp(
+        opid: Opid(100),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(106): TraceOp(
-        opid: Opid(106),
-        parent_opid: Some(Opid(85)),
+      Opid(101): TraceOp(
+        opid: Opid(101),
+        parent_opid: Some(Opid(80)),
         content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
       ),
-      Opid(107): TraceOp(
-        opid: Opid(107),
-        parent_opid: Some(Opid(6)),
+      Opid(102): TraceOp(
+        opid: Opid(102),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1539,9 +1408,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(108): TraceOp(
-        opid: Opid(108),
-        parent_opid: Some(Opid(6)),
+      Opid(103): TraceOp(
+        opid: Opid(103),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1561,9 +1430,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(109): TraceOp(
-        opid: Opid(109),
-        parent_opid: Some(Opid(7)),
+      Opid(104): TraceOp(
+        opid: Opid(104),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(18, [
             2,
@@ -1587,9 +1456,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(110): TraceOp(
-        opid: Opid(110),
-        parent_opid: Some(Opid(7)),
+      Opid(105): TraceOp(
+        opid: Opid(105),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(18, [
             2,
@@ -1613,9 +1482,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(18))),
       ),
-      Opid(111): TraceOp(
-        opid: Opid(111),
-        parent_opid: Some(Opid(8)),
+      Opid(106): TraceOp(
+        opid: Opid(106),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1640,9 +1509,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(112): TraceOp(
-        opid: Opid(112),
-        parent_opid: Some(Opid(8)),
+      Opid(107): TraceOp(
+        opid: Opid(107),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1667,34 +1536,79 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
+      Opid(108): TraceOp(
+        opid: Opid(108),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(109): TraceOp(
+        opid: Opid(109),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(110): TraceOp(
+        opid: Opid(110),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(111): TraceOp(
+        opid: Opid(111),
+        parent_opid: Some(Opid(80)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(112): TraceOp(
+        opid: Opid(112),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(113): TraceOp(
         opid: Opid(113),
-        parent_opid: Some(Opid(8)),
-        content: AdvanceInputIterator,
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(114): TraceOp(
         opid: Opid(114),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(113)),
         content: AdvanceInputIterator,
       ),
       Opid(115): TraceOp(
         opid: Opid(115),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(113)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
       ),
       Opid(116): TraceOp(
         opid: Opid(116),
-        parent_opid: Some(Opid(85)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(113)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
       ),
       Opid(117): TraceOp(
         opid: Opid(117),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(116)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(118): TraceOp(
         opid: Opid(118),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1707,7 +1621,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(119): TraceOp(
         opid: Opid(119),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1728,7 +1642,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1747,7 +1661,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(122): TraceOp(
         opid: Opid(122),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1766,7 +1680,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(123): TraceOp(
         opid: Opid(123),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(14, [
             2,
@@ -1789,7 +1703,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(124): TraceOp(
         opid: Opid(124),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(14, [
             2,
@@ -1812,7 +1726,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(125): TraceOp(
         opid: Opid(125),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1833,7 +1747,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(126): TraceOp(
         opid: Opid(126),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1854,17 +1768,17 @@ TestInterpreterOutputTrace(
       ),
       Opid(127): TraceOp(
         opid: Opid(127),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
       Opid(128): TraceOp(
         opid: Opid(128),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(129): TraceOp(
         opid: Opid(129),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(130): TraceOp(
@@ -1877,7 +1791,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(131): TraceOp(
         opid: Opid(131),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1896,7 +1810,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(132): TraceOp(
         opid: Opid(132),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1915,7 +1829,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(133): TraceOp(
         opid: Opid(133),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(21, [
             3,
@@ -1938,7 +1852,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(134): TraceOp(
         opid: Opid(134),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(21, [
             3,
@@ -1961,7 +1875,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(135): TraceOp(
         opid: Opid(135),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1982,7 +1896,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(136): TraceOp(
         opid: Opid(136),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -2003,17 +1917,17 @@ TestInterpreterOutputTrace(
       ),
       Opid(137): TraceOp(
         opid: Opid(137),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
       Opid(138): TraceOp(
         opid: Opid(138),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(139): TraceOp(
         opid: Opid(139),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(140): TraceOp(
@@ -2023,235 +1937,62 @@ TestInterpreterOutputTrace(
       ),
       Opid(141): TraceOp(
         opid: Opid(141),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(142): TraceOp(
         opid: Opid(142),
-        parent_opid: Some(Opid(24)),
+        parent_opid: Some(Opid(116)),
         content: OutputIteratorExhausted,
       ),
       Opid(143): TraceOp(
         opid: Opid(143),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(77)),
+        content: OutputIteratorExhausted,
       ),
       Opid(144): TraceOp(
         opid: Opid(144),
-        parent_opid: Some(Opid(21)),
+        parent_opid: Some(Opid(48)),
         content: OutputIteratorExhausted,
       ),
       Opid(145): TraceOp(
         opid: Opid(145),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
       ),
       Opid(146): TraceOp(
         opid: Opid(146),
-        parent_opid: Some(Opid(18)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+            Vid(2): Some(Prime(PrimeNumber(5))),
+          },
+        )),
       ),
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+            Vid(2): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
       ),
       Opid(148): TraceOp(
         opid: Opid(148),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
-      ),
-      Opid(149): TraceOp(
-        opid: Opid(149),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        )),
-      ),
-      Opid(150): TraceOp(
-        opid: Opid(150),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        ))),
-      ),
-      Opid(151): TraceOp(
-        opid: Opid(151),
-        parent_opid: Some(Opid(150)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(152): TraceOp(
-        opid: Opid(152),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(153): TraceOp(
-        opid: Opid(153),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(154): TraceOp(
-        opid: Opid(154),
-        parent_opid: Some(Opid(153)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(155): TraceOp(
-        opid: Opid(155),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(6, [
-                  2,
-                  3,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(5))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(5))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(156): TraceOp(
-        opid: Opid(156),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(6, [
-                  2,
-                  3,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(5))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(5))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(157): TraceOp(
-        opid: Opid(157),
-        parent_opid: Some(Opid(156)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
-          2,
-        ])))),
-      ),
-      Opid(158): TraceOp(
-        opid: Opid(158),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-            Vid(2): Some(Prime(PrimeNumber(5))),
-          },
-        )),
-      ),
-      Opid(159): TraceOp(
-        opid: Opid(159),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-            Vid(2): Some(Prime(PrimeNumber(5))),
-          },
-        ))),
-      ),
-      Opid(160): TraceOp(
-        opid: Opid(160),
-        parent_opid: Some(Opid(159)),
+        parent_opid: Some(Opid(147)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
       ),
-      Opid(161): TraceOp(
-        opid: Opid(161),
-        parent_opid: Some(Opid(6)),
+      Opid(149): TraceOp(
+        opid: Opid(149),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2264,9 +2005,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(162): TraceOp(
-        opid: Opid(162),
-        parent_opid: Some(Opid(6)),
+      Opid(150): TraceOp(
+        opid: Opid(150),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2279,9 +2020,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(163): TraceOp(
-        opid: Opid(163),
-        parent_opid: Some(Opid(7)),
+      Opid(151): TraceOp(
+        opid: Opid(151),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(10, [
             2,
@@ -2300,9 +2041,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(164): TraceOp(
-        opid: Opid(164),
-        parent_opid: Some(Opid(7)),
+      Opid(152): TraceOp(
+        opid: Opid(152),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(10, [
             2,
@@ -2321,9 +2062,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(10))),
       ),
-      Opid(165): TraceOp(
-        opid: Opid(165),
-        parent_opid: Some(Opid(8)),
+      Opid(153): TraceOp(
+        opid: Opid(153),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2340,9 +2081,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(166): TraceOp(
-        opid: Opid(166),
-        parent_opid: Some(Opid(8)),
+      Opid(154): TraceOp(
+        opid: Opid(154),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2359,32 +2100,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(5))),
       ),
-      Opid(167): TraceOp(
-        opid: Opid(167),
-        parent_opid: Some(Opid(8)),
+      Opid(155): TraceOp(
+        opid: Opid(155),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(168): TraceOp(
-        opid: Opid(168),
-        parent_opid: Some(Opid(7)),
+      Opid(156): TraceOp(
+        opid: Opid(156),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(169): TraceOp(
-        opid: Opid(169),
-        parent_opid: Some(Opid(6)),
+      Opid(157): TraceOp(
+        opid: Opid(157),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(170): TraceOp(
-        opid: Opid(170),
-        parent_opid: Some(Opid(159)),
+      Opid(158): TraceOp(
+        opid: Opid(158),
+        parent_opid: Some(Opid(147)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
       ),
-      Opid(171): TraceOp(
-        opid: Opid(171),
-        parent_opid: Some(Opid(6)),
+      Opid(159): TraceOp(
+        opid: Opid(159),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2397,9 +2138,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(172): TraceOp(
-        opid: Opid(172),
-        parent_opid: Some(Opid(6)),
+      Opid(160): TraceOp(
+        opid: Opid(160),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2412,9 +2153,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(173): TraceOp(
-        opid: Opid(173),
-        parent_opid: Some(Opid(7)),
+      Opid(161): TraceOp(
+        opid: Opid(161),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(15, [
             3,
@@ -2433,9 +2174,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(174): TraceOp(
-        opid: Opid(174),
-        parent_opid: Some(Opid(7)),
+      Opid(162): TraceOp(
+        opid: Opid(162),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(15, [
             3,
@@ -2454,9 +2195,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(15))),
       ),
-      Opid(175): TraceOp(
-        opid: Opid(175),
-        parent_opid: Some(Opid(8)),
+      Opid(163): TraceOp(
+        opid: Opid(163),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2473,9 +2214,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(176): TraceOp(
-        opid: Opid(176),
-        parent_opid: Some(Opid(8)),
+      Opid(164): TraceOp(
+        opid: Opid(164),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2492,34 +2233,67 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(5))),
       ),
-      Opid(177): TraceOp(
-        opid: Opid(177),
-        parent_opid: Some(Opid(8)),
+      Opid(165): TraceOp(
+        opid: Opid(165),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(178): TraceOp(
-        opid: Opid(178),
-        parent_opid: Some(Opid(7)),
+      Opid(166): TraceOp(
+        opid: Opid(166),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(179): TraceOp(
-        opid: Opid(179),
-        parent_opid: Some(Opid(6)),
+      Opid(167): TraceOp(
+        opid: Opid(167),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(180): TraceOp(
-        opid: Opid(180),
-        parent_opid: Some(Opid(159)),
+      Opid(168): TraceOp(
+        opid: Opid(168),
+        parent_opid: Some(Opid(147)),
         content: OutputIteratorExhausted,
       ),
-      Opid(181): TraceOp(
-        opid: Opid(181),
-        parent_opid: Some(Opid(5)),
+      Opid(169): TraceOp(
+        opid: Opid(169),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(182): TraceOp(
-        opid: Opid(182),
-        parent_opid: Some(Opid(5)),
+      Opid(170): TraceOp(
+        opid: Opid(170),
+        parent_opid: Some(Opid(45)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(171): TraceOp(
+        opid: Opid(171),
+        parent_opid: Some(Opid(45)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(172): TraceOp(
+        opid: Opid(172),
+        parent_opid: Some(Opid(45)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
+      ),
+      Opid(173): TraceOp(
+        opid: Opid(173),
+        parent_opid: Some(Opid(172)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(174): TraceOp(
+        opid: Opid(174),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2534,9 +2308,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(183): TraceOp(
-        opid: Opid(183),
-        parent_opid: Some(Opid(5)),
+      Opid(175): TraceOp(
+        opid: Opid(175),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2551,17 +2325,17 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(184): TraceOp(
-        opid: Opid(184),
-        parent_opid: Some(Opid(183)),
+      Opid(176): TraceOp(
+        opid: Opid(176),
+        parent_opid: Some(Opid(175)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
       ),
-      Opid(185): TraceOp(
-        opid: Opid(185),
-        parent_opid: Some(Opid(6)),
+      Opid(177): TraceOp(
+        opid: Opid(177),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2577,9 +2351,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(186): TraceOp(
-        opid: Opid(186),
-        parent_opid: Some(Opid(6)),
+      Opid(178): TraceOp(
+        opid: Opid(178),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2595,9 +2369,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(187): TraceOp(
-        opid: Opid(187),
-        parent_opid: Some(Opid(7)),
+      Opid(179): TraceOp(
+        opid: Opid(179),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2619,9 +2393,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(188): TraceOp(
-        opid: Opid(188),
-        parent_opid: Some(Opid(7)),
+      Opid(180): TraceOp(
+        opid: Opid(180),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2643,9 +2417,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
-      Opid(189): TraceOp(
-        opid: Opid(189),
-        parent_opid: Some(Opid(8)),
+      Opid(181): TraceOp(
+        opid: Opid(181),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2668,9 +2442,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(190): TraceOp(
-        opid: Opid(190),
-        parent_opid: Some(Opid(8)),
+      Opid(182): TraceOp(
+        opid: Opid(182),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2693,32 +2467,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
-      Opid(191): TraceOp(
-        opid: Opid(191),
-        parent_opid: Some(Opid(8)),
+      Opid(183): TraceOp(
+        opid: Opid(183),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(192): TraceOp(
-        opid: Opid(192),
-        parent_opid: Some(Opid(7)),
+      Opid(184): TraceOp(
+        opid: Opid(184),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(193): TraceOp(
-        opid: Opid(193),
-        parent_opid: Some(Opid(6)),
+      Opid(185): TraceOp(
+        opid: Opid(185),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(194): TraceOp(
-        opid: Opid(194),
-        parent_opid: Some(Opid(183)),
+      Opid(186): TraceOp(
+        opid: Opid(186),
+        parent_opid: Some(Opid(175)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
       ),
-      Opid(195): TraceOp(
-        opid: Opid(195),
-        parent_opid: Some(Opid(6)),
+      Opid(187): TraceOp(
+        opid: Opid(187),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2734,9 +2508,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(196): TraceOp(
-        opid: Opid(196),
-        parent_opid: Some(Opid(6)),
+      Opid(188): TraceOp(
+        opid: Opid(188),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2752,9 +2526,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(197): TraceOp(
-        opid: Opid(197),
-        parent_opid: Some(Opid(7)),
+      Opid(189): TraceOp(
+        opid: Opid(189),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(12, [
             2,
@@ -2776,9 +2550,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(198): TraceOp(
-        opid: Opid(198),
-        parent_opid: Some(Opid(7)),
+      Opid(190): TraceOp(
+        opid: Opid(190),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(12, [
             2,
@@ -2800,9 +2574,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(12))),
       ),
-      Opid(199): TraceOp(
-        opid: Opid(199),
-        parent_opid: Some(Opid(8)),
+      Opid(191): TraceOp(
+        opid: Opid(191),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2825,9 +2599,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(200): TraceOp(
-        opid: Opid(200),
-        parent_opid: Some(Opid(8)),
+      Opid(192): TraceOp(
+        opid: Opid(192),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2850,32 +2624,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
-      Opid(201): TraceOp(
-        opid: Opid(201),
-        parent_opid: Some(Opid(8)),
+      Opid(193): TraceOp(
+        opid: Opid(193),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(202): TraceOp(
-        opid: Opid(202),
-        parent_opid: Some(Opid(7)),
+      Opid(194): TraceOp(
+        opid: Opid(194),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(203): TraceOp(
-        opid: Opid(203),
-        parent_opid: Some(Opid(6)),
+      Opid(195): TraceOp(
+        opid: Opid(195),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(204): TraceOp(
-        opid: Opid(204),
-        parent_opid: Some(Opid(183)),
+      Opid(196): TraceOp(
+        opid: Opid(196),
+        parent_opid: Some(Opid(175)),
         content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
       ),
-      Opid(205): TraceOp(
-        opid: Opid(205),
-        parent_opid: Some(Opid(6)),
+      Opid(197): TraceOp(
+        opid: Opid(197),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2891,9 +2665,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(206): TraceOp(
-        opid: Opid(206),
-        parent_opid: Some(Opid(6)),
+      Opid(198): TraceOp(
+        opid: Opid(198),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -2909,9 +2683,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(207): TraceOp(
-        opid: Opid(207),
-        parent_opid: Some(Opid(7)),
+      Opid(199): TraceOp(
+        opid: Opid(199),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(18, [
             2,
@@ -2933,9 +2707,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(208): TraceOp(
-        opid: Opid(208),
-        parent_opid: Some(Opid(7)),
+      Opid(200): TraceOp(
+        opid: Opid(200),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(18, [
             2,
@@ -2957,9 +2731,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(18))),
       ),
-      Opid(209): TraceOp(
-        opid: Opid(209),
-        parent_opid: Some(Opid(8)),
+      Opid(201): TraceOp(
+        opid: Opid(201),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -2982,9 +2756,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(210): TraceOp(
-        opid: Opid(210),
-        parent_opid: Some(Opid(8)),
+      Opid(202): TraceOp(
+        opid: Opid(202),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -3007,34 +2781,70 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
+      Opid(203): TraceOp(
+        opid: Opid(203),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(204): TraceOp(
+        opid: Opid(204),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(205): TraceOp(
+        opid: Opid(205),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(206): TraceOp(
+        opid: Opid(206),
+        parent_opid: Some(Opid(175)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(207): TraceOp(
+        opid: Opid(207),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(208): TraceOp(
+        opid: Opid(208),
+        parent_opid: Some(Opid(74)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(209): TraceOp(
+        opid: Opid(209),
+        parent_opid: Some(Opid(74)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(210): TraceOp(
+        opid: Opid(210),
+        parent_opid: Some(Opid(74)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
+      ),
       Opid(211): TraceOp(
         opid: Opid(211),
-        parent_opid: Some(Opid(8)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(210)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(212): TraceOp(
         opid: Opid(212),
-        parent_opid: Some(Opid(7)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(213): TraceOp(
-        opid: Opid(213),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(214): TraceOp(
-        opid: Opid(214),
-        parent_opid: Some(Opid(183)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(215): TraceOp(
-        opid: Opid(215),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(216): TraceOp(
-        opid: Opid(216),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -3043,9 +2853,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(217): TraceOp(
-        opid: Opid(217),
-        parent_opid: Some(Opid(5)),
+      Opid(213): TraceOp(
+        opid: Opid(213),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -3054,17 +2864,17 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(218): TraceOp(
-        opid: Opid(218),
-        parent_opid: Some(Opid(217)),
+      Opid(214): TraceOp(
+        opid: Opid(214),
+        parent_opid: Some(Opid(213)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
       ),
-      Opid(219): TraceOp(
-        opid: Opid(219),
-        parent_opid: Some(Opid(6)),
+      Opid(215): TraceOp(
+        opid: Opid(215),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3077,9 +2887,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(220): TraceOp(
-        opid: Opid(220),
-        parent_opid: Some(Opid(6)),
+      Opid(216): TraceOp(
+        opid: Opid(216),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3092,9 +2902,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(221): TraceOp(
-        opid: Opid(221),
-        parent_opid: Some(Opid(7)),
+      Opid(217): TraceOp(
+        opid: Opid(217),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(14, [
             2,
@@ -3113,9 +2923,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(222): TraceOp(
-        opid: Opid(222),
-        parent_opid: Some(Opid(7)),
+      Opid(218): TraceOp(
+        opid: Opid(218),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(14, [
             2,
@@ -3134,9 +2944,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(14))),
       ),
-      Opid(223): TraceOp(
-        opid: Opid(223),
-        parent_opid: Some(Opid(8)),
+      Opid(219): TraceOp(
+        opid: Opid(219),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -3153,9 +2963,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(224): TraceOp(
-        opid: Opid(224),
-        parent_opid: Some(Opid(8)),
+      Opid(220): TraceOp(
+        opid: Opid(220),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -3172,32 +2982,32 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(7))),
       ),
-      Opid(225): TraceOp(
-        opid: Opid(225),
-        parent_opid: Some(Opid(8)),
+      Opid(221): TraceOp(
+        opid: Opid(221),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(226): TraceOp(
-        opid: Opid(226),
-        parent_opid: Some(Opid(7)),
+      Opid(222): TraceOp(
+        opid: Opid(222),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(227): TraceOp(
-        opid: Opid(227),
-        parent_opid: Some(Opid(6)),
+      Opid(223): TraceOp(
+        opid: Opid(223),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(228): TraceOp(
-        opid: Opid(228),
-        parent_opid: Some(Opid(217)),
+      Opid(224): TraceOp(
+        opid: Opid(224),
+        parent_opid: Some(Opid(213)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(21, [
           3,
           7,
         ])))),
       ),
-      Opid(229): TraceOp(
-        opid: Opid(229),
-        parent_opid: Some(Opid(6)),
+      Opid(225): TraceOp(
+        opid: Opid(225),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3210,9 +3020,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(230): TraceOp(
-        opid: Opid(230),
-        parent_opid: Some(Opid(6)),
+      Opid(226): TraceOp(
+        opid: Opid(226),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3225,9 +3035,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(231): TraceOp(
-        opid: Opid(231),
-        parent_opid: Some(Opid(7)),
+      Opid(227): TraceOp(
+        opid: Opid(227),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(21, [
             3,
@@ -3246,9 +3056,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(232): TraceOp(
-        opid: Opid(232),
-        parent_opid: Some(Opid(7)),
+      Opid(228): TraceOp(
+        opid: Opid(228),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(21, [
             3,
@@ -3267,9 +3077,9 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(21))),
       ),
-      Opid(233): TraceOp(
-        opid: Opid(233),
-        parent_opid: Some(Opid(8)),
+      Opid(229): TraceOp(
+        opid: Opid(229),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -3286,9 +3096,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(234): TraceOp(
-        opid: Opid(234),
-        parent_opid: Some(Opid(8)),
+      Opid(230): TraceOp(
+        opid: Opid(230),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -3305,34 +3115,66 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(7))),
       ),
+      Opid(231): TraceOp(
+        opid: Opid(231),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(232): TraceOp(
+        opid: Opid(232),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(233): TraceOp(
+        opid: Opid(233),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(234): TraceOp(
+        opid: Opid(234),
+        parent_opid: Some(Opid(213)),
+        content: OutputIteratorExhausted,
+      ),
       Opid(235): TraceOp(
         opid: Opid(235),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(236): TraceOp(
         opid: Opid(236),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(113)),
         content: AdvanceInputIterator,
       ),
       Opid(237): TraceOp(
         opid: Opid(237),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(113)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(7))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
       ),
       Opid(238): TraceOp(
         opid: Opid(238),
-        parent_opid: Some(Opid(217)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(113)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(7))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
       ),
       Opid(239): TraceOp(
         opid: Opid(239),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(238)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+          2,
+        ])))),
       ),
       Opid(240): TraceOp(
         opid: Opid(240),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3347,7 +3189,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(241): TraceOp(
         opid: Opid(241),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3369,7 +3211,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(243): TraceOp(
         opid: Opid(243),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3385,7 +3227,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(244): TraceOp(
         opid: Opid(244),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3401,7 +3243,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(245): TraceOp(
         opid: Opid(245),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3422,7 +3264,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(246): TraceOp(
         opid: Opid(246),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3443,7 +3285,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(247): TraceOp(
         opid: Opid(247),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3465,7 +3307,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(248): TraceOp(
         opid: Opid(248),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3487,17 +3329,17 @@ TestInterpreterOutputTrace(
       ),
       Opid(249): TraceOp(
         opid: Opid(249),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
       Opid(250): TraceOp(
         opid: Opid(250),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(251): TraceOp(
         opid: Opid(251),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(252): TraceOp(
@@ -3509,7 +3351,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(253): TraceOp(
         opid: Opid(253),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3525,7 +3367,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(254): TraceOp(
         opid: Opid(254),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3541,7 +3383,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(255): TraceOp(
         opid: Opid(255),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -3562,7 +3404,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(256): TraceOp(
         opid: Opid(256),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -3583,7 +3425,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(257): TraceOp(
         opid: Opid(257),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3605,7 +3447,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(258): TraceOp(
         opid: Opid(258),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3627,17 +3469,17 @@ TestInterpreterOutputTrace(
       ),
       Opid(259): TraceOp(
         opid: Opid(259),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
       Opid(260): TraceOp(
         opid: Opid(260),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(261): TraceOp(
         opid: Opid(261),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(262): TraceOp(
@@ -3650,7 +3492,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(263): TraceOp(
         opid: Opid(263),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3667,7 +3509,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(264): TraceOp(
         opid: Opid(264),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -3684,7 +3526,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(265): TraceOp(
         opid: Opid(265),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(24, [
             2,
@@ -3707,7 +3549,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(266): TraceOp(
         opid: Opid(266),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(24, [
             2,
@@ -3730,7 +3572,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(267): TraceOp(
         opid: Opid(267),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3753,7 +3595,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(268): TraceOp(
         opid: Opid(268),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -3776,17 +3618,17 @@ TestInterpreterOutputTrace(
       ),
       Opid(269): TraceOp(
         opid: Opid(269),
-        parent_opid: Some(Opid(8)),
+        parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
       Opid(270): TraceOp(
         opid: Opid(270),
-        parent_opid: Some(Opid(7)),
+        parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
       Opid(271): TraceOp(
         opid: Opid(271),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(272): TraceOp(
@@ -3796,112 +3638,67 @@ TestInterpreterOutputTrace(
       ),
       Opid(273): TraceOp(
         opid: Opid(273),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(274): TraceOp(
         opid: Opid(274),
-        parent_opid: Some(Opid(156)),
+        parent_opid: Some(Opid(238)),
         content: OutputIteratorExhausted,
       ),
       Opid(275): TraceOp(
         opid: Opid(275),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(210)),
+        content: OutputIteratorExhausted,
       ),
       Opid(276): TraceOp(
         opid: Opid(276),
-        parent_opid: Some(Opid(153)),
+        parent_opid: Some(Opid(172)),
         content: OutputIteratorExhausted,
       ),
       Opid(277): TraceOp(
         opid: Opid(277),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(278): TraceOp(
         opid: Opid(278),
-        parent_opid: Some(Opid(150)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
       ),
       Opid(279): TraceOp(
         opid: Opid(279),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: OutputIteratorExhausted,
       ),
       Opid(280): TraceOp(
         opid: Opid(280),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
       ),
       Opid(281): TraceOp(
         opid: Opid(281),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
       ),
       Opid(282): TraceOp(
         opid: Opid(282),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
       ),
       Opid(283): TraceOp(
         opid: Opid(283),
-        parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
       ),
       Opid(284): TraceOp(
         opid: Opid(284),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
       ),
       Opid(285): TraceOp(
         opid: Opid(285),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(286): TraceOp(
-        opid: Opid(286),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(287): TraceOp(
-        opid: Opid(287),
         parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(288): TraceOp(
-        opid: Opid(288),
-        parent_opid: Some(Opid(5)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(289): TraceOp(
-        opid: Opid(289),
-        parent_opid: Some(Opid(6)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(290): TraceOp(
-        opid: Opid(290),
-        parent_opid: Some(Opid(6)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(291): TraceOp(
-        opid: Opid(291),
-        parent_opid: Some(Opid(7)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(292): TraceOp(
-        opid: Opid(292),
-        parent_opid: Some(Opid(7)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(293): TraceOp(
-        opid: Opid(293),
-        parent_opid: Some(Opid(8)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(294): TraceOp(
-        opid: Opid(294),
-        parent_opid: Some(Opid(8)),
         content: OutputIteratorExhausted,
       ),
     },

--- a/trustfall_core/src/resources/test_data/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/recurse_directive.trace.ron
@@ -10,262 +10,126 @@ TestInterpreterOutputTrace(
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
-        parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): Some(Neither(NeitherNumber(0))),
+          },
+        )),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): Some(Neither(NeitherNumber(0))),
+          },
+        ), Int64(0))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): Some(Neither(NeitherNumber(0))),
+          },
+          values: [
+            Int64(0),
+          ],
+        )),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): Some(Neither(NeitherNumber(0))),
+          },
+          values: [
+            Int64(0),
+          ],
+        ), Int64(0))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
-        parent_opid: Some(Opid(2)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        )),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        ))),
+        parent_opid: Some(Opid(13)),
+        content: AdvanceInputIterator,
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
-        parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        parent_opid: Some(Opid(13)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+        parent_opid: Some(Opid(13)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        )),
+        ))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        ))),
+        parent_opid: Some(Opid(16)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
-        parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
-      ),
-      Opid(19): TraceOp(
-        opid: Opid(19),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(20): TraceOp(
-        opid: Opid(20),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(21): TraceOp(
-        opid: Opid(21),
-        parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(22): TraceOp(
-        opid: Opid(22),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-            Vid(2): Some(Neither(NeitherNumber(0))),
-          },
-        )),
-      ),
-      Opid(23): TraceOp(
-        opid: Opid(23),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-            Vid(2): Some(Neither(NeitherNumber(0))),
-          },
-        ), Int64(0))),
-      ),
-      Opid(24): TraceOp(
-        opid: Opid(24),
-        parent_opid: Some(Opid(6)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-            Vid(2): Some(Neither(NeitherNumber(0))),
-          },
-          values: [
-            Int64(0),
-          ],
-        )),
-      ),
-      Opid(25): TraceOp(
-        opid: Opid(25),
-        parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-            Vid(2): Some(Neither(NeitherNumber(0))),
-          },
-          values: [
-            Int64(0),
-          ],
-        ), Int64(0))),
-      ),
-      Opid(26): TraceOp(
-        opid: Opid(26),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(27): TraceOp(
-        opid: Opid(27),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(28): TraceOp(
-        opid: Opid(28),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -274,9 +138,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(29): TraceOp(
-        opid: Opid(29),
-        parent_opid: Some(Opid(5)),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -285,9 +149,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(1))),
       ),
-      Opid(30): TraceOp(
-        opid: Opid(30),
-        parent_opid: Some(Opid(6)),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -299,9 +163,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(31): TraceOp(
-        opid: Opid(31),
-        parent_opid: Some(Opid(6)),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -313,19 +177,54 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(0))),
       ),
-      Opid(32): TraceOp(
-        opid: Opid(32),
-        parent_opid: Some(Opid(6)),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(33): TraceOp(
-        opid: Opid(33),
-        parent_opid: Some(Opid(5)),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(34): TraceOp(
-        opid: Opid(34),
-        parent_opid: Some(Opid(5)),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(27)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -334,9 +233,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(35): TraceOp(
-        opid: Opid(35),
-        parent_opid: Some(Opid(5)),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -345,9 +244,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(36): TraceOp(
-        opid: Opid(36),
-        parent_opid: Some(Opid(6)),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -359,9 +258,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(37): TraceOp(
-        opid: Opid(37),
-        parent_opid: Some(Opid(6)),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -373,19 +272,54 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(0))),
       ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(36): TraceOp(
+        opid: Opid(36),
+        parent_opid: Some(Opid(35)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(35)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
       Opid(38): TraceOp(
         opid: Opid(38),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(35)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(38)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -396,7 +330,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(41): TraceOp(
         opid: Opid(41),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -407,7 +341,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -421,7 +355,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(43): TraceOp(
         opid: Opid(43),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -435,255 +369,127 @@ TestInterpreterOutputTrace(
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(45): TraceOp(
         opid: Opid(45),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(46): TraceOp(
         opid: Opid(46),
-        parent_opid: Some(Opid(20)),
+        parent_opid: Some(Opid(38)),
         content: OutputIteratorExhausted,
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(27)),
+        content: OutputIteratorExhausted,
       ),
       Opid(48): TraceOp(
         opid: Opid(48),
-        parent_opid: Some(Opid(17)),
+        parent_opid: Some(Opid(16)),
         content: OutputIteratorExhausted,
       ),
       Opid(49): TraceOp(
         opid: Opid(49),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
       ),
       Opid(50): TraceOp(
         opid: Opid(50),
-        parent_opid: Some(Opid(14)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+            Vid(2): Some(Neither(NeitherNumber(1))),
+          },
+        )),
       ),
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+            Vid(2): Some(Neither(NeitherNumber(1))),
+          },
+        ), Int64(1))),
       ),
       Opid(52): TraceOp(
         opid: Opid(52),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+            Vid(2): Some(Neither(NeitherNumber(1))),
+          },
+          values: [
+            Int64(1),
+          ],
+        )),
       ),
       Opid(53): TraceOp(
         opid: Opid(53),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
+            Vid(2): Some(Neither(NeitherNumber(1))),
           },
-        )),
+          values: [
+            Int64(1),
+          ],
+        ), Int64(1))),
       ),
       Opid(54): TraceOp(
         opid: Opid(54),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        ))),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(55): TraceOp(
         opid: Opid(55),
-        parent_opid: Some(Opid(54)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(56): TraceOp(
         opid: Opid(56),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(13)),
+        content: AdvanceInputIterator,
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+        parent_opid: Some(Opid(13)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        ))),
+        )),
       ),
       Opid(58): TraceOp(
         opid: Opid(58),
-        parent_opid: Some(Opid(57)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        parent_opid: Some(Opid(13)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
       ),
       Opid(59): TraceOp(
         opid: Opid(59),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(58)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(60): TraceOp(
         opid: Opid(60),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(61): TraceOp(
-        opid: Opid(61),
-        parent_opid: Some(Opid(60)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(62): TraceOp(
-        opid: Opid(62),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-            Vid(2): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(63): TraceOp(
-        opid: Opid(63),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-            Vid(2): Some(Neither(NeitherNumber(1))),
-          },
-        ), Int64(1))),
-      ),
-      Opid(64): TraceOp(
-        opid: Opid(64),
-        parent_opid: Some(Opid(6)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-            Vid(2): Some(Neither(NeitherNumber(1))),
-          },
-          values: [
-            Int64(1),
-          ],
-        )),
-      ),
-      Opid(65): TraceOp(
-        opid: Opid(65),
-        parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-            Vid(2): Some(Neither(NeitherNumber(1))),
-          },
-          values: [
-            Int64(1),
-          ],
-        ), Int64(1))),
-      ),
-      Opid(66): TraceOp(
-        opid: Opid(66),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(67): TraceOp(
-        opid: Opid(67),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(68): TraceOp(
-        opid: Opid(68),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -692,9 +498,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(69): TraceOp(
-        opid: Opid(69),
-        parent_opid: Some(Opid(5)),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -703,9 +509,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(70): TraceOp(
-        opid: Opid(70),
-        parent_opid: Some(Opid(6)),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -717,9 +523,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(71): TraceOp(
-        opid: Opid(71),
-        parent_opid: Some(Opid(6)),
+      Opid(63): TraceOp(
+        opid: Opid(63),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -731,19 +537,49 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(1))),
       ),
-      Opid(72): TraceOp(
-        opid: Opid(72),
-        parent_opid: Some(Opid(6)),
+      Opid(64): TraceOp(
+        opid: Opid(64),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(73): TraceOp(
-        opid: Opid(73),
-        parent_opid: Some(Opid(5)),
+      Opid(65): TraceOp(
+        opid: Opid(65),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(74): TraceOp(
-        opid: Opid(74),
-        parent_opid: Some(Opid(5)),
+      Opid(66): TraceOp(
+        opid: Opid(66),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(67): TraceOp(
+        opid: Opid(67),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(68): TraceOp(
+        opid: Opid(68),
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(69): TraceOp(
+        opid: Opid(69),
+        parent_opid: Some(Opid(68)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(70): TraceOp(
+        opid: Opid(70),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -752,9 +588,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(75): TraceOp(
-        opid: Opid(75),
-        parent_opid: Some(Opid(5)),
+      Opid(71): TraceOp(
+        opid: Opid(71),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -763,9 +599,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(76): TraceOp(
-        opid: Opid(76),
-        parent_opid: Some(Opid(6)),
+      Opid(72): TraceOp(
+        opid: Opid(72),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -777,9 +613,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(77): TraceOp(
-        opid: Opid(77),
-        parent_opid: Some(Opid(6)),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -791,19 +627,51 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(1))),
       ),
+      Opid(74): TraceOp(
+        opid: Opid(74),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(75): TraceOp(
+        opid: Opid(75),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(76): TraceOp(
+        opid: Opid(76),
+        parent_opid: Some(Opid(35)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(77): TraceOp(
+        opid: Opid(77),
+        parent_opid: Some(Opid(35)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
       Opid(78): TraceOp(
         opid: Opid(78),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(35)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
       ),
       Opid(79): TraceOp(
         opid: Opid(79),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(78)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
       ),
       Opid(80): TraceOp(
         opid: Opid(80),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -818,7 +686,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(81): TraceOp(
         opid: Opid(81),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -833,7 +701,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(82): TraceOp(
         opid: Opid(82),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -849,7 +717,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(83): TraceOp(
         opid: Opid(83),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -865,259 +733,127 @@ TestInterpreterOutputTrace(
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(85): TraceOp(
         opid: Opid(85),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(86): TraceOp(
         opid: Opid(86),
-        parent_opid: Some(Opid(60)),
+        parent_opid: Some(Opid(78)),
         content: OutputIteratorExhausted,
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(68)),
+        content: OutputIteratorExhausted,
       ),
       Opid(88): TraceOp(
         opid: Opid(88),
-        parent_opid: Some(Opid(57)),
+        parent_opid: Some(Opid(58)),
         content: OutputIteratorExhausted,
       ),
       Opid(89): TraceOp(
         opid: Opid(89),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
-        parent_opid: Some(Opid(54)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        )),
       ),
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        ), Int64(2))),
       ),
       Opid(92): TraceOp(
         opid: Opid(92),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+          values: [
+            Int64(2),
+          ],
+        )),
       ),
       Opid(93): TraceOp(
         opid: Opid(93),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
           },
-        )),
+          values: [
+            Int64(2),
+          ],
+        ), Int64(2))),
       ),
       Opid(94): TraceOp(
         opid: Opid(94),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        ))),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(95): TraceOp(
         opid: Opid(95),
-        parent_opid: Some(Opid(94)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(96): TraceOp(
         opid: Opid(96),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(13)),
+        content: AdvanceInputIterator,
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+        parent_opid: Some(Opid(13)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        ))),
+        )),
       ),
       Opid(98): TraceOp(
         opid: Opid(98),
-        parent_opid: Some(Opid(97)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
+        parent_opid: Some(Opid(13)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
       ),
       Opid(99): TraceOp(
         opid: Opid(99),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
+        parent_opid: Some(Opid(98)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(100): TraceOp(
         opid: Opid(100),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(101): TraceOp(
-        opid: Opid(101),
-        parent_opid: Some(Opid(100)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(102): TraceOp(
-        opid: Opid(102),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(103): TraceOp(
-        opid: Opid(103),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-        ), Int64(2))),
-      ),
-      Opid(104): TraceOp(
-        opid: Opid(104),
-        parent_opid: Some(Opid(6)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-          values: [
-            Int64(2),
-          ],
-        )),
-      ),
-      Opid(105): TraceOp(
-        opid: Opid(105),
-        parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-            Vid(2): Some(Prime(PrimeNumber(2))),
-          },
-          values: [
-            Int64(2),
-          ],
-        ), Int64(2))),
-      ),
-      Opid(106): TraceOp(
-        opid: Opid(106),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(107): TraceOp(
-        opid: Opid(107),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(108): TraceOp(
-        opid: Opid(108),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1126,9 +862,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(109): TraceOp(
-        opid: Opid(109),
-        parent_opid: Some(Opid(5)),
+      Opid(101): TraceOp(
+        opid: Opid(101),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1137,9 +873,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(110): TraceOp(
-        opid: Opid(110),
-        parent_opid: Some(Opid(6)),
+      Opid(102): TraceOp(
+        opid: Opid(102),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1151,9 +887,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(111): TraceOp(
-        opid: Opid(111),
-        parent_opid: Some(Opid(6)),
+      Opid(103): TraceOp(
+        opid: Opid(103),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1165,19 +901,51 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(2))),
       ),
-      Opid(112): TraceOp(
-        opid: Opid(112),
-        parent_opid: Some(Opid(6)),
+      Opid(104): TraceOp(
+        opid: Opid(104),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(113): TraceOp(
-        opid: Opid(113),
-        parent_opid: Some(Opid(5)),
+      Opid(105): TraceOp(
+        opid: Opid(105),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(114): TraceOp(
-        opid: Opid(114),
-        parent_opid: Some(Opid(5)),
+      Opid(106): TraceOp(
+        opid: Opid(106),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(107): TraceOp(
+        opid: Opid(107),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(108): TraceOp(
+        opid: Opid(108),
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(109): TraceOp(
+        opid: Opid(109),
+        parent_opid: Some(Opid(108)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(110): TraceOp(
+        opid: Opid(110),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1190,9 +958,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(115): TraceOp(
-        opid: Opid(115),
-        parent_opid: Some(Opid(5)),
+      Opid(111): TraceOp(
+        opid: Opid(111),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1205,9 +973,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(116): TraceOp(
-        opid: Opid(116),
-        parent_opid: Some(Opid(6)),
+      Opid(112): TraceOp(
+        opid: Opid(112),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1221,9 +989,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(117): TraceOp(
-        opid: Opid(117),
-        parent_opid: Some(Opid(6)),
+      Opid(113): TraceOp(
+        opid: Opid(113),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1237,19 +1005,53 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(2))),
       ),
+      Opid(114): TraceOp(
+        opid: Opid(114),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(115): TraceOp(
+        opid: Opid(115),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(116): TraceOp(
+        opid: Opid(116),
+        parent_opid: Some(Opid(35)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(117): TraceOp(
+        opid: Opid(117),
+        parent_opid: Some(Opid(35)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
       Opid(118): TraceOp(
         opid: Opid(118),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(35)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
       ),
       Opid(119): TraceOp(
         opid: Opid(119),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(118)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(120): TraceOp(
         opid: Opid(120),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1260,7 +1062,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1271,7 +1073,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(122): TraceOp(
         opid: Opid(122),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1285,7 +1087,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(123): TraceOp(
         opid: Opid(123),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -1299,52 +1101,102 @@ TestInterpreterOutputTrace(
       ),
       Opid(124): TraceOp(
         opid: Opid(124),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(125): TraceOp(
         opid: Opid(125),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(126): TraceOp(
         opid: Opid(126),
-        parent_opid: Some(Opid(100)),
+        parent_opid: Some(Opid(118)),
         content: OutputIteratorExhausted,
       ),
       Opid(127): TraceOp(
         opid: Opid(127),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(108)),
+        content: OutputIteratorExhausted,
       ),
       Opid(128): TraceOp(
         opid: Opid(128),
-        parent_opid: Some(Opid(97)),
+        parent_opid: Some(Opid(98)),
         content: OutputIteratorExhausted,
       ),
       Opid(129): TraceOp(
         opid: Opid(129),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
       ),
       Opid(130): TraceOp(
         opid: Opid(130),
-        parent_opid: Some(Opid(94)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+        )),
       ),
       Opid(131): TraceOp(
         opid: Opid(131),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+        ), Int64(3))),
       ),
       Opid(132): TraceOp(
         opid: Opid(132),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+          values: [
+            Int64(3),
+          ],
+        )),
       ),
       Opid(133): TraceOp(
         opid: Opid(133),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+          values: [
+            Int64(3),
+          ],
+        ), Int64(3))),
+      ),
+      Opid(134): TraceOp(
+        opid: Opid(134),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(135): TraceOp(
+        opid: Opid(135),
         parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(136): TraceOp(
+        opid: Opid(136),
+        parent_opid: Some(Opid(13)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(137): TraceOp(
+        opid: Opid(137),
+        parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1352,9 +1204,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(134): TraceOp(
-        opid: Opid(134),
-        parent_opid: Some(Opid(2)),
+      Opid(138): TraceOp(
+        opid: Opid(138),
+        parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1362,203 +1214,16 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(135): TraceOp(
-        opid: Opid(135),
-        parent_opid: Some(Opid(134)),
+      Opid(139): TraceOp(
+        opid: Opid(139),
+        parent_opid: Some(Opid(138)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(136): TraceOp(
-        opid: Opid(136),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(137): TraceOp(
-        opid: Opid(137),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(138): TraceOp(
-        opid: Opid(138),
-        parent_opid: Some(Opid(137)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(139): TraceOp(
-        opid: Opid(139),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
       Opid(140): TraceOp(
         opid: Opid(140),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(141): TraceOp(
-        opid: Opid(141),
-        parent_opid: Some(Opid(140)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(142): TraceOp(
-        opid: Opid(142),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-            Vid(2): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(143): TraceOp(
-        opid: Opid(143),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-            Vid(2): Some(Prime(PrimeNumber(3))),
-          },
-        ), Int64(3))),
-      ),
-      Opid(144): TraceOp(
-        opid: Opid(144),
-        parent_opid: Some(Opid(6)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-            Vid(2): Some(Prime(PrimeNumber(3))),
-          },
-          values: [
-            Int64(3),
-          ],
-        )),
-      ),
-      Opid(145): TraceOp(
-        opid: Opid(145),
-        parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-            Vid(2): Some(Prime(PrimeNumber(3))),
-          },
-          values: [
-            Int64(3),
-          ],
-        ), Int64(3))),
-      ),
-      Opid(146): TraceOp(
-        opid: Opid(146),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(147): TraceOp(
-        opid: Opid(147),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(148): TraceOp(
-        opid: Opid(148),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1571,9 +1236,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(149): TraceOp(
-        opid: Opid(149),
-        parent_opid: Some(Opid(5)),
+      Opid(141): TraceOp(
+        opid: Opid(141),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1586,9 +1251,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(150): TraceOp(
-        opid: Opid(150),
-        parent_opid: Some(Opid(6)),
+      Opid(142): TraceOp(
+        opid: Opid(142),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1602,9 +1267,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(151): TraceOp(
-        opid: Opid(151),
-        parent_opid: Some(Opid(6)),
+      Opid(143): TraceOp(
+        opid: Opid(143),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1618,19 +1283,53 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(3))),
       ),
-      Opid(152): TraceOp(
-        opid: Opid(152),
-        parent_opid: Some(Opid(6)),
+      Opid(144): TraceOp(
+        opid: Opid(144),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(153): TraceOp(
-        opid: Opid(153),
-        parent_opid: Some(Opid(5)),
+      Opid(145): TraceOp(
+        opid: Opid(145),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(154): TraceOp(
-        opid: Opid(154),
-        parent_opid: Some(Opid(5)),
+      Opid(146): TraceOp(
+        opid: Opid(146),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(147): TraceOp(
+        opid: Opid(147),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(148): TraceOp(
+        opid: Opid(148),
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(149): TraceOp(
+        opid: Opid(149),
+        parent_opid: Some(Opid(148)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(150): TraceOp(
+        opid: Opid(150),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1639,9 +1338,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(155): TraceOp(
-        opid: Opid(155),
-        parent_opid: Some(Opid(5)),
+      Opid(151): TraceOp(
+        opid: Opid(151),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1650,9 +1349,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(156): TraceOp(
-        opid: Opid(156),
-        parent_opid: Some(Opid(6)),
+      Opid(152): TraceOp(
+        opid: Opid(152),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1664,9 +1363,9 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(157): TraceOp(
-        opid: Opid(157),
-        parent_opid: Some(Opid(6)),
+      Opid(153): TraceOp(
+        opid: Opid(153),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1678,19 +1377,52 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(3))),
       ),
+      Opid(154): TraceOp(
+        opid: Opid(154),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(155): TraceOp(
+        opid: Opid(155),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(156): TraceOp(
+        opid: Opid(156),
+        parent_opid: Some(Opid(35)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(157): TraceOp(
+        opid: Opid(157),
+        parent_opid: Some(Opid(35)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
       Opid(158): TraceOp(
         opid: Opid(158),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(35)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
       ),
       Opid(159): TraceOp(
         opid: Opid(159),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(158)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
       ),
       Opid(160): TraceOp(
         opid: Opid(160),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1707,7 +1439,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(161): TraceOp(
         opid: Opid(161),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1724,7 +1456,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(162): TraceOp(
         opid: Opid(162),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1741,7 +1473,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(163): TraceOp(
         opid: Opid(163),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1758,97 +1490,52 @@ TestInterpreterOutputTrace(
       ),
       Opid(164): TraceOp(
         opid: Opid(164),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(165): TraceOp(
         opid: Opid(165),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(166): TraceOp(
         opid: Opid(166),
-        parent_opid: Some(Opid(140)),
+        parent_opid: Some(Opid(158)),
         content: OutputIteratorExhausted,
       ),
       Opid(167): TraceOp(
         opid: Opid(167),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(148)),
+        content: OutputIteratorExhausted,
       ),
       Opid(168): TraceOp(
         opid: Opid(168),
-        parent_opid: Some(Opid(137)),
+        parent_opid: Some(Opid(138)),
         content: OutputIteratorExhausted,
       ),
       Opid(169): TraceOp(
         opid: Opid(169),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(170): TraceOp(
         opid: Opid(170),
-        parent_opid: Some(Opid(134)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
       ),
       Opid(171): TraceOp(
         opid: Opid(171),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: OutputIteratorExhausted,
       ),
       Opid(172): TraceOp(
         opid: Opid(172),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
       ),
       Opid(173): TraceOp(
         opid: Opid(173),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(174): TraceOp(
-        opid: Opid(174),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(175): TraceOp(
-        opid: Opid(175),
         parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(176): TraceOp(
-        opid: Opid(176),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(177): TraceOp(
-        opid: Opid(177),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(178): TraceOp(
-        opid: Opid(178),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(179): TraceOp(
-        opid: Opid(179),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(180): TraceOp(
-        opid: Opid(180),
-        parent_opid: Some(Opid(5)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(181): TraceOp(
-        opid: Opid(181),
-        parent_opid: Some(Opid(6)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(182): TraceOp(
-        opid: Opid(182),
-        parent_opid: Some(Opid(6)),
         content: OutputIteratorExhausted,
       ),
     },

--- a/trustfall_core/src/resources/test_data/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -10,53 +10,72 @@ TestInterpreterOutputTrace(
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
-        parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
-      ),
-      Opid(4): TraceOp(
-        opid: Opid(4),
-        parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
-      ),
-      Opid(5): TraceOp(
-        opid: Opid(5),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
-      ),
-      Opid(6): TraceOp(
-        opid: Opid(6),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(7): TraceOp(
-        opid: Opid(7),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(8): TraceOp(
-        opid: Opid(8),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(9): TraceOp(
-        opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(10): TraceOp(
-        opid: Opid(10),
+      Opid(4): TraceOp(
+        opid: Opid(4),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(11): TraceOp(
-        opid: Opid(11),
+      Opid(5): TraceOp(
+        opid: Opid(5),
         parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(8)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -67,32 +86,49 @@ TestInterpreterOutputTrace(
             ]))),
           },
         )),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(8)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
+        parent_opid: Some(Opid(11)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
-        parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -100,63 +136,30 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        )),
+        ), Int64(4))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        ))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
-        parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
-        parent_opid: Some(Opid(4)),
+        parent_opid: Some(Opid(16)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -166,41 +169,11 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
         )),
       ),
-      Opid(18): TraceOp(
-        opid: Opid(18),
-        parent_opid: Some(Opid(4)),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -210,48 +183,18 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
         ))),
       ),
-      Opid(19): TraceOp(
-        opid: Opid(19),
-        parent_opid: Some(Opid(18)),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(19)),
         content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(20): TraceOp(
-        opid: Opid(20),
-        parent_opid: Some(Opid(5)),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -265,49 +208,10 @@ TestInterpreterOutputTrace(
             ]))),
           },
         )),
-      ),
-      Opid(21): TraceOp(
-        opid: Opid(21),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-            Vid(2): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ), Int64(4))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(23): TraceOp(
-        opid: Opid(23),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-            Vid(2): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(24): TraceOp(
-        opid: Opid(24),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -322,23 +226,30 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+      ),
       Opid(25): TraceOp(
         opid: Opid(25),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(24)),
         content: AdvanceInputIterator,
       ),
       Opid(26): TraceOp(
         opid: Opid(26),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(24)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-            Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
           },
@@ -346,8 +257,8 @@ TestInterpreterOutputTrace(
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -355,20 +266,19 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
-            Vid(2): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
           },
-        ), Int64(4))),
+        ))),
       ),
       Opid(28): TraceOp(
         opid: Opid(28),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(27)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -385,7 +295,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -402,19 +312,19 @@ TestInterpreterOutputTrace(
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
-        parent_opid: Some(Opid(18)),
+        parent_opid: Some(Opid(27)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -431,7 +341,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(34): TraceOp(
         opid: Opid(34),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -448,64 +358,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(36): TraceOp(
         opid: Opid(36),
-        parent_opid: Some(Opid(18)),
+        parent_opid: Some(Opid(27)),
         content: OutputIteratorExhausted,
       ),
       Opid(37): TraceOp(
         opid: Opid(37),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(38): TraceOp(
-        opid: Opid(38),
-        parent_opid: Some(Opid(15)),
+        parent_opid: Some(Opid(19)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
-      Opid(39): TraceOp(
-        opid: Opid(39),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(40): TraceOp(
-        opid: Opid(40),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(41): TraceOp(
-        opid: Opid(41),
-        parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
-          2,
-        ])))),
-      ),
-      Opid(42): TraceOp(
-        opid: Opid(42),
-        parent_opid: Some(Opid(5)),
+      Opid(38): TraceOp(
+        opid: Opid(38),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -520,9 +390,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(43): TraceOp(
-        opid: Opid(43),
-        parent_opid: Some(Opid(5)),
+      Opid(39): TraceOp(
+        opid: Opid(39),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -537,14 +407,54 @@ TestInterpreterOutputTrace(
           },
         ), Int64(8))),
       ),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(8, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(8, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
       Opid(44): TraceOp(
         opid: Opid(44),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(43)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+          2,
+        ])))),
       ),
       Opid(45): TraceOp(
         opid: Opid(45),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -561,7 +471,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(46): TraceOp(
         opid: Opid(46),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -578,19 +488,19 @@ TestInterpreterOutputTrace(
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(48): TraceOp(
         opid: Opid(48),
-        parent_opid: Some(Opid(40)),
+        parent_opid: Some(Opid(43)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
       Opid(49): TraceOp(
         opid: Opid(49),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -607,7 +517,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(50): TraceOp(
         opid: Opid(50),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -624,139 +534,29 @@ TestInterpreterOutputTrace(
       ),
       Opid(51): TraceOp(
         opid: Opid(51),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(52): TraceOp(
         opid: Opid(52),
-        parent_opid: Some(Opid(40)),
+        parent_opid: Some(Opid(43)),
         content: OutputIteratorExhausted,
       ),
       Opid(53): TraceOp(
         opid: Opid(53),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(19)),
+        content: OutputIteratorExhausted,
       ),
       Opid(54): TraceOp(
         opid: Opid(54),
-        parent_opid: Some(Opid(15)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(55): TraceOp(
-        opid: Opid(55),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(56): TraceOp(
-        opid: Opid(56),
-        parent_opid: Some(Opid(12)),
+        parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
-      Opid(57): TraceOp(
-        opid: Opid(57),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(58): TraceOp(
-        opid: Opid(58),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(59): TraceOp(
-        opid: Opid(59),
-        parent_opid: Some(Opid(58)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
-          2,
-        ])))),
-      ),
-      Opid(60): TraceOp(
-        opid: Opid(60),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(8, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(61): TraceOp(
-        opid: Opid(61),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(8, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(62): TraceOp(
-        opid: Opid(62),
-        parent_opid: Some(Opid(61)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
-          2,
-        ])))),
-      ),
-      Opid(63): TraceOp(
-        opid: Opid(63),
-        parent_opid: Some(Opid(5)),
+      Opid(55): TraceOp(
+        opid: Opid(55),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -771,9 +571,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(64): TraceOp(
-        opid: Opid(64),
-        parent_opid: Some(Opid(5)),
+      Opid(56): TraceOp(
+        opid: Opid(56),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -788,14 +588,54 @@ TestInterpreterOutputTrace(
           },
         ), Int64(8))),
       ),
-      Opid(65): TraceOp(
-        opid: Opid(65),
-        parent_opid: Some(Opid(5)),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(66): TraceOp(
-        opid: Opid(66),
-        parent_opid: Some(Opid(5)),
+      Opid(58): TraceOp(
+        opid: Opid(58),
+        parent_opid: Some(Opid(16)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(59): TraceOp(
+        opid: Opid(59),
+        parent_opid: Some(Opid(16)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(8, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(60): TraceOp(
+        opid: Opid(60),
+        parent_opid: Some(Opid(16)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(8, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(60)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+          2,
+        ])))),
+      ),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -805,6 +645,47 @@ TestInterpreterOutputTrace(
               2,
             ]))),
             Vid(2): Some(Composite(CompositeNumber(8, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(63): TraceOp(
+        opid: Opid(63),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(8, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(8, [
+              2,
+            ]))),
+          },
+        ), Int64(8))),
+      ),
+      Opid(64): TraceOp(
+        opid: Opid(64),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(65): TraceOp(
+        opid: Opid(65),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(66): TraceOp(
+        opid: Opid(66),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(8, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
           },
@@ -812,8 +693,8 @@ TestInterpreterOutputTrace(
       ),
       Opid(67): TraceOp(
         opid: Opid(67),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -821,20 +702,19 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
-            Vid(2): Some(Composite(CompositeNumber(8, [
-              2,
-            ]))),
           },
-        ), Int64(8))),
+        ))),
       ),
       Opid(68): TraceOp(
         opid: Opid(68),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(67)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+          2,
+        ])))),
       ),
       Opid(69): TraceOp(
         opid: Opid(69),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -851,7 +731,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(70): TraceOp(
         opid: Opid(70),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -868,19 +748,19 @@ TestInterpreterOutputTrace(
       ),
       Opid(71): TraceOp(
         opid: Opid(71),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(72): TraceOp(
         opid: Opid(72),
-        parent_opid: Some(Opid(61)),
+        parent_opid: Some(Opid(67)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
       Opid(73): TraceOp(
         opid: Opid(73),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -897,7 +777,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(74): TraceOp(
         opid: Opid(74),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -914,64 +794,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(75): TraceOp(
         opid: Opid(75),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(76): TraceOp(
         opid: Opid(76),
-        parent_opid: Some(Opid(61)),
+        parent_opid: Some(Opid(67)),
         content: OutputIteratorExhausted,
       ),
       Opid(77): TraceOp(
         opid: Opid(77),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(78): TraceOp(
-        opid: Opid(78),
-        parent_opid: Some(Opid(58)),
+        parent_opid: Some(Opid(60)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
-      Opid(79): TraceOp(
-        opid: Opid(79),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(80): TraceOp(
-        opid: Opid(80),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(81): TraceOp(
-        opid: Opid(81),
-        parent_opid: Some(Opid(80)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(16, [
-          2,
-        ])))),
-      ),
-      Opid(82): TraceOp(
-        opid: Opid(82),
-        parent_opid: Some(Opid(5)),
+      Opid(78): TraceOp(
+        opid: Opid(78),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -986,9 +826,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(83): TraceOp(
-        opid: Opid(83),
-        parent_opid: Some(Opid(5)),
+      Opid(79): TraceOp(
+        opid: Opid(79),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -1003,14 +843,54 @@ TestInterpreterOutputTrace(
           },
         ), Int64(16))),
       ),
+      Opid(80): TraceOp(
+        opid: Opid(80),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(81): TraceOp(
+        opid: Opid(81),
+        parent_opid: Some(Opid(24)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(82): TraceOp(
+        opid: Opid(82),
+        parent_opid: Some(Opid(24)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(16, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(83): TraceOp(
+        opid: Opid(83),
+        parent_opid: Some(Opid(24)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(16, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
       Opid(84): TraceOp(
         opid: Opid(84),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(83)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(16, [
+          2,
+        ])))),
       ),
       Opid(85): TraceOp(
         opid: Opid(85),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -1027,7 +907,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(86): TraceOp(
         opid: Opid(86),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(16, [
             2,
@@ -1044,19 +924,19 @@ TestInterpreterOutputTrace(
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(88): TraceOp(
         opid: Opid(88),
-        parent_opid: Some(Opid(80)),
+        parent_opid: Some(Opid(83)),
         content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
       Opid(89): TraceOp(
         opid: Opid(89),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(32, [
             2,
@@ -1073,7 +953,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(32, [
             2,
@@ -1090,82 +970,37 @@ TestInterpreterOutputTrace(
       ),
       Opid(91): TraceOp(
         opid: Opid(91),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(92): TraceOp(
         opid: Opid(92),
-        parent_opid: Some(Opid(80)),
+        parent_opid: Some(Opid(83)),
         content: OutputIteratorExhausted,
       ),
       Opid(93): TraceOp(
         opid: Opid(93),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(60)),
+        content: OutputIteratorExhausted,
       ),
       Opid(94): TraceOp(
         opid: Opid(94),
-        parent_opid: Some(Opid(58)),
+        parent_opid: Some(Opid(11)),
         content: OutputIteratorExhausted,
       ),
       Opid(95): TraceOp(
         opid: Opid(95),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(96): TraceOp(
         opid: Opid(96),
-        parent_opid: Some(Opid(12)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(98): TraceOp(
-        opid: Opid(98),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(99): TraceOp(
-        opid: Opid(99),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(100): TraceOp(
-        opid: Opid(100),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(101): TraceOp(
-        opid: Opid(101),
-        parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(102): TraceOp(
-        opid: Opid(102),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(103): TraceOp(
-        opid: Opid(103),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(104): TraceOp(
-        opid: Opid(104),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(105): TraceOp(
-        opid: Opid(105),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(106): TraceOp(
-        opid: Opid(106),
-        parent_opid: Some(Opid(5)),
         content: OutputIteratorExhausted,
       ),
     },

--- a/trustfall_core/src/resources/test_data/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -10,60 +10,30 @@ TestInterpreterOutputTrace(
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
-        parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
-      ),
-      Opid(7): TraceOp(
-        opid: Opid(7),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(8): TraceOp(
-        opid: Opid(8),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(9): TraceOp(
-        opid: Opid(9),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(10): TraceOp(
-        opid: Opid(10),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(11): TraceOp(
-        opid: Opid(11),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(12): TraceOp(
-        opid: Opid(12),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
       ),
-      Opid(13): TraceOp(
-        opid: Opid(13),
+      Opid(7): TraceOp(
+        opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
@@ -72,150 +42,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(14): TraceOp(
-        opid: Opid(14),
+      Opid(8): TraceOp(
+        opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        ))),
-      ),
-      Opid(15): TraceOp(
-        opid: Opid(15),
-        parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
-      ),
-      Opid(16): TraceOp(
-        opid: Opid(16),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(17): TraceOp(
-        opid: Opid(17),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(18): TraceOp(
-        opid: Opid(18),
-        parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
-      ),
-      Opid(19): TraceOp(
-        opid: Opid(19),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(20): TraceOp(
-        opid: Opid(20),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(21): TraceOp(
-        opid: Opid(21),
-        parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(22): TraceOp(
-        opid: Opid(22),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        )),
-      ),
-      Opid(23): TraceOp(
-        opid: Opid(23),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -223,14 +52,49 @@ TestInterpreterOutputTrace(
           },
         ), Int64(0))),
       ),
-      Opid(24): TraceOp(
-        opid: Opid(24),
-        parent_opid: Some(Opid(5)),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(25): TraceOp(
-        opid: Opid(25),
-        parent_opid: Some(Opid(5)),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(13)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -238,9 +102,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(26): TraceOp(
-        opid: Opid(26),
-        parent_opid: Some(Opid(5)),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -248,14 +112,84 @@ TestInterpreterOutputTrace(
           },
         ), Int64(1))),
       ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(21)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ), Int64(2))),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
       Opid(27): TraceOp(
         opid: Opid(27),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(28): TraceOp(
         opid: Opid(28),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -265,22 +199,22 @@ TestInterpreterOutputTrace(
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
-        ), Int64(2))),
+        ))),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(29)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -290,7 +224,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -300,200 +234,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(34): TraceOp(
         opid: Opid(34),
-        parent_opid: Some(Opid(20)),
+        parent_opid: Some(Opid(29)),
         content: OutputIteratorExhausted,
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(21)),
+        content: OutputIteratorExhausted,
       ),
       Opid(36): TraceOp(
         opid: Opid(36),
-        parent_opid: Some(Opid(17)),
+        parent_opid: Some(Opid(13)),
         content: OutputIteratorExhausted,
       ),
       Opid(37): TraceOp(
         opid: Opid(37),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
       ),
       Opid(38): TraceOp(
         opid: Opid(38),
-        parent_opid: Some(Opid(14)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(40): TraceOp(
-        opid: Opid(40),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
-      ),
-      Opid(41): TraceOp(
-        opid: Opid(41),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(42): TraceOp(
-        opid: Opid(42),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        ))),
-      ),
-      Opid(43): TraceOp(
-        opid: Opid(43),
-        parent_opid: Some(Opid(42)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
-      ),
-      Opid(44): TraceOp(
-        opid: Opid(44),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(45): TraceOp(
-        opid: Opid(45),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(46): TraceOp(
-        opid: Opid(46),
-        parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(47): TraceOp(
-        opid: Opid(47),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(48): TraceOp(
-        opid: Opid(48),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(49): TraceOp(
-        opid: Opid(49),
-        parent_opid: Some(Opid(48)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(50): TraceOp(
-        opid: Opid(50),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(51): TraceOp(
-        opid: Opid(51),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -501,14 +277,44 @@ TestInterpreterOutputTrace(
           },
         ), Int64(1))),
       ),
-      Opid(52): TraceOp(
-        opid: Opid(52),
-        parent_opid: Some(Opid(5)),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(53): TraceOp(
-        opid: Opid(53),
-        parent_opid: Some(Opid(5)),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(44): TraceOp(
+        opid: Opid(44),
+        parent_opid: Some(Opid(43)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(45): TraceOp(
+        opid: Opid(45),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -516,9 +322,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(54): TraceOp(
-        opid: Opid(54),
-        parent_opid: Some(Opid(5)),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -526,14 +332,74 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
+      Opid(47): TraceOp(
+        opid: Opid(47),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(48): TraceOp(
+        opid: Opid(48),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(49): TraceOp(
+        opid: Opid(49),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(50): TraceOp(
+        opid: Opid(50),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(51): TraceOp(
+        opid: Opid(51),
+        parent_opid: Some(Opid(50)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(52): TraceOp(
+        opid: Opid(52),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(53): TraceOp(
+        opid: Opid(53),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ), Int64(3))),
+      ),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(55): TraceOp(
         opid: Opid(55),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(56): TraceOp(
         opid: Opid(56),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -543,22 +409,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
-        ), Int64(3))),
+        ))),
       ),
       Opid(58): TraceOp(
         opid: Opid(58),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(57)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
       ),
       Opid(59): TraceOp(
         opid: Opid(59),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -570,7 +438,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(60): TraceOp(
         opid: Opid(60),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -582,204 +450,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(61): TraceOp(
         opid: Opid(61),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(62): TraceOp(
         opid: Opid(62),
-        parent_opid: Some(Opid(48)),
+        parent_opid: Some(Opid(57)),
         content: OutputIteratorExhausted,
       ),
       Opid(63): TraceOp(
         opid: Opid(63),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(50)),
+        content: OutputIteratorExhausted,
       ),
       Opid(64): TraceOp(
         opid: Opid(64),
-        parent_opid: Some(Opid(45)),
+        parent_opid: Some(Opid(43)),
         content: OutputIteratorExhausted,
       ),
       Opid(65): TraceOp(
         opid: Opid(65),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
       ),
       Opid(66): TraceOp(
         opid: Opid(66),
-        parent_opid: Some(Opid(42)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
       ),
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(68): TraceOp(
-        opid: Opid(68),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
-      ),
-      Opid(69): TraceOp(
-        opid: Opid(69),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(70): TraceOp(
-        opid: Opid(70),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        ))),
-      ),
-      Opid(71): TraceOp(
-        opid: Opid(71),
-        parent_opid: Some(Opid(70)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(72): TraceOp(
-        opid: Opid(72),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(73): TraceOp(
-        opid: Opid(73),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(74): TraceOp(
-        opid: Opid(74),
-        parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(75): TraceOp(
-        opid: Opid(75),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(76): TraceOp(
-        opid: Opid(76),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(77): TraceOp(
-        opid: Opid(77),
-        parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(78): TraceOp(
-        opid: Opid(78),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(79): TraceOp(
-        opid: Opid(79),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -787,14 +493,44 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(80): TraceOp(
-        opid: Opid(80),
-        parent_opid: Some(Opid(5)),
+      Opid(68): TraceOp(
+        opid: Opid(68),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(81): TraceOp(
-        opid: Opid(81),
-        parent_opid: Some(Opid(5)),
+      Opid(69): TraceOp(
+        opid: Opid(69),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(70): TraceOp(
+        opid: Opid(70),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(71): TraceOp(
+        opid: Opid(71),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(72): TraceOp(
+        opid: Opid(72),
+        parent_opid: Some(Opid(71)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -802,9 +538,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(82): TraceOp(
-        opid: Opid(82),
-        parent_opid: Some(Opid(5)),
+      Opid(74): TraceOp(
+        opid: Opid(74),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -812,14 +548,80 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
+      Opid(75): TraceOp(
+        opid: Opid(75),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(76): TraceOp(
+        opid: Opid(76),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(77): TraceOp(
+        opid: Opid(77),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(78): TraceOp(
+        opid: Opid(78),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(79): TraceOp(
+        opid: Opid(79),
+        parent_opid: Some(Opid(78)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(80): TraceOp(
+        opid: Opid(80),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(81): TraceOp(
+        opid: Opid(81),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(82): TraceOp(
+        opid: Opid(82),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(83): TraceOp(
         opid: Opid(83),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -831,24 +633,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(85): TraceOp(
         opid: Opid(85),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
-        ), Int64(4))),
+        ))),
       ),
       Opid(86): TraceOp(
         opid: Opid(86),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(85)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -858,7 +660,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(88): TraceOp(
         opid: Opid(88),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -868,211 +670,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(89): TraceOp(
         opid: Opid(89),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
-        parent_opid: Some(Opid(76)),
+        parent_opid: Some(Opid(85)),
         content: OutputIteratorExhausted,
       ),
       Opid(91): TraceOp(
         opid: Opid(91),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(78)),
+        content: OutputIteratorExhausted,
       ),
       Opid(92): TraceOp(
         opid: Opid(92),
-        parent_opid: Some(Opid(73)),
+        parent_opid: Some(Opid(71)),
         content: OutputIteratorExhausted,
       ),
       Opid(93): TraceOp(
         opid: Opid(93),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
       ),
       Opid(94): TraceOp(
         opid: Opid(94),
-        parent_opid: Some(Opid(70)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
       ),
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(96): TraceOp(
-        opid: Opid(96),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
-      ),
-      Opid(97): TraceOp(
-        opid: Opid(97),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(98): TraceOp(
-        opid: Opid(98),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        ))),
-      ),
-      Opid(99): TraceOp(
-        opid: Opid(99),
-        parent_opid: Some(Opid(98)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(100): TraceOp(
-        opid: Opid(100),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(101): TraceOp(
-        opid: Opid(101),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(102): TraceOp(
-        opid: Opid(102),
-        parent_opid: Some(Opid(101)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(103): TraceOp(
-        opid: Opid(103),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(104): TraceOp(
-        opid: Opid(104),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(105): TraceOp(
-        opid: Opid(105),
-        parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(106): TraceOp(
-        opid: Opid(106),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(107): TraceOp(
-        opid: Opid(107),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1080,14 +713,46 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(108): TraceOp(
-        opid: Opid(108),
-        parent_opid: Some(Opid(5)),
+      Opid(96): TraceOp(
+        opid: Opid(96),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(109): TraceOp(
-        opid: Opid(109),
-        parent_opid: Some(Opid(5)),
+      Opid(97): TraceOp(
+        opid: Opid(97),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(98): TraceOp(
+        opid: Opid(98),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(99): TraceOp(
+        opid: Opid(99),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(100): TraceOp(
+        opid: Opid(100),
+        parent_opid: Some(Opid(99)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(101): TraceOp(
+        opid: Opid(101),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1097,9 +762,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(110): TraceOp(
-        opid: Opid(110),
-        parent_opid: Some(Opid(5)),
+      Opid(102): TraceOp(
+        opid: Opid(102),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1109,14 +774,78 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
+      Opid(103): TraceOp(
+        opid: Opid(103),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(104): TraceOp(
+        opid: Opid(104),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(105): TraceOp(
+        opid: Opid(105),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(106): TraceOp(
+        opid: Opid(106),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(107): TraceOp(
+        opid: Opid(107),
+        parent_opid: Some(Opid(106)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(108): TraceOp(
+        opid: Opid(108),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(109): TraceOp(
+        opid: Opid(109),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ), Int64(5))),
+      ),
+      Opid(110): TraceOp(
+        opid: Opid(110),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(111): TraceOp(
         opid: Opid(111),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(112): TraceOp(
         opid: Opid(112),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1126,22 +855,25 @@ TestInterpreterOutputTrace(
       ),
       Opid(113): TraceOp(
         opid: Opid(113),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
-        ), Int64(5))),
+        ))),
       ),
       Opid(114): TraceOp(
         opid: Opid(114),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(113)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
       ),
       Opid(115): TraceOp(
         opid: Opid(115),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1154,7 +886,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(116): TraceOp(
         opid: Opid(116),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1167,7 +899,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(117): TraceOp(
         opid: Opid(117),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1184,7 +916,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(118): TraceOp(
         opid: Opid(118),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1201,53 +933,38 @@ TestInterpreterOutputTrace(
       ),
       Opid(119): TraceOp(
         opid: Opid(119),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(120): TraceOp(
         opid: Opid(120),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
-        parent_opid: Some(Opid(104)),
+        parent_opid: Some(Opid(113)),
         content: OutputIteratorExhausted,
       ),
       Opid(122): TraceOp(
         opid: Opid(122),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(106)),
+        content: OutputIteratorExhausted,
       ),
       Opid(123): TraceOp(
         opid: Opid(123),
-        parent_opid: Some(Opid(101)),
+        parent_opid: Some(Opid(99)),
         content: OutputIteratorExhausted,
       ),
       Opid(124): TraceOp(
         opid: Opid(124),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(125): TraceOp(
-        opid: Opid(125),
-        parent_opid: Some(Opid(98)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(126): TraceOp(
-        opid: Opid(126),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(127): TraceOp(
-        opid: Opid(127),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(128): TraceOp(
-        opid: Opid(128),
+      Opid(125): TraceOp(
+        opid: Opid(125),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
@@ -1260,195 +977,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(129): TraceOp(
-        opid: Opid(129),
+      Opid(126): TraceOp(
+        opid: Opid(126),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(130): TraceOp(
-        opid: Opid(130),
-        parent_opid: Some(Opid(129)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(131): TraceOp(
-        opid: Opid(131),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(132): TraceOp(
-        opid: Opid(132),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(133): TraceOp(
-        opid: Opid(133),
-        parent_opid: Some(Opid(132)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(134): TraceOp(
-        opid: Opid(134),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(135): TraceOp(
-        opid: Opid(135),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(136): TraceOp(
-        opid: Opid(136),
-        parent_opid: Some(Opid(135)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(137): TraceOp(
-        opid: Opid(137),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(138): TraceOp(
-        opid: Opid(138),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1460,14 +991,52 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(139): TraceOp(
-        opid: Opid(139),
-        parent_opid: Some(Opid(5)),
+      Opid(127): TraceOp(
+        opid: Opid(127),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(140): TraceOp(
-        opid: Opid(140),
-        parent_opid: Some(Opid(5)),
+      Opid(128): TraceOp(
+        opid: Opid(128),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(129): TraceOp(
+        opid: Opid(129),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(130): TraceOp(
+        opid: Opid(130),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(131): TraceOp(
+        opid: Opid(131),
+        parent_opid: Some(Opid(130)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(132): TraceOp(
+        opid: Opid(132),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1477,9 +1046,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(141): TraceOp(
-        opid: Opid(141),
-        parent_opid: Some(Opid(5)),
+      Opid(133): TraceOp(
+        opid: Opid(133),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1489,44 +1058,134 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
+      Opid(134): TraceOp(
+        opid: Opid(134),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(135): TraceOp(
+        opid: Opid(135),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(136): TraceOp(
+        opid: Opid(136),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(137): TraceOp(
+        opid: Opid(137),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(138): TraceOp(
+        opid: Opid(138),
+        parent_opid: Some(Opid(137)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(139): TraceOp(
+        opid: Opid(139),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(140): TraceOp(
+        opid: Opid(140),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(6))),
+      ),
+      Opid(141): TraceOp(
+        opid: Opid(141),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        )),
+      ),
       Opid(142): TraceOp(
         opid: Opid(142),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        ), Int64(6))),
       ),
       Opid(143): TraceOp(
         opid: Opid(143),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(144): TraceOp(
         opid: Opid(144),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ), Int64(6))),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(145): TraceOp(
         opid: Opid(145),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(26)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(146): TraceOp(
+        opid: Opid(146),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1536,17 +1195,13 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
-            Vid(2): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
           },
         )),
       ),
-      Opid(146): TraceOp(
-        opid: Opid(146),
-        parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+      Opid(147): TraceOp(
+        opid: Opid(147),
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1555,26 +1210,17 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
-            Vid(2): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
           },
-        ), Int64(6))),
-      ),
-      Opid(147): TraceOp(
-        opid: Opid(147),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
+        ))),
       ),
       Opid(148): TraceOp(
         opid: Opid(148),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(147)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(149): TraceOp(
         opid: Opid(149),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1586,7 +1232,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(150): TraceOp(
         opid: Opid(150),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1598,215 +1244,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(151): TraceOp(
         opid: Opid(151),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(152): TraceOp(
         opid: Opid(152),
-        parent_opid: Some(Opid(135)),
+        parent_opid: Some(Opid(147)),
         content: OutputIteratorExhausted,
       ),
       Opid(153): TraceOp(
         opid: Opid(153),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(137)),
+        content: OutputIteratorExhausted,
       ),
       Opid(154): TraceOp(
         opid: Opid(154),
-        parent_opid: Some(Opid(132)),
+        parent_opid: Some(Opid(130)),
         content: OutputIteratorExhausted,
       ),
       Opid(155): TraceOp(
         opid: Opid(155),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
       ),
       Opid(156): TraceOp(
         opid: Opid(156),
-        parent_opid: Some(Opid(129)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
       ),
       Opid(157): TraceOp(
         opid: Opid(157),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(158): TraceOp(
-        opid: Opid(158),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
-      ),
-      Opid(159): TraceOp(
-        opid: Opid(159),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        )),
-      ),
-      Opid(160): TraceOp(
-        opid: Opid(160),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        ))),
-      ),
-      Opid(161): TraceOp(
-        opid: Opid(161),
-        parent_opid: Some(Opid(160)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(162): TraceOp(
-        opid: Opid(162),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(163): TraceOp(
-        opid: Opid(163),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(164): TraceOp(
-        opid: Opid(164),
-        parent_opid: Some(Opid(163)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(165): TraceOp(
-        opid: Opid(165),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(6, [
-                  2,
-                  3,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(5))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(5))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(166): TraceOp(
-        opid: Opid(166),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(6, [
-                  2,
-                  3,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(5))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(5))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(167): TraceOp(
-        opid: Opid(167),
-        parent_opid: Some(Opid(166)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
-          2,
-        ])))),
-      ),
-      Opid(168): TraceOp(
-        opid: Opid(168),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        )),
-      ),
-      Opid(169): TraceOp(
-        opid: Opid(169),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1814,14 +1287,47 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(170): TraceOp(
-        opid: Opid(170),
-        parent_opid: Some(Opid(5)),
+      Opid(158): TraceOp(
+        opid: Opid(158),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(171): TraceOp(
-        opid: Opid(171),
-        parent_opid: Some(Opid(5)),
+      Opid(159): TraceOp(
+        opid: Opid(159),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(160): TraceOp(
+        opid: Opid(160),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(161): TraceOp(
+        opid: Opid(161),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
+      ),
+      Opid(162): TraceOp(
+        opid: Opid(162),
+        parent_opid: Some(Opid(161)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(163): TraceOp(
+        opid: Opid(163),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1832,9 +1338,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(172): TraceOp(
-        opid: Opid(172),
-        parent_opid: Some(Opid(5)),
+      Opid(164): TraceOp(
+        opid: Opid(164),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1845,9 +1351,9 @@ TestInterpreterOutputTrace(
           },
         ), Int64(6))),
       ),
-      Opid(173): TraceOp(
-        opid: Opid(173),
-        parent_opid: Some(Opid(6)),
+      Opid(165): TraceOp(
+        opid: Opid(165),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1859,39 +1365,105 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+        )),
+      ),
+      Opid(166): TraceOp(
+        opid: Opid(166),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        ), Int64(6))),
+      ),
+      Opid(167): TraceOp(
+        opid: Opid(167),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(168): TraceOp(
+        opid: Opid(168),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(169): TraceOp(
+        opid: Opid(169),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(170): TraceOp(
+        opid: Opid(170),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(171): TraceOp(
+        opid: Opid(171),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
+      ),
+      Opid(172): TraceOp(
+        opid: Opid(172),
+        parent_opid: Some(Opid(171)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+      ),
+      Opid(173): TraceOp(
+        opid: Opid(173),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(7))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
       ),
       Opid(174): TraceOp(
         opid: Opid(174),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
+          current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
-            Vid(2): Some(Composite(CompositeNumber(6, [
-              2,
-              3,
-            ]))),
           },
-        ), Int64(6))),
+        ), Int64(7))),
       ),
       Opid(175): TraceOp(
         opid: Opid(175),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(176): TraceOp(
         opid: Opid(176),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(177): TraceOp(
         opid: Opid(177),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1901,22 +1473,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(178): TraceOp(
         opid: Opid(178),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
-        ), Int64(7))),
+        ))),
       ),
       Opid(179): TraceOp(
         opid: Opid(179),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(178)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+          2,
+        ])))),
       ),
       Opid(180): TraceOp(
         opid: Opid(180),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -1928,7 +1502,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(181): TraceOp(
         opid: Opid(181),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -1940,92 +1514,47 @@ TestInterpreterOutputTrace(
       ),
       Opid(182): TraceOp(
         opid: Opid(182),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(183): TraceOp(
         opid: Opid(183),
-        parent_opid: Some(Opid(166)),
+        parent_opid: Some(Opid(178)),
         content: OutputIteratorExhausted,
       ),
       Opid(184): TraceOp(
         opid: Opid(184),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(171)),
+        content: OutputIteratorExhausted,
       ),
       Opid(185): TraceOp(
         opid: Opid(185),
-        parent_opid: Some(Opid(163)),
+        parent_opid: Some(Opid(161)),
         content: OutputIteratorExhausted,
       ),
       Opid(186): TraceOp(
         opid: Opid(186),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(187): TraceOp(
         opid: Opid(187),
-        parent_opid: Some(Opid(160)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
       ),
       Opid(188): TraceOp(
         opid: Opid(188),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: OutputIteratorExhausted,
       ),
       Opid(189): TraceOp(
         opid: Opid(189),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
       ),
       Opid(190): TraceOp(
         opid: Opid(190),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(191): TraceOp(
-        opid: Opid(191),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(192): TraceOp(
-        opid: Opid(192),
         parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(193): TraceOp(
-        opid: Opid(193),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(194): TraceOp(
-        opid: Opid(194),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(195): TraceOp(
-        opid: Opid(195),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(196): TraceOp(
-        opid: Opid(196),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(197): TraceOp(
-        opid: Opid(197),
-        parent_opid: Some(Opid(5)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(198): TraceOp(
-        opid: Opid(198),
-        parent_opid: Some(Opid(6)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(199): TraceOp(
-        opid: Opid(199),
-        parent_opid: Some(Opid(6)),
         content: OutputIteratorExhausted,
       ),
     },

--- a/trustfall_core/src/resources/test_data/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -10,60 +10,30 @@ TestInterpreterOutputTrace(
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ProjectProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
-        parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
-        parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
-      ),
-      Opid(7): TraceOp(
-        opid: Opid(7),
-        parent_opid: Some(Opid(6)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(8): TraceOp(
-        opid: Opid(8),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(9): TraceOp(
-        opid: Opid(9),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(10): TraceOp(
-        opid: Opid(10),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(11): TraceOp(
-        opid: Opid(11),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(12): TraceOp(
-        opid: Opid(12),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
       ),
-      Opid(13): TraceOp(
-        opid: Opid(13),
+      Opid(7): TraceOp(
+        opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
@@ -72,150 +42,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(14): TraceOp(
-        opid: Opid(14),
+      Opid(8): TraceOp(
+        opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        ))),
-      ),
-      Opid(15): TraceOp(
-        opid: Opid(15),
-        parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
-      ),
-      Opid(16): TraceOp(
-        opid: Opid(16),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(17): TraceOp(
-        opid: Opid(17),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(0))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(18): TraceOp(
-        opid: Opid(18),
-        parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
-      ),
-      Opid(19): TraceOp(
-        opid: Opid(19),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(20): TraceOp(
-        opid: Opid(20),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(0))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(0))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(0))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(21): TraceOp(
-        opid: Opid(21),
-        parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(22): TraceOp(
-        opid: Opid(22),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(0))),
-          },
-        )),
-      ),
-      Opid(23): TraceOp(
-        opid: Opid(23),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
@@ -223,14 +52,49 @@ TestInterpreterOutputTrace(
           },
         ), Int64(0))),
       ),
-      Opid(24): TraceOp(
-        opid: Opid(24),
-        parent_opid: Some(Opid(5)),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(25): TraceOp(
-        opid: Opid(25),
-        parent_opid: Some(Opid(5)),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(0))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(13)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -238,9 +102,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(26): TraceOp(
-        opid: Opid(26),
-        parent_opid: Some(Opid(5)),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -248,14 +112,84 @@ TestInterpreterOutputTrace(
           },
         ), Int64(1))),
       ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(21)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ), Int64(2))),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+      ),
       Opid(27): TraceOp(
         opid: Opid(27),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(28): TraceOp(
         opid: Opid(28),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -265,22 +199,22 @@ TestInterpreterOutputTrace(
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
-        ), Int64(2))),
+        ))),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(29)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -290,7 +224,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -300,200 +234,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(34): TraceOp(
         opid: Opid(34),
-        parent_opid: Some(Opid(20)),
+        parent_opid: Some(Opid(29)),
         content: OutputIteratorExhausted,
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(21)),
+        content: OutputIteratorExhausted,
       ),
       Opid(36): TraceOp(
         opid: Opid(36),
-        parent_opid: Some(Opid(17)),
+        parent_opid: Some(Opid(13)),
         content: OutputIteratorExhausted,
       ),
       Opid(37): TraceOp(
         opid: Opid(37),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
       ),
       Opid(38): TraceOp(
         opid: Opid(38),
-        parent_opid: Some(Opid(14)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(40): TraceOp(
-        opid: Opid(40),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
-      ),
-      Opid(41): TraceOp(
-        opid: Opid(41),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(42): TraceOp(
-        opid: Opid(42),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        ))),
-      ),
-      Opid(43): TraceOp(
-        opid: Opid(43),
-        parent_opid: Some(Opid(42)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
-      ),
-      Opid(44): TraceOp(
-        opid: Opid(44),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(45): TraceOp(
-        opid: Opid(45),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Neither(NeitherNumber(1))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(46): TraceOp(
-        opid: Opid(46),
-        parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(47): TraceOp(
-        opid: Opid(47),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(48): TraceOp(
-        opid: Opid(48),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Neither(NeitherNumber(1))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Neither(NeitherNumber(1))),
-                  },
-                  suspended_tokens: [
-                    Some(Neither(NeitherNumber(1))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(49): TraceOp(
-        opid: Opid(49),
-        parent_opid: Some(Opid(48)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(50): TraceOp(
-        opid: Opid(50),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
-          tokens: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(51): TraceOp(
-        opid: Opid(51),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
@@ -501,14 +277,44 @@ TestInterpreterOutputTrace(
           },
         ), Int64(1))),
       ),
-      Opid(52): TraceOp(
-        opid: Opid(52),
-        parent_opid: Some(Opid(5)),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(53): TraceOp(
-        opid: Opid(53),
-        parent_opid: Some(Opid(5)),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(44): TraceOp(
+        opid: Opid(44),
+        parent_opid: Some(Opid(43)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(45): TraceOp(
+        opid: Opid(45),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -516,9 +322,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(54): TraceOp(
-        opid: Opid(54),
-        parent_opid: Some(Opid(5)),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -526,14 +332,74 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
+      Opid(47): TraceOp(
+        opid: Opid(47),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(48): TraceOp(
+        opid: Opid(48),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(49): TraceOp(
+        opid: Opid(49),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(50): TraceOp(
+        opid: Opid(50),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(51): TraceOp(
+        opid: Opid(51),
+        parent_opid: Some(Opid(50)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(52): TraceOp(
+        opid: Opid(52),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(53): TraceOp(
+        opid: Opid(53),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ), Int64(3))),
+      ),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(55): TraceOp(
         opid: Opid(55),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(56): TraceOp(
         opid: Opid(56),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -543,22 +409,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
-        ), Int64(3))),
+        ))),
       ),
       Opid(58): TraceOp(
         opid: Opid(58),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(57)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
       ),
       Opid(59): TraceOp(
         opid: Opid(59),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -570,7 +438,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(60): TraceOp(
         opid: Opid(60),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -582,204 +450,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(61): TraceOp(
         opid: Opid(61),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(62): TraceOp(
         opid: Opid(62),
-        parent_opid: Some(Opid(48)),
+        parent_opid: Some(Opid(57)),
         content: OutputIteratorExhausted,
       ),
       Opid(63): TraceOp(
         opid: Opid(63),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(50)),
+        content: OutputIteratorExhausted,
       ),
       Opid(64): TraceOp(
         opid: Opid(64),
-        parent_opid: Some(Opid(45)),
+        parent_opid: Some(Opid(43)),
         content: OutputIteratorExhausted,
       ),
       Opid(65): TraceOp(
         opid: Opid(65),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
       ),
       Opid(66): TraceOp(
         opid: Opid(66),
-        parent_opid: Some(Opid(42)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
       ),
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(68): TraceOp(
-        opid: Opid(68),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
-      ),
-      Opid(69): TraceOp(
-        opid: Opid(69),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(70): TraceOp(
-        opid: Opid(70),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        ))),
-      ),
-      Opid(71): TraceOp(
-        opid: Opid(71),
-        parent_opid: Some(Opid(70)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
-      ),
-      Opid(72): TraceOp(
-        opid: Opid(72),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(73): TraceOp(
-        opid: Opid(73),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(2))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(74): TraceOp(
-        opid: Opid(74),
-        parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(75): TraceOp(
-        opid: Opid(75),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(76): TraceOp(
-        opid: Opid(76),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(2))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(2))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(2))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(77): TraceOp(
-        opid: Opid(77),
-        parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(78): TraceOp(
-        opid: Opid(78),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(2))),
-          },
-        )),
-      ),
-      Opid(79): TraceOp(
-        opid: Opid(79),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
@@ -787,14 +493,44 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(80): TraceOp(
-        opid: Opid(80),
-        parent_opid: Some(Opid(5)),
+      Opid(68): TraceOp(
+        opid: Opid(68),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(81): TraceOp(
-        opid: Opid(81),
-        parent_opid: Some(Opid(5)),
+      Opid(69): TraceOp(
+        opid: Opid(69),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(70): TraceOp(
+        opid: Opid(70),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(71): TraceOp(
+        opid: Opid(71),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(72): TraceOp(
+        opid: Opid(72),
+        parent_opid: Some(Opid(71)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -802,9 +538,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(82): TraceOp(
-        opid: Opid(82),
-        parent_opid: Some(Opid(5)),
+      Opid(74): TraceOp(
+        opid: Opid(74),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -812,14 +548,80 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
+      Opid(75): TraceOp(
+        opid: Opid(75),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(76): TraceOp(
+        opid: Opid(76),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(77): TraceOp(
+        opid: Opid(77),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(78): TraceOp(
+        opid: Opid(78),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(79): TraceOp(
+        opid: Opid(79),
+        parent_opid: Some(Opid(78)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(80): TraceOp(
+        opid: Opid(80),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(81): TraceOp(
+        opid: Opid(81),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(82): TraceOp(
+        opid: Opid(82),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(83): TraceOp(
         opid: Opid(83),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -831,24 +633,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(85): TraceOp(
         opid: Opid(85),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
-        ), Int64(4))),
+        ))),
       ),
       Opid(86): TraceOp(
         opid: Opid(86),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(85)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -858,7 +660,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(88): TraceOp(
         opid: Opid(88),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -868,211 +670,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(89): TraceOp(
         opid: Opid(89),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
-        parent_opid: Some(Opid(76)),
+        parent_opid: Some(Opid(85)),
         content: OutputIteratorExhausted,
       ),
       Opid(91): TraceOp(
         opid: Opid(91),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(78)),
+        content: OutputIteratorExhausted,
       ),
       Opid(92): TraceOp(
         opid: Opid(92),
-        parent_opid: Some(Opid(73)),
+        parent_opid: Some(Opid(71)),
         content: OutputIteratorExhausted,
       ),
       Opid(93): TraceOp(
         opid: Opid(93),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
       ),
       Opid(94): TraceOp(
         opid: Opid(94),
-        parent_opid: Some(Opid(70)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
       ),
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(96): TraceOp(
-        opid: Opid(96),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
-      ),
-      Opid(97): TraceOp(
-        opid: Opid(97),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(98): TraceOp(
-        opid: Opid(98),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        ))),
-      ),
-      Opid(99): TraceOp(
-        opid: Opid(99),
-        parent_opid: Some(Opid(98)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
-          2,
-        ])))),
-      ),
-      Opid(100): TraceOp(
-        opid: Opid(100),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(101): TraceOp(
-        opid: Opid(101),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(3))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(102): TraceOp(
-        opid: Opid(102),
-        parent_opid: Some(Opid(101)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(103): TraceOp(
-        opid: Opid(103),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(104): TraceOp(
-        opid: Opid(104),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(3))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(3))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(3))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(105): TraceOp(
-        opid: Opid(105),
-        parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(106): TraceOp(
-        opid: Opid(106),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(3))),
-          },
-        )),
-      ),
-      Opid(107): TraceOp(
-        opid: Opid(107),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
@@ -1080,14 +713,46 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(108): TraceOp(
-        opid: Opid(108),
-        parent_opid: Some(Opid(5)),
+      Opid(96): TraceOp(
+        opid: Opid(96),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(109): TraceOp(
-        opid: Opid(109),
-        parent_opid: Some(Opid(5)),
+      Opid(97): TraceOp(
+        opid: Opid(97),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(98): TraceOp(
+        opid: Opid(98),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(99): TraceOp(
+        opid: Opid(99),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(3))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(100): TraceOp(
+        opid: Opid(100),
+        parent_opid: Some(Opid(99)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(101): TraceOp(
+        opid: Opid(101),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1097,9 +762,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(110): TraceOp(
-        opid: Opid(110),
-        parent_opid: Some(Opid(5)),
+      Opid(102): TraceOp(
+        opid: Opid(102),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1109,14 +774,78 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
+      Opid(103): TraceOp(
+        opid: Opid(103),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(104): TraceOp(
+        opid: Opid(104),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(105): TraceOp(
+        opid: Opid(105),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(106): TraceOp(
+        opid: Opid(106),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(107): TraceOp(
+        opid: Opid(107),
+        parent_opid: Some(Opid(106)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(108): TraceOp(
+        opid: Opid(108),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(109): TraceOp(
+        opid: Opid(109),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ), Int64(5))),
+      ),
+      Opid(110): TraceOp(
+        opid: Opid(110),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(111): TraceOp(
         opid: Opid(111),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(112): TraceOp(
         opid: Opid(112),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1126,22 +855,25 @@ TestInterpreterOutputTrace(
       ),
       Opid(113): TraceOp(
         opid: Opid(113),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
-        ), Int64(5))),
+        ))),
       ),
       Opid(114): TraceOp(
         opid: Opid(114),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(113)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
       ),
       Opid(115): TraceOp(
         opid: Opid(115),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1154,7 +886,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(116): TraceOp(
         opid: Opid(116),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1167,48 +899,33 @@ TestInterpreterOutputTrace(
       ),
       Opid(117): TraceOp(
         opid: Opid(117),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(118): TraceOp(
         opid: Opid(118),
-        parent_opid: Some(Opid(104)),
+        parent_opid: Some(Opid(113)),
         content: OutputIteratorExhausted,
       ),
       Opid(119): TraceOp(
         opid: Opid(119),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(106)),
+        content: OutputIteratorExhausted,
       ),
       Opid(120): TraceOp(
         opid: Opid(120),
-        parent_opid: Some(Opid(101)),
+        parent_opid: Some(Opid(99)),
         content: OutputIteratorExhausted,
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(122): TraceOp(
-        opid: Opid(122),
-        parent_opid: Some(Opid(98)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(123): TraceOp(
-        opid: Opid(123),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(124): TraceOp(
-        opid: Opid(124),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(125): TraceOp(
-        opid: Opid(125),
+      Opid(122): TraceOp(
+        opid: Opid(122),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
@@ -1221,195 +938,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(126): TraceOp(
-        opid: Opid(126),
+      Opid(123): TraceOp(
+        opid: Opid(123),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        ))),
-      ),
-      Opid(127): TraceOp(
-        opid: Opid(127),
-        parent_opid: Some(Opid(126)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
-      ),
-      Opid(128): TraceOp(
-        opid: Opid(128),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(129): TraceOp(
-        opid: Opid(129),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(130): TraceOp(
-        opid: Opid(130),
-        parent_opid: Some(Opid(129)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(131): TraceOp(
-        opid: Opid(131),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(132): TraceOp(
-        opid: Opid(132),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Composite(CompositeNumber(4, [
-                  2,
-                ]))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  },
-                  suspended_tokens: [
-                    Some(Composite(CompositeNumber(4, [
-                      2,
-                    ]))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(133): TraceOp(
-        opid: Opid(133),
-        parent_opid: Some(Opid(132)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(134): TraceOp(
-        opid: Opid(134),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
-            2,
-          ]))),
-          tokens: {
-            Vid(1): Some(Composite(CompositeNumber(4, [
-              2,
-            ]))),
-          },
-        )),
-      ),
-      Opid(135): TraceOp(
-        opid: Opid(135),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(4, [
             2,
@@ -1421,14 +952,52 @@ TestInterpreterOutputTrace(
           },
         ), Int64(4))),
       ),
-      Opid(136): TraceOp(
-        opid: Opid(136),
-        parent_opid: Some(Opid(5)),
+      Opid(124): TraceOp(
+        opid: Opid(124),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(137): TraceOp(
-        opid: Opid(137),
-        parent_opid: Some(Opid(5)),
+      Opid(125): TraceOp(
+        opid: Opid(125),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(126): TraceOp(
+        opid: Opid(126),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(127): TraceOp(
+        opid: Opid(127),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(128): TraceOp(
+        opid: Opid(128),
+        parent_opid: Some(Opid(127)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+      ),
+      Opid(129): TraceOp(
+        opid: Opid(129),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1438,9 +1007,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(138): TraceOp(
-        opid: Opid(138),
-        parent_opid: Some(Opid(5)),
+      Opid(130): TraceOp(
+        opid: Opid(130),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1450,14 +1019,91 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
+      Opid(131): TraceOp(
+        opid: Opid(131),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(132): TraceOp(
+        opid: Opid(132),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(133): TraceOp(
+        opid: Opid(133),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(134): TraceOp(
+        opid: Opid(134),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(135): TraceOp(
+        opid: Opid(135),
+        parent_opid: Some(Opid(134)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(136): TraceOp(
+        opid: Opid(136),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(137): TraceOp(
+        opid: Opid(137),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(6))),
+      ),
+      Opid(138): TraceOp(
+        opid: Opid(138),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(139): TraceOp(
         opid: Opid(139),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(140): TraceOp(
         opid: Opid(140),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1472,8 +1118,8 @@ TestInterpreterOutputTrace(
       ),
       Opid(141): TraceOp(
         opid: Opid(141),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1483,16 +1129,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
-        ), Int64(6))),
+        ))),
       ),
       Opid(142): TraceOp(
         opid: Opid(142),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(141)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(143): TraceOp(
         opid: Opid(143),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1504,7 +1150,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(144): TraceOp(
         opid: Opid(144),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1516,215 +1162,42 @@ TestInterpreterOutputTrace(
       ),
       Opid(145): TraceOp(
         opid: Opid(145),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(146): TraceOp(
         opid: Opid(146),
-        parent_opid: Some(Opid(132)),
+        parent_opid: Some(Opid(141)),
         content: OutputIteratorExhausted,
       ),
       Opid(147): TraceOp(
         opid: Opid(147),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(134)),
+        content: OutputIteratorExhausted,
       ),
       Opid(148): TraceOp(
         opid: Opid(148),
-        parent_opid: Some(Opid(129)),
+        parent_opid: Some(Opid(127)),
         content: OutputIteratorExhausted,
       ),
       Opid(149): TraceOp(
         opid: Opid(149),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
       ),
       Opid(150): TraceOp(
         opid: Opid(150),
-        parent_opid: Some(Opid(126)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
       ),
       Opid(151): TraceOp(
         opid: Opid(151),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(152): TraceOp(
-        opid: Opid(152),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
-      ),
-      Opid(153): TraceOp(
-        opid: Opid(153),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        )),
-      ),
-      Opid(154): TraceOp(
-        opid: Opid(154),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        ))),
-      ),
-      Opid(155): TraceOp(
-        opid: Opid(155),
-        parent_opid: Some(Opid(154)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
-          2,
-          3,
-        ])))),
-      ),
-      Opid(156): TraceOp(
-        opid: Opid(156),
-        parent_opid: Some(Opid(3)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-            ),
-          ]),
-        )),
-      ),
-      Opid(157): TraceOp(
-        opid: Opid(157),
-        parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
-            2,
-            3,
-          ]))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Prime(PrimeNumber(5))),
-              ],
-            ),
-          ]),
-        ))),
-      ),
-      Opid(158): TraceOp(
-        opid: Opid(158),
-        parent_opid: Some(Opid(157)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
-      ),
-      Opid(159): TraceOp(
-        opid: Opid(159),
-        parent_opid: Some(Opid(4)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(6, [
-                  2,
-                  3,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(5))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(5))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        )),
-      ),
-      Opid(160): TraceOp(
-        opid: Opid(160),
-        parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-          piggyback: Some([
-            SerializableContext(
-              current_token: None,
-              tokens: {
-                Vid(1): Some(Prime(PrimeNumber(5))),
-              },
-              suspended_tokens: [
-                Some(Composite(CompositeNumber(6, [
-                  2,
-                  3,
-                ]))),
-              ],
-              piggyback: Some([
-                SerializableContext(
-                  current_token: None,
-                  tokens: {
-                    Vid(1): Some(Prime(PrimeNumber(5))),
-                  },
-                  suspended_tokens: [
-                    Some(Prime(PrimeNumber(5))),
-                  ],
-                ),
-              ]),
-            ),
-          ]),
-        ))),
-      ),
-      Opid(161): TraceOp(
-        opid: Opid(161),
-        parent_opid: Some(Opid(160)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
-          2,
-        ])))),
-      ),
-      Opid(162): TraceOp(
-        opid: Opid(162),
-        parent_opid: Some(Opid(5)),
-        content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
-          tokens: {
-            Vid(1): Some(Prime(PrimeNumber(5))),
-          },
-        )),
-      ),
-      Opid(163): TraceOp(
-        opid: Opid(163),
-        parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
@@ -1732,14 +1205,47 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(164): TraceOp(
-        opid: Opid(164),
-        parent_opid: Some(Opid(5)),
+      Opid(152): TraceOp(
+        opid: Opid(152),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(165): TraceOp(
-        opid: Opid(165),
-        parent_opid: Some(Opid(5)),
+      Opid(153): TraceOp(
+        opid: Opid(153),
+        parent_opid: Some(Opid(10)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(154): TraceOp(
+        opid: Opid(154),
+        parent_opid: Some(Opid(10)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(155): TraceOp(
+        opid: Opid(155),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(5))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
+      ),
+      Opid(156): TraceOp(
+        opid: Opid(156),
+        parent_opid: Some(Opid(155)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(157): TraceOp(
+        opid: Opid(157),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1750,9 +1256,9 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(166): TraceOp(
-        opid: Opid(166),
-        parent_opid: Some(Opid(5)),
+      Opid(158): TraceOp(
+        opid: Opid(158),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(6, [
             2,
@@ -1763,14 +1269,80 @@ TestInterpreterOutputTrace(
           },
         ), Int64(6))),
       ),
+      Opid(159): TraceOp(
+        opid: Opid(159),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(160): TraceOp(
+        opid: Opid(160),
+        parent_opid: Some(Opid(18)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(161): TraceOp(
+        opid: Opid(161),
+        parent_opid: Some(Opid(18)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(162): TraceOp(
+        opid: Opid(162),
+        parent_opid: Some(Opid(18)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ))),
+      ),
+      Opid(163): TraceOp(
+        opid: Opid(163),
+        parent_opid: Some(Opid(162)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+      ),
+      Opid(164): TraceOp(
+        opid: Opid(164),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(7))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        )),
+      ),
+      Opid(165): TraceOp(
+        opid: Opid(165),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(7))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+        ), Int64(7))),
+      ),
+      Opid(166): TraceOp(
+        opid: Opid(166),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
       Opid(167): TraceOp(
         opid: Opid(167),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: AdvanceInputIterator,
       ),
       Opid(168): TraceOp(
         opid: Opid(168),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(26)),
         content: YieldInto(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
@@ -1780,22 +1352,24 @@ TestInterpreterOutputTrace(
       ),
       Opid(169): TraceOp(
         opid: Opid(169),
-        parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        parent_opid: Some(Opid(26)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
-        ), Int64(7))),
+        ))),
       ),
       Opid(170): TraceOp(
         opid: Opid(170),
-        parent_opid: Some(Opid(5)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(169)),
+        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+          2,
+        ])))),
       ),
       Opid(171): TraceOp(
         opid: Opid(171),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -1807,7 +1381,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(172): TraceOp(
         opid: Opid(172),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -1819,7 +1393,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(173): TraceOp(
         opid: Opid(173),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -1834,7 +1408,7 @@ TestInterpreterOutputTrace(
       ),
       Opid(174): TraceOp(
         opid: Opid(174),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           current_token: Some(Composite(CompositeNumber(8, [
             2,
@@ -1849,97 +1423,52 @@ TestInterpreterOutputTrace(
       ),
       Opid(175): TraceOp(
         opid: Opid(175),
-        parent_opid: Some(Opid(6)),
+        parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
       Opid(176): TraceOp(
         opid: Opid(176),
-        parent_opid: Some(Opid(5)),
+        parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
       Opid(177): TraceOp(
         opid: Opid(177),
-        parent_opid: Some(Opid(160)),
+        parent_opid: Some(Opid(169)),
         content: OutputIteratorExhausted,
       ),
       Opid(178): TraceOp(
         opid: Opid(178),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(162)),
+        content: OutputIteratorExhausted,
       ),
       Opid(179): TraceOp(
         opid: Opid(179),
-        parent_opid: Some(Opid(157)),
+        parent_opid: Some(Opid(155)),
         content: OutputIteratorExhausted,
       ),
       Opid(180): TraceOp(
         opid: Opid(180),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(181): TraceOp(
         opid: Opid(181),
-        parent_opid: Some(Opid(154)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
       ),
       Opid(182): TraceOp(
         opid: Opid(182),
         parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        content: OutputIteratorExhausted,
       ),
       Opid(183): TraceOp(
         opid: Opid(183),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
       ),
       Opid(184): TraceOp(
         opid: Opid(184),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(185): TraceOp(
-        opid: Opid(185),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(186): TraceOp(
-        opid: Opid(186),
         parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(187): TraceOp(
-        opid: Opid(187),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(188): TraceOp(
-        opid: Opid(188),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(189): TraceOp(
-        opid: Opid(189),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(190): TraceOp(
-        opid: Opid(190),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(191): TraceOp(
-        opid: Opid(191),
-        parent_opid: Some(Opid(5)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(192): TraceOp(
-        opid: Opid(192),
-        parent_opid: Some(Opid(6)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(193): TraceOp(
-        opid: Opid(193),
-        parent_opid: Some(Opid(6)),
         content: OutputIteratorExhausted,
       ),
     },


### PR DESCRIPTION
Implement a new directly-optimal recursion execution algorithm that can support unlimited-depth recursion.

Traces show that the new implementation produces the first result in less than half as many steps on even the shallowest of recursion situations. The more steps previously involved in getting the first result from the recursion, the more significant the improvement will be. 

After this merges, we'll still need to update the front-end to make the `@recurse` depth parameter nullable and plumb that change throughout Trustfall to enable unlimited-depth recursion.
