### PR TITLE
Support `@tag` on `@fold @transform` fields.

### DIFF
--- a/trustfall_core/src/frontend/error.rs
+++ b/trustfall_core/src/frontend/error.rs
@@ -43,6 +43,12 @@ pub enum FrontendError {
     #[error("Multiple fields have @tag directives with the same name: {0}")]
     MultipleTagsWithSameName(String),
 
+    #[error(
+        "Tagged fields with an applied @transform must explicitly specify the tag name, like this: \
+        @tag(name: \"some_name\"). Affected field: {0}"
+    )]
+    ExplicitTagNameRequired(String),
+
     #[error("Incompatible types encountered in @filter.")]
     FilterTypeError(#[from] FilterTypeError),
 

--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -1367,26 +1367,19 @@ where
             }
         }
         for tag_directive in &transform_group.tag {
-            let tag_name = tag_directive
-                .name
-                .as_ref()
-                .map(|x| x.as_ref())
-                .unwrap_or_else(|| {
-                    todo!("handle implicit names for the tagged field")
-                    // subfield
-                    //     .alias
-                    //     .as_ref()
-                    //     .map(|x| x.as_ref())
-                    //     .unwrap_or_else(|| subfield.name.as_ref())
-                });
-            let field = FieldRef::FoldSpecificField(fold_specific_field.clone());
+            let tag_name = tag_directive.name.as_ref().map(|x| x.as_ref());
+            if let Some(tag_name) = tag_name {
+                let field = FieldRef::FoldSpecificField(fold_specific_field.clone());
 
-            if let Err(e) =
-                tags.register_tag(tag_name, field, component_path)
-            {
-                errors.push(FrontendError::MultipleTagsWithSameName(
-                    tag_name.to_string(),
-                ));
+                if let Err(e) = tags.register_tag(tag_name, field, component_path) {
+                    errors.push(FrontendError::MultipleTagsWithSameName(
+                        tag_name.to_string(),
+                    ));
+                }
+            } else {
+                errors.push(FrontendError::ExplicitTagNameRequired(
+                    starting_field.name.as_ref().to_owned(),
+                ))
             }
         }
     }

--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -380,7 +380,7 @@ fn make_filter_expr<LeftT: NamedTypedValue>(
                             }
                         };
 
-                        Argument::Tag(defined_tag.field.clone().into())
+                        Argument::Tag(defined_tag.field.clone())
                     }
                 })
             },
@@ -1175,7 +1175,7 @@ where
                 });
 
             for output_directive in &subfield.output {
-                // TODO: handle transformed fields here.
+                // TODO: handle outputs of non-fold-related transformed fields here.
                 let field_ref = FieldRef::ContextField(ContextField {
                     vertex_id: current_vid,
                     field_name: subfield.name.clone(),
@@ -1224,7 +1224,10 @@ where
                     field_type: subfield_raw_type.to_owned(),
                 };
 
-                if let Err(e) = tags.register_tag(tag_name, tag_field, component_path) {
+                // TODO: handle tags on non-fold-related transformed fields here
+                if let Err(e) =
+                    tags.register_tag(tag_name, FieldRef::ContextField(tag_field), component_path)
+                {
                     errors.push(FrontendError::MultipleTagsWithSameName(
                         tag_name.to_string(),
                     ));

--- a/trustfall_core/src/frontend/tags.rs
+++ b/trustfall_core/src/frontend/tags.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::util::ComponentPath;
 use crate::{
-    ir::{ContextField, Vid},
+    ir::{FieldRef, Vid},
     util::{BTreeMapOccupiedError, BTreeMapTryInsertExt},
 };
 
@@ -13,18 +13,18 @@ use crate::{
 pub(super) struct TagHandler<'a> {
     tags: BTreeMap<&'a str, TagEntry<'a>>,
     used_tags: BTreeSet<&'a str>,
-    component_imported_tags: Vec<(Vid, Vec<ContextField>)>,
+    component_imported_tags: Vec<(Vid, Vec<FieldRef>)>,
 }
 
 #[derive(Debug, Clone)]
 pub(super) struct TagEntry<'a> {
     pub(super) name: &'a str,
-    pub(super) field: ContextField,
+    pub(super) field: FieldRef,
     pub(super) path: ComponentPath,
 }
 
 impl<'a> TagEntry<'a> {
-    fn new(name: &'a str, field: ContextField, path: ComponentPath) -> Self {
+    fn new(name: &'a str, field: FieldRef, path: ComponentPath) -> Self {
         Self { name, field, path }
     }
 }
@@ -38,7 +38,7 @@ impl<'a> TagHandler<'a> {
     pub(super) fn register_tag(
         &mut self,
         name: &'a str,
-        field: ContextField,
+        field: FieldRef,
         path: &ComponentPath,
     ) -> Result<(), BTreeMapOccupiedError<'_, &'a str, TagEntry<'a>>> {
         self.tags
@@ -51,7 +51,7 @@ impl<'a> TagHandler<'a> {
         self.component_imported_tags.push((component_root, vec![]));
     }
 
-    pub(super) fn end_subcomponent(&mut self, component_root: Vid) -> Vec<ContextField> {
+    pub(super) fn end_subcomponent(&mut self, component_root: Vid) -> Vec<FieldRef> {
         let (expected_vid, external_tags) = self.component_imported_tags.pop().unwrap();
         assert_eq!(expected_vid, component_root);
         external_tags
@@ -69,27 +69,36 @@ impl<'a> TagHandler<'a> {
             .ok_or_else(|| TagLookupError::UndefinedTag(name.to_string()))?;
 
         if entry.path.is_parent(use_path) {
-            if entry.field.vertex_id <= use_vid {
-                if &entry.path != use_path {
-                    // The tag is used inside a fold and imported from an outer component.
-                    // Mark it as imported at the appropriate level.
-                    let importing_component_root = use_path[entry.path.len()];
-
-                    // The -1 in the index calculation is because the root component
-                    // cannot import tags -- it has no parent component to import from.
-                    let (component_root, imported_tags) = self
-                        .component_imported_tags
-                        .get_mut(entry.path.len() - 1)
-                        .unwrap();
-                    assert_eq!(*component_root, importing_component_root);
-                    imported_tags.push(entry.field.clone());
+            match &entry.field {
+                FieldRef::ContextField(field) => {
+                    if field.vertex_id > use_vid {
+                        return Err(TagLookupError::TagUsedBeforeDefinition(name.to_string()));
+                    }
                 }
-
-                self.used_tags.insert(entry.name);
-                Ok(entry)
-            } else {
-                Err(TagLookupError::TagUsedBeforeDefinition(name.to_string()))
+                FieldRef::FoldSpecificField(field) => {
+                    if field.fold_root_vid > use_vid {
+                        return Err(TagLookupError::TagUsedBeforeDefinition(name.to_string()));
+                    }
+                }
             }
+
+            if &entry.path != use_path {
+                // The tag is used inside a fold and imported from an outer component.
+                // Mark it as imported at the appropriate level.
+                let importing_component_root = use_path[entry.path.len()];
+
+                // The -1 in the index calculation is because the root component
+                // cannot import tags -- it has no parent component to import from.
+                let (component_root, imported_tags) = self
+                    .component_imported_tags
+                    .get_mut(entry.path.len() - 1)
+                    .unwrap();
+                assert_eq!(*component_root, importing_component_root);
+                imported_tags.push(entry.field.clone());
+            }
+
+            self.used_tags.insert(entry.name);
+            Ok(entry)
         } else {
             // The tag is defined in a fold that is either inside of, or parallel to,
             // the component that uses the tag. This is not allowed.

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ir::{
-        indexed::IndexedQuery, types::is_argument_type_valid, EdgeParameters, Eid, FieldValue, Vid,
+        indexed::IndexedQuery, types::is_argument_type_valid, EdgeParameters, Eid, FieldRef,
+        FieldValue, Vid,
     },
     util::BTreeMapTryInsertExt,
 };
@@ -30,7 +31,7 @@ pub struct DataContext<DataToken: Clone + Debug> {
     folded_contexts: BTreeMap<Eid, Vec<DataContext<DataToken>>>,
     folded_values: BTreeMap<(Eid, Arc<str>), ValueOrVec>,
     piggyback: Option<Vec<DataContext<DataToken>>>,
-    imported_tags: BTreeMap<(Vid, Arc<str>), FieldValue>,
+    imported_tags: BTreeMap<FieldRef, FieldValue>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,7 +85,7 @@ where
 
     /// Tagged values imported from an ancestor component of the one currently being evaluated.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    imported_tags: BTreeMap<(Vid, Arc<str>), FieldValue>,
+    imported_tags: BTreeMap<FieldRef, FieldValue>,
 }
 
 impl<DataToken> From<SerializableContext<DataToken>> for DataContext<DataToken>

--- a/trustfall_core/src/resources/test_data/frontend_errors/fold_count_tag_value_used_inside_own_fold.frontend-error.ron
+++ b/trustfall_core/src/resources/test_data/frontend_errors/fold_count_tag_value_used_inside_own_fold.frontend-error.ron
@@ -1,0 +1,1 @@
+Err(UndefinedTagInFilter("value", "tagged_count"))

--- a/trustfall_core/src/resources/test_data/frontend_errors/fold_count_tag_value_used_inside_own_fold.graphql-parsed.ron
+++ b/trustfall_core/src/resources/test_data/frontend_errors/fold_count_tag_value_used_inside_own_fold.graphql-parsed.ron
@@ -29,7 +29,7 @@ Ok(TestParsedGraphQLQuery(
               ),
               tag: [
                 TagDirective(
-                  name: Some("successor_count"),
+                  name: Some("tagged_count"),
                 ),
               ],
             )),
@@ -40,45 +40,22 @@ Ok(TestParsedGraphQLQuery(
             column: 9,
           ),
           name: "successor",
-          transform_group: Some(TransformGroup(
-            transform: TransformDirective(
-              kind: Count,
-            ),
-            tag: [
-              TagDirective(
-                name: Some("successor_count"),
-              ),
-            ],
-          )),
-        )),
-        (FieldConnection(
-          position: Pos(
-            line: 6,
-            column: 9,
-          ),
-          name: "predecessor",
-        ), FieldNode(
-          position: Pos(
-            line: 6,
-            column: 9,
-          ),
-          name: "predecessor",
           connections: [
             (FieldConnection(
               position: Pos(
-                line: 7,
+                line: 5,
                 column: 13,
               ),
               name: "value",
             ), FieldNode(
               position: Pos(
-                line: 7,
+                line: 5,
                 column: 13,
               ),
               name: "value",
               filter: [
                 FilterDirective(
-                  operation: Equals((), TagRef("successor_count")),
+                  operation: Equals((), TagRef("tagged_count")),
                 ),
               ],
               output: [
@@ -86,6 +63,16 @@ Ok(TestParsedGraphQLQuery(
               ],
             )),
           ],
+          transform_group: Some(TransformGroup(
+            transform: TransformDirective(
+              kind: Count,
+            ),
+            tag: [
+              TagDirective(
+                name: Some("tagged_count"),
+              ),
+            ],
+          )),
         )),
       ],
     ),

--- a/trustfall_core/src/resources/test_data/frontend_errors/fold_count_tag_value_used_inside_own_fold.graphql.ron
+++ b/trustfall_core/src/resources/test_data/frontend_errors/fold_count_tag_value_used_inside_own_fold.graphql.ron
@@ -1,0 +1,12 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        successor @fold @transform(op: "count") @tag(name: "tagged_count") {
+            value @filter(op: "=", value: ["%tagged_count"]) @output
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/src/resources/test_data/frontend_errors/implicit_tag_name_on_transformed_value.frontend-error.ron
+++ b/trustfall_core/src/resources/test_data/frontend_errors/implicit_tag_name_on_transformed_value.frontend-error.ron
@@ -1,0 +1,4 @@
+Err(MultipleErrors(DisplayVec([
+  ExplicitTagNameRequired("successor"),
+  UndefinedTagInFilter("value", "successorcount"),
+])))

--- a/trustfall_core/src/resources/test_data/frontend_errors/implicit_tag_name_on_transformed_value.graphql-parsed.ron
+++ b/trustfall_core/src/resources/test_data/frontend_errors/implicit_tag_name_on_transformed_value.graphql-parsed.ron
@@ -1,0 +1,89 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+            transform: Some(TransformGroup(
+              transform: TransformDirective(
+                kind: Count,
+              ),
+              tag: [
+                TagDirective(),
+              ],
+            )),
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          transform_group: Some(TransformGroup(
+            transform: TransformDirective(
+              kind: Count,
+            ),
+            tag: [
+              TagDirective(),
+            ],
+          )),
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "predecessor",
+        ), FieldNode(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "predecessor",
+          connections: [
+            (FieldConnection(
+              position: Pos(
+                line: 7,
+                column: 13,
+              ),
+              name: "value",
+            ), FieldNode(
+              position: Pos(
+                line: 7,
+                column: 13,
+              ),
+              name: "value",
+              filter: [
+                FilterDirective(
+                  operation: Equals((), TagRef("successorcount")),
+                ),
+              ],
+              output: [
+                OutputDirective(),
+              ],
+            )),
+          ],
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/src/resources/test_data/frontend_errors/implicit_tag_name_on_transformed_value.graphql.ron
+++ b/trustfall_core/src/resources/test_data/frontend_errors/implicit_tag_name_on_transformed_value.graphql.ron
@@ -1,0 +1,14 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        successor @fold @transform(op: "count") @tag
+
+        predecessor {
+            value @filter(op: "=", value: ["%successorcount"]) @output
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/coercion_allows_additional_edge.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/coercion_allows_additional_edge.trace.ron
@@ -198,6 +198,22 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -219,6 +235,22 @@ TestInterpreterOutputTrace(
               2,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -430,6 +462,22 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -451,6 +499,22 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -662,6 +726,22 @@ TestInterpreterOutputTrace(
               7,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(7))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(7))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -683,6 +763,22 @@ TestInterpreterOutputTrace(
               2,
               7,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(7))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(7))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -868,6 +964,22 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(3)),
@@ -889,6 +1001,22 @@ TestInterpreterOutputTrace(
               3,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -1035,6 +1163,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -1053,6 +1191,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -1263,6 +1411,22 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -1284,6 +1448,22 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -1495,6 +1675,22 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -1516,6 +1712,22 @@ TestInterpreterOutputTrace(
               2,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/coercion_on_folded_edge.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/coercion_on_folded_edge.trace.ron
@@ -105,6 +105,9 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
+          folded_contexts: {
+            Eid(1): [],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
           },
@@ -117,6 +120,9 @@ TestInterpreterOutputTrace(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+          folded_contexts: {
+            Eid(1): [],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
@@ -237,6 +243,9 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
+          folded_contexts: {
+            Eid(1): [],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
           },
@@ -249,6 +258,9 @@ TestInterpreterOutputTrace(
           current_token: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+          folded_contexts: {
+            Eid(1): [],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
@@ -369,6 +381,9 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
+          folded_contexts: {
+            Eid(1): [],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
           },
@@ -381,6 +396,9 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
@@ -526,6 +544,16 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(2)),
@@ -540,6 +568,16 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -701,6 +739,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(3)),
@@ -719,6 +767,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([
@@ -847,6 +905,9 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
+          folded_contexts: {
+            Eid(1): [],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
           },
@@ -859,6 +920,9 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+          folded_contexts: {
+            Eid(1): [],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([]),
@@ -1025,6 +1089,16 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "prime"): Vec([
               Value(Int64(5)),
@@ -1045,6 +1119,16 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "prime"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/empty_fold_output.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/empty_fold_output.trace.ron
@@ -85,6 +85,9 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
+          folded_contexts: {
+            Eid(1): [],
+          },
           folded_values: {
             (Eid(1), "mult"): Vec([]),
           },
@@ -97,6 +100,9 @@ TestInterpreterOutputTrace(
           current_token: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+          folded_contexts: {
+            Eid(1): [],
           },
           folded_values: {
             (Eid(1), "mult"): Vec([]),

--- a/trustfall_core/src/resources/test_data/valid_queries/execute_fold_before_traverse.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/execute_fold_before_traverse.trace.ron
@@ -218,6 +218,32 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(4)),
@@ -234,6 +260,32 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -258,6 +310,32 @@ TestInterpreterOutputTrace(
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(4): Some(Prime(PrimeNumber(3))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(4)),
@@ -275,6 +353,32 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(4): Some(Prime(PrimeNumber(3))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/filter_in_fold_using_external_tag.ir.ron
@@ -46,11 +46,11 @@ Ok(TestIRQuery(
             },
           ),
           imported_tags: [
-            ContextField(
+            ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "name",
               field_type: "String",
-            ),
+            )),
           ],
         ),
       },

--- a/trustfall_core/src/resources/test_data/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -61,7 +61,11 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -74,7 +78,11 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ))),
       ),
@@ -104,7 +112,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -117,7 +129,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), String("four"))),
       ),
@@ -144,7 +160,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -158,7 +178,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), String("six"))),
       ),
@@ -205,7 +229,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -222,7 +250,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), Int64(4))),
       ),
@@ -246,7 +278,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -265,7 +301,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), Int64(6))),
       ),
@@ -366,11 +406,11 @@ TestInterpreterOutputTrace(
               },
             ),
             imported_tags: [
-              ContextField(
+              ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "name",
                 field_type: "String",
-              ),
+              )),
             ],
           ),
         },

--- a/trustfall_core/src/resources/test_data/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
@@ -73,11 +73,11 @@ Ok(TestIRQuery(
             },
           ),
           imported_tags: [
-            ContextField(
+            ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "name",
               field_type: "String",
-            ),
+            )),
           ],
         ),
       },

--- a/trustfall_core/src/resources/test_data/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -61,7 +61,11 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -74,7 +78,11 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ))),
       ),
@@ -108,7 +116,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -125,7 +137,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ))),
       ),
@@ -155,7 +171,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -168,7 +188,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), String("four"))),
       ),
@@ -193,7 +217,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -206,7 +234,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), String("eight"))),
       ),
@@ -253,7 +285,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -270,7 +306,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), Int64(4))),
       ),
@@ -292,7 +332,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -309,7 +353,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), Int64(8))),
       ),
@@ -377,7 +425,11 @@ TestInterpreterOutputTrace(
             ]),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         )),
       ),
@@ -400,7 +452,11 @@ TestInterpreterOutputTrace(
             ]),
           },
           imported_tags: {
-            (Vid(1), "name"): String("two"),
+            ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "name",
+              field_type: "String",
+            )): String("two"),
           },
         ), Int64(4))),
       ),
@@ -528,11 +584,11 @@ TestInterpreterOutputTrace(
               },
             ),
             imported_tags: [
-              ContextField(
+              ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "name",
                 field_type: "String",
-              ),
+              )),
             ],
           ),
         },

--- a/trustfall_core/src/resources/test_data/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -418,6 +418,44 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+                imported_tags: {
+                  ContextField(ContextField(
+                    vertex_id: Vid(1),
+                    field_name: "name",
+                    field_type: "String",
+                  )): String("two"),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+                imported_tags: {
+                  ContextField(ContextField(
+                    vertex_id: Vid(1),
+                    field_name: "name",
+                    field_type: "String",
+                  )): String("two"),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "second"): Vec([
               Value(Int64(4)),
@@ -444,6 +482,44 @@ TestInterpreterOutputTrace(
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+                imported_tags: {
+                  ContextField(ContextField(
+                    vertex_id: Vid(1),
+                    field_name: "name",
+                    field_type: "String",
+                  )): String("two"),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+                imported_tags: {
+                  ContextField(ContextField(
+                    vertex_id: Vid(1),
+                    field_name: "name",
+                    field_type: "String",
+                  )): String("two"),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "second"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter.trace.ron
@@ -299,6 +299,22 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -320,6 +336,22 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -274,6 +274,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -292,6 +302,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -274,6 +274,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -292,6 +302,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -274,6 +274,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -292,6 +302,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -274,6 +274,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -292,6 +302,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -295,6 +295,22 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(3)),
@@ -319,6 +335,22 @@ TestInterpreterOutputTrace(
               3,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_explicitly_named.graphql.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_explicitly_named.graphql.ron
@@ -1,0 +1,14 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        successor @fold @transform(op: "count") @tag(name: "successor_count")
+
+        predecessor {
+            value @filter(op: "=", value: ["%successor_count"]) @output
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_explicitly_named.ir.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_explicitly_named.ir.ron
@@ -1,0 +1,61 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Two",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Prime",
+        ),
+        Vid(3): IRVertex(
+          vid: Vid(3),
+          type_name: "Number",
+          filters: [
+            Equals(LocalField(
+              field_name: "value",
+              field_type: "Int",
+            ), Tag(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )))),
+          ],
+        ),
+      },
+      edges: {
+        Eid(2): IREdge(
+          eid: Eid(2),
+          from_vid: Vid(1),
+          to_vid: Vid(3),
+          edge_name: "predecessor",
+        ),
+      },
+      folds: {
+        Eid(1): IRFold(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "successor",
+          component: IRQueryComponent(
+            root: Vid(2),
+            vertices: {
+              Vid(2): IRVertex(
+                vid: Vid(2),
+                type_name: "Number",
+              ),
+            },
+          ),
+        ),
+      },
+      outputs: {
+        "value": ContextField(
+          vertex_id: Vid(3),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_explicitly_named.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_explicitly_named.trace.ron
@@ -1,0 +1,347 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(GetStartingTokens(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(2))),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: None,
+        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: None,
+        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(12)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        )),
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        ))),
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(16)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        )),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        ), Int64(1))),
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        )),
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        ), Int64(1))),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(16)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(5)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Two",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Prime",
+          ),
+          Vid(3): IRVertex(
+            vid: Vid(3),
+            type_name: "Number",
+            filters: [
+              Equals(LocalField(
+                field_name: "value",
+                field_type: "Int",
+              ), Tag(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )))),
+            ],
+          ),
+        },
+        edges: {
+          Eid(2): IREdge(
+            eid: Eid(2),
+            from_vid: Vid(1),
+            to_vid: Vid(3),
+            edge_name: "predecessor",
+          ),
+        },
+        folds: {
+          Eid(1): IRFold(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "successor",
+            component: IRQueryComponent(
+              root: Vid(2),
+              vertices: {
+                Vid(2): IRVertex(
+                  vid: Vid(2),
+                  type_name: "Number",
+                ),
+              },
+            ),
+          ),
+        },
+        outputs: {
+          "value": ContextField(
+            vertex_id: Vid(3),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+  results: [
+    {
+      "value": Int64(1),
+    },
+  ],
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.graphql-parsed.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.graphql-parsed.ron
@@ -1,0 +1,99 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+            transform: Some(TransformGroup(
+              transform: TransformDirective(
+                kind: Count,
+              ),
+              tag: [
+                TagDirective(
+                  name: Some("successor_count"),
+                ),
+              ],
+            )),
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          transform_group: Some(TransformGroup(
+            transform: TransformDirective(
+              kind: Count,
+            ),
+            tag: [
+              TagDirective(
+                name: Some("successor_count"),
+              ),
+            ],
+          )),
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "predecessor",
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+            transform: Some(TransformGroup(
+              transform: TransformDirective(
+                kind: Count,
+              ),
+              output: [
+                OutputDirective(),
+              ],
+              filter: [
+                FilterDirective(
+                  operation: Equals((), TagRef("successor_count")),
+                ),
+              ],
+            )),
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "predecessor",
+          transform_group: Some(TransformGroup(
+            transform: TransformDirective(
+              kind: Count,
+            ),
+            output: [
+              OutputDirective(),
+            ],
+            filter: [
+              FilterDirective(
+                operation: Equals((), TagRef("successor_count")),
+              ),
+            ],
+          )),
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.graphql.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.graphql.ron
@@ -1,0 +1,15 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        successor @fold @transform(op: "count") @tag(name: "successor_count")
+
+        predecessor @fold
+                    @transform(op: "count")
+                    @filter(op: "=", value: ["%successor_count"])
+                    @output
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.ir.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.ir.ron
@@ -1,0 +1,57 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Two",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Prime",
+        ),
+      },
+      folds: {
+        Eid(1): IRFold(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "successor",
+          component: IRQueryComponent(
+            root: Vid(2),
+            vertices: {
+              Vid(2): IRVertex(
+                vid: Vid(2),
+                type_name: "Number",
+              ),
+            },
+          ),
+        ),
+        Eid(2): IRFold(
+          eid: Eid(2),
+          from_vid: Vid(1),
+          to_vid: Vid(3),
+          edge_name: "predecessor",
+          component: IRQueryComponent(
+            root: Vid(3),
+            vertices: {
+              Vid(3): IRVertex(
+                vid: Vid(3),
+                type_name: "Number",
+              ),
+            },
+          ),
+          fold_specific_outputs: {
+            "predecessorcount": Count,
+          },
+          post_filters: [
+            Equals(Count, Tag(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )))),
+          ],
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
@@ -1,0 +1,211 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(GetStartingTokens(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(2))),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(8)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(8)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        )),
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+        ))),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(12)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(12)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Two",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Prime",
+          ),
+        },
+        folds: {
+          Eid(1): IRFold(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "successor",
+            component: IRQueryComponent(
+              root: Vid(2),
+              vertices: {
+                Vid(2): IRVertex(
+                  vid: Vid(2),
+                  type_name: "Number",
+                ),
+              },
+            ),
+          ),
+          Eid(2): IRFold(
+            eid: Eid(2),
+            from_vid: Vid(1),
+            to_vid: Vid(3),
+            edge_name: "predecessor",
+            component: IRQueryComponent(
+              root: Vid(3),
+              vertices: {
+                Vid(3): IRVertex(
+                  vid: Vid(3),
+                  type_name: "Number",
+                ),
+              },
+            ),
+            fold_specific_outputs: {
+              "predecessorcount": Count,
+            },
+            post_filters: [
+              Equals(Count, Tag(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )))),
+            ],
+          ),
+        },
+      ),
+    ),
+  ),
+  results: [
+    {
+      "predecessorcount": Uint64(1),
+    },
+  ],
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.graphql-parsed.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.graphql-parsed.ron
@@ -20,6 +20,22 @@ Ok(TestParsedGraphQLQuery(
             line: 4,
             column: 9,
           ),
+          name: "value",
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          output: [
+            OutputDirective(),
+          ],
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
           name: "successor",
           fold: Some(FoldGroup(
             fold: FoldDirective(),
@@ -29,14 +45,14 @@ Ok(TestParsedGraphQLQuery(
               ),
               tag: [
                 TagDirective(
-                  name: Some("successor_count"),
+                  name: Some("tagged_count"),
                 ),
               ],
             )),
           )),
         ), FieldNode(
           position: Pos(
-            line: 4,
+            line: 6,
             column: 9,
           ),
           name: "successor",
@@ -46,43 +62,43 @@ Ok(TestParsedGraphQLQuery(
             ),
             tag: [
               TagDirective(
-                name: Some("successor_count"),
+                name: Some("tagged_count"),
               ),
             ],
           )),
         )),
         (FieldConnection(
           position: Pos(
-            line: 6,
+            line: 8,
             column: 9,
           ),
           name: "predecessor",
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+          )),
         ), FieldNode(
           position: Pos(
-            line: 6,
+            line: 8,
             column: 9,
           ),
           name: "predecessor",
           connections: [
             (FieldConnection(
               position: Pos(
-                line: 7,
+                line: 9,
                 column: 13,
               ),
               name: "value",
             ), FieldNode(
               position: Pos(
-                line: 7,
+                line: 9,
                 column: 13,
               ),
               name: "value",
               filter: [
                 FilterDirective(
-                  operation: Equals((), TagRef("successor_count")),
+                  operation: Equals((), TagRef("tagged_count")),
                 ),
-              ],
-              output: [
-                OutputDirective(),
               ],
             )),
           ],

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.graphql.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.graphql.ron
@@ -1,0 +1,16 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        value @output
+
+        successor @fold @transform(op: "count") @tag(name: "tagged_count")
+
+        predecessor @fold {
+            value @filter(op: "=", value: ["%tagged_count"])
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.ir.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.ir.ron
@@ -1,0 +1,71 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Two",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Prime",
+        ),
+      },
+      folds: {
+        Eid(1): IRFold(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "successor",
+          component: IRQueryComponent(
+            root: Vid(2),
+            vertices: {
+              Vid(2): IRVertex(
+                vid: Vid(2),
+                type_name: "Number",
+              ),
+            },
+          ),
+        ),
+        Eid(2): IRFold(
+          eid: Eid(2),
+          from_vid: Vid(1),
+          to_vid: Vid(3),
+          edge_name: "predecessor",
+          component: IRQueryComponent(
+            root: Vid(3),
+            vertices: {
+              Vid(3): IRVertex(
+                vid: Vid(3),
+                type_name: "Number",
+                filters: [
+                  Equals(LocalField(
+                    field_name: "value",
+                    field_type: "Int",
+                  ), Tag(FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(1),
+                    fold_root_vid: Vid(2),
+                    kind: Count,
+                  )))),
+                ],
+              ),
+            },
+          ),
+          imported_tags: [
+            FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
+          ],
+        ),
+      },
+      outputs: {
+        "value": ContextField(
+          vertex_id: Vid(1),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
@@ -1,0 +1,389 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(GetStartingTokens(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(2))),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: None,
+        content: Call(ProjectProperty(Vid(1), "Prime", "value")),
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(10)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+          imported_tags: {
+            FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )): Uint64(1),
+          },
+        )),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
+          imported_tags: {
+            FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )): Uint64(1),
+          },
+        ))),
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: None,
+        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(15)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(14)),
+        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(15)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {},
+          imported_tags: {
+            FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )): Uint64(1),
+          },
+        )),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(15)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Neither(NeitherNumber(1))),
+          tokens: {},
+          imported_tags: {
+            FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )): Uint64(1),
+          },
+        ), Int64(1))),
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(15)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(14)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(15)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(15)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Neither(NeitherNumber(1))),
+                tokens: {
+                  Vid(3): Some(Neither(NeitherNumber(1))),
+                },
+                imported_tags: {
+                  FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(1),
+                    fold_root_vid: Vid(2),
+                    kind: Count,
+                  )): Uint64(1),
+                },
+              ),
+            ],
+          },
+        )),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ProjectProperty(SerializableContext(
+          current_token: Some(Prime(PrimeNumber(2))),
+          tokens: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Neither(NeitherNumber(1))),
+                tokens: {
+                  Vid(3): Some(Neither(NeitherNumber(1))),
+                },
+                imported_tags: {
+                  FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(1),
+                    fold_root_vid: Vid(2),
+                    kind: Count,
+                  )): Uint64(1),
+                },
+              ),
+            ],
+          },
+        ), Int64(2))),
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Two",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Prime",
+          ),
+        },
+        folds: {
+          Eid(1): IRFold(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "successor",
+            component: IRQueryComponent(
+              root: Vid(2),
+              vertices: {
+                Vid(2): IRVertex(
+                  vid: Vid(2),
+                  type_name: "Number",
+                ),
+              },
+            ),
+          ),
+          Eid(2): IRFold(
+            eid: Eid(2),
+            from_vid: Vid(1),
+            to_vid: Vid(3),
+            edge_name: "predecessor",
+            component: IRQueryComponent(
+              root: Vid(3),
+              vertices: {
+                Vid(3): IRVertex(
+                  vid: Vid(3),
+                  type_name: "Number",
+                  filters: [
+                    Equals(LocalField(
+                      field_name: "value",
+                      field_type: "Int",
+                    ), Tag(FoldSpecificField(FoldSpecificField(
+                      fold_eid: Eid(1),
+                      fold_root_vid: Vid(2),
+                      kind: Count,
+                    )))),
+                  ],
+                ),
+              },
+            ),
+            imported_tags: [
+              FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
+            ],
+          ),
+        },
+        outputs: {
+          "value": ContextField(
+            vertex_id: Vid(1),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+  results: [
+    {
+      "value": Int64(2),
+    },
+  ],
+)

--- a/trustfall_core/src/resources/test_data/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
@@ -63,11 +63,11 @@ Ok(TestIRQuery(
                   },
                 ),
                 imported_tags: [
-                  ContextField(
+                  ContextField(ContextField(
                     vertex_id: Vid(2),
                     field_name: "name",
                     field_type: "String",
-                  ),
+                  )),
                 ],
               ),
             },

--- a/trustfall_core/src/resources/test_data/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -380,6 +380,27 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+                imported_tags: {
+                  ContextField(ContextField(
+                    vertex_id: Vid(2),
+                    field_name: "name",
+                    field_type: "String",
+                  )): String("four"),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "second"): Vec([
               Value(Int64(8)),
@@ -398,6 +419,27 @@ TestInterpreterOutputTrace(
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+                imported_tags: {
+                  ContextField(ContextField(
+                    vertex_id: Vid(2),
+                    field_name: "name",
+                    field_type: "String",
+                  )): String("four"),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "second"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -110,7 +110,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         )),
       ),
@@ -127,7 +131,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         ))),
       ),
@@ -157,7 +165,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         )),
       ),
@@ -170,7 +182,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         ), String("four"))),
       ),
@@ -195,7 +211,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         )),
       ),
@@ -208,7 +228,11 @@ TestInterpreterOutputTrace(
           ]))),
           tokens: {},
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         ), String("eight"))),
       ),
@@ -255,7 +279,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         )),
       ),
@@ -272,7 +300,11 @@ TestInterpreterOutputTrace(
             ]))),
           },
           imported_tags: {
-            (Vid(2), "name"): String("four"),
+            ContextField(ContextField(
+              vertex_id: Vid(2),
+              field_name: "name",
+              field_type: "String",
+            )): String("four"),
           },
         ), Int64(8))),
       ),
@@ -473,11 +505,11 @@ TestInterpreterOutputTrace(
                     },
                   ),
                   imported_tags: [
-                    ContextField(
+                    ContextField(ContextField(
                       vertex_id: Vid(2),
                       field_name: "name",
                       field_type: "String",
-                    ),
+                    )),
                   ],
                 ),
               },

--- a/trustfall_core/src/resources/test_data/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -208,6 +208,22 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -230,6 +246,22 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([
@@ -414,6 +446,60 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -442,6 +528,60 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+            ],
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/multiple_folds.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/multiple_folds.trace.ron
@@ -189,6 +189,30 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "mult"): Vec([
               Value(Int64(4)),
@@ -208,6 +232,30 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "mult"): Vec([
@@ -314,6 +362,44 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+              ),
+            ],
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Neither(NeitherNumber(1))),
+                tokens: {
+                  Vid(3): Some(Neither(NeitherNumber(1))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(3): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "mult"): Vec([
               Value(Int64(4)),
@@ -337,6 +423,44 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(8, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(8, [
+                    2,
+                  ]))),
+                },
+              ),
+            ],
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Neither(NeitherNumber(1))),
+                tokens: {
+                  Vid(3): Some(Neither(NeitherNumber(1))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(3): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "mult"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/nested_fold.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/nested_fold.trace.ron
@@ -521,6 +521,48 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(10, [
+                  2,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(10, [
+                    2,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(20, [
+                  2,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(20, [
+                    2,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(30, [
+                  2,
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(30, [
+                    2,
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(10)),
@@ -543,6 +585,48 @@ TestInterpreterOutputTrace(
               2,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(10, [
+                  2,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(10, [
+                    2,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(20, [
+                  2,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(20, [
+                    2,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(30, [
+                  2,
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(30, [
+                    2,
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -572,6 +656,48 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(15, [
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(15, [
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(30, [
+                  2,
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(30, [
+                    2,
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(45, [
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(45, [
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(15)),
@@ -594,6 +720,48 @@ TestInterpreterOutputTrace(
               3,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(15, [
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(15, [
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(30, [
+                  2,
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(30, [
+                    2,
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(45, [
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(45, [
+                    3,
+                    5,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -627,6 +795,132 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(10, [
+                  2,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(10, [
+                    2,
+                    5,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(10, [
+                        2,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(10, [
+                          2,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(20, [
+                        2,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(20, [
+                          2,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(30, [
+                        2,
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(30, [
+                          2,
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(10)),
+                    Value(Int64(20)),
+                    Value(Int64(30)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(15, [
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(15, [
+                    3,
+                    5,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(15, [
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(15, [
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(30, [
+                        2,
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(30, [
+                          2,
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(45, [
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(45, [
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(15)),
+                    Value(Int64(30)),
+                    Value(Int64(45)),
+                  ]),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "value"): Vec([
               Value(Int64(10)),
@@ -654,6 +948,132 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(10, [
+                  2,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(10, [
+                    2,
+                    5,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(10, [
+                        2,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(10, [
+                          2,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(20, [
+                        2,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(20, [
+                          2,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(30, [
+                        2,
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(30, [
+                          2,
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(10)),
+                    Value(Int64(20)),
+                    Value(Int64(30)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(15, [
+                  3,
+                  5,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(15, [
+                    3,
+                    5,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(15, [
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(15, [
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(30, [
+                        2,
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(30, [
+                          2,
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(45, [
+                        3,
+                        5,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(45, [
+                          3,
+                          5,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(15)),
+                    Value(Int64(30)),
+                    Value(Int64(45)),
+                  ]),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "value"): Vec([
@@ -1389,6 +1809,46 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(6)),
@@ -1411,6 +1871,46 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -1440,6 +1940,46 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(24, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(24, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(36, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(36, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(12)),
@@ -1462,6 +2002,46 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(24, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(24, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(36, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(36, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -1491,6 +2071,46 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(36, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(36, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(54, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(54, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(18)),
@@ -1513,6 +2133,46 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(36, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(36, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(54, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(54, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -1551,6 +2211,187 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(6, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(6, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(12, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(12, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(18, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(18, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(6)),
+                    Value(Int64(12)),
+                    Value(Int64(18)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(12, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(12, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(24, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(24, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(36, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(36, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(12)),
+                    Value(Int64(24)),
+                    Value(Int64(36)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(18, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(18, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(36, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(36, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(54, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(54, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(18)),
+                    Value(Int64(36)),
+                    Value(Int64(54)),
+                  ]),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "value"): Vec([
@@ -1591,6 +2432,187 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(6, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(6, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(12, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(12, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(18, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(18, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(6)),
+                    Value(Int64(12)),
+                    Value(Int64(18)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(12, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(12, [
+                    2,
+                    3,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(12, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(12, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(24, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(24, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(36, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(36, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(12)),
+                    Value(Int64(24)),
+                    Value(Int64(36)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(18, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(18, [
+                    2,
+                    3,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(18, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(18, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(36, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(36, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(54, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(54, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(18)),
+                    Value(Int64(36)),
+                    Value(Int64(54)),
+                  ]),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "value"): Vec([
@@ -2122,6 +3144,48 @@ TestInterpreterOutputTrace(
               7,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(14, [
+                  2,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(14, [
+                    2,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(28, [
+                  2,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(28, [
+                    2,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(42, [
+                  2,
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(42, [
+                    2,
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(14)),
@@ -2144,6 +3208,48 @@ TestInterpreterOutputTrace(
               2,
               7,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(14, [
+                  2,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(14, [
+                    2,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(28, [
+                  2,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(28, [
+                    2,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(42, [
+                  2,
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(42, [
+                    2,
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -2173,6 +3279,48 @@ TestInterpreterOutputTrace(
               7,
             ]))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(21, [
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(21, [
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(42, [
+                  2,
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(42, [
+                    2,
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(63, [
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(63, [
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "mult"): Vec([
               Value(Int64(21)),
@@ -2195,6 +3343,48 @@ TestInterpreterOutputTrace(
               3,
               7,
             ]))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(21, [
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(21, [
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(42, [
+                  2,
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(42, [
+                    2,
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(63, [
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(63, [
+                    3,
+                    7,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "mult"): Vec([
@@ -2228,6 +3418,132 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(14, [
+                  2,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(14, [
+                    2,
+                    7,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(14, [
+                        2,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(14, [
+                          2,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(28, [
+                        2,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(28, [
+                          2,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(42, [
+                        2,
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(42, [
+                          2,
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(14)),
+                    Value(Int64(28)),
+                    Value(Int64(42)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(21, [
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(21, [
+                    3,
+                    7,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(21, [
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(21, [
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(42, [
+                        2,
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(42, [
+                          2,
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(63, [
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(63, [
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(21)),
+                    Value(Int64(42)),
+                    Value(Int64(63)),
+                  ]),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "value"): Vec([
               Value(Int64(14)),
@@ -2255,6 +3571,132 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(14, [
+                  2,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(14, [
+                    2,
+                    7,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(14, [
+                        2,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(14, [
+                          2,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(28, [
+                        2,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(28, [
+                          2,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(42, [
+                        2,
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(42, [
+                          2,
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(14)),
+                    Value(Int64(28)),
+                    Value(Int64(42)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(21, [
+                  3,
+                  7,
+                ]))),
+                tokens: {
+                  Vid(2): Some(Composite(CompositeNumber(21, [
+                    3,
+                    7,
+                  ]))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(21, [
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(21, [
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(42, [
+                        2,
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(42, [
+                          2,
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(63, [
+                        3,
+                        7,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(63, [
+                          3,
+                          7,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "mult"): Vec([
+                    Value(Int64(21)),
+                    Value(Int64(42)),
+                    Value(Int64(63)),
+                  ]),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "value"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/nested_fold_count_output.trace.ron
@@ -422,6 +422,32 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "multiplecount"): Value(Uint64(2)),
             (Eid(2), "multiples"): Vec([
@@ -438,6 +464,32 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "multiplecount"): Value(Uint64(2)),
@@ -461,6 +513,32 @@ TestInterpreterOutputTrace(
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(9, [
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(9, [
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(2), "multiplecount"): Value(Uint64(2)),
             (Eid(2), "multiples"): Vec([
@@ -477,6 +555,32 @@ TestInterpreterOutputTrace(
           current_token: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+          folded_contexts: {
+            Eid(2): [
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Composite(CompositeNumber(9, [
+                  3,
+                ]))),
+                tokens: {
+                  Vid(3): Some(Composite(CompositeNumber(9, [
+                    3,
+                  ]))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(2), "multiplecount"): Value(Uint64(2)),
@@ -516,6 +620,88 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(4, [
+                        2,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(4, [
+                          2,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(6, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(6, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "multiplecount"): Value(Uint64(2)),
+                  (Eid(2), "multiples"): Vec([
+                    Value(Int64(4)),
+                    Value(Int64(6)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(6, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(6, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(9, [
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(9, [
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "multiplecount"): Value(Uint64(2)),
+                  (Eid(2), "multiples"): Vec([
+                    Value(Int64(6)),
+                    Value(Int64(9)),
+                  ]),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -552,6 +738,88 @@ TestInterpreterOutputTrace(
               2,
               3,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(4, [
+                        2,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(4, [
+                          2,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(6, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(6, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "multiplecount"): Value(Uint64(2)),
+                  (Eid(2), "multiples"): Vec([
+                    Value(Int64(4)),
+                    Value(Int64(6)),
+                  ]),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+                folded_contexts: {
+                  Eid(2): [
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(6, [
+                        2,
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(6, [
+                          2,
+                          3,
+                        ]))),
+                      },
+                    ),
+                    SerializableContext(
+                      current_token: Some(Composite(CompositeNumber(9, [
+                        3,
+                      ]))),
+                      tokens: {
+                        Vid(3): Some(Composite(CompositeNumber(9, [
+                          3,
+                        ]))),
+                      },
+                    ),
+                  ],
+                },
+                folded_values: {
+                  (Eid(2), "multiplecount"): Value(Uint64(2)),
+                  (Eid(2), "multiples"): Vec([
+                    Value(Int64(6)),
+                    Value(Int64(9)),
+                  ]),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/output_fold_count.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/output_fold_count.trace.ron
@@ -129,6 +129,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -148,6 +158,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([

--- a/trustfall_core/src/resources/test_data/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/src/resources/test_data/valid_queries/output_fold_count_multiple.trace.ron
@@ -198,6 +198,22 @@ TestInterpreterOutputTrace(
               7,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(7))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(7))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -220,6 +236,22 @@ TestInterpreterOutputTrace(
               2,
               7,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(7))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(7))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([
@@ -471,6 +503,28 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -496,6 +550,28 @@ TestInterpreterOutputTrace(
               3,
               5,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(3))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(3))),
+                },
+              ),
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(5))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(5))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([
@@ -670,6 +746,16 @@ TestInterpreterOutputTrace(
               2,
             ]))),
           },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
+          },
           folded_values: {
             (Eid(1), "factors"): Vec([
               Value(Int64(2)),
@@ -689,6 +775,16 @@ TestInterpreterOutputTrace(
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                current_token: Some(Prime(PrimeNumber(2))),
+                tokens: {
+                  Vid(2): Some(Prime(PrimeNumber(2))),
+                },
+              ),
+            ],
           },
           folded_values: {
             (Eid(1), "factors"): Vec([


### PR DESCRIPTION
- Use FieldRef to record tag information in DataContext.
- Initial implementation for tagging fold-transform values.
- Require explicit tag names for transformed values.
- Implement the edge cases around using transformed tags in other folds.