### PR TITLE
Show human-readable error messages in Playground.

### DIFF
--- a/experiments/browser_based_querying/src/hackernews/Playground.tsx
+++ b/experiments/browser_based_querying/src/hackernews/Playground.tsx
@@ -77,7 +77,7 @@ function PlaygroundNonIdealState(props: { children: React.ReactNode }): JSX.Elem
 }
 
 type QueryMessageEvent = MessageEvent<
-  { state: 'success'; done: boolean; value: object } | { state: 'error'; error: string }
+  { status: 'success'; done: boolean; value: object } | { status: 'error'; error: string }
 >;
 
 export default function HackerNewsPlayground(): JSX.Element {
@@ -151,14 +151,14 @@ export default function HackerNewsPlayground(): JSX.Element {
 
   const handleQueryMessage = useCallback((evt: QueryMessageEvent) => {
     const outcome = evt.data;
-    if (outcome.state === 'error') {
+    if (outcome.status === 'error') {
       debug('received error: ', outcome);
       setHasMore(false);
       setNextResult({
         status: 'error',
         error: `Error:\n${outcome.error}`,
       });
-    } else if (outcome.state === 'success') {
+    } else if (outcome.status === 'success') {
       if (outcome.done) {
         setHasMore(false);
         setNextResult({ status: 'ready', value: null });

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -640,12 +640,24 @@ function dispatch(e: MessageEvent<AdapterMessage>): void {
   }
 
   if (payload.op === 'query') {
-    _resultIter = performQuery(payload.query, payload.args);
+    try {
+      _resultIter = performQuery(payload.query, payload.args);
+    } catch (e) {
+      debug('error running query: ', e);
+      const result = {
+        status: 'error',
+        error: `${e}`,
+      };
+      postMessage(result);
+      debug('result posted');
+      return;
+    }
   }
 
   if (payload.op === 'query' || payload.op === 'next') {
     const rawResult = _resultIter.next();
     const result = {
+      status: 'success',
       done: rawResult.done,
       value: rawResult.value,
     };

--- a/trustfall_wasm/src/lib.rs
+++ b/trustfall_wasm/src/lib.rs
@@ -71,13 +71,13 @@ pub fn execute_query(
     // TODO: add a proper error type
     let args = from_js_args(args)?;
 
-    let query = trustfall_core::frontend::parse(schema, query).map_err(|e| e.to_string())?;
+    let query = trustfall_core::frontend::parse(schema, query).map_err(|e| format!("{e}"))?;
 
     let wrapped_adapter = Rc::new(RefCell::new(AdapterShim::new(adapter)));
 
     let results_iter =
         trustfall_core::interpreter::execution::interpret_ir(wrapped_adapter, query, args)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| format!("{e}"))?;
 
     Ok(QueryResultIterator::new(results_iter))
 }


### PR DESCRIPTION
Use the Display-provided string representation of query erorrs, instead of just JSON-ifying their data.
