### PR TITLE
Add some documentation to graphql_query/ in `trustfall_core`

### DIFF
--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -254,7 +254,7 @@ impl TryFrom<&Positioned<Directive>> for OutputDirective {
 }
 
 /// A GraphQL `@transform` directive.
-/// 
+///
 /// For example, the following GraphQL and Rust would be equivalent:
 /// ```graphql
 /// @transform(op: "count")

--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -11,7 +11,7 @@ use crate::ir::{Operation, TransformationKind};
 
 use super::error::ParseError;
 
-/// A value passed as an operator argument in a Trustfall query, for example as in 
+/// A value passed as an operator argument in a Trustfall query, for example as in
 /// the `value` array of the `@filter` directive (see [FilterDirective]).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperatorArgument {

--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -35,9 +35,9 @@ pub enum OperatorArgument {
 ///
 /// and
 ///
-/// ```
+/// ```ignore
 /// FilterDirective {
-///     operation: Operation::GreaterThanOrEqual(VariableRef(Arc::new("$some_value")))
+///     operation: Operation::GreaterThanOrEqual(OperatorArgument::VariableRef(Arc::new("$some_value"), 1))
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -187,7 +187,7 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
 ///
 /// and
 ///
-/// ```
+/// ```ignore
 /// OutputDirective { name: Some(Arc::new("betterName"))}
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -262,8 +262,8 @@ impl TryFrom<&Positioned<Directive>> for OutputDirective {
 ///
 /// and
 ///
-/// ```
-/// TransformDirective { kind: TransformKind::Count }
+/// ```ignore
+/// TransformDirective { kind: TransformationKind::Count }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub(crate) struct TransformDirective {
@@ -338,7 +338,7 @@ impl TryFrom<&Positioned<Directive>> for TransformDirective {
 ///
 /// and
 ///
-/// ```
+/// ```ignore
 /// TagDirective { name: Some(Arc::new("%tag_name"))}
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -452,7 +452,7 @@ impl TryFrom<&Positioned<Directive>> for FoldDirective {
 ///
 /// and
 ///
-/// ```
+/// ```ignore
 /// RecurseDirective { depth: NonZeroUsize::new(1usize)}
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -1,5 +1,5 @@
-//! Directives in GraphQL can be identified by staring with `@`. While
-//! `trustfall_core` doesn't support all GraphQL directives, some are available.
+//! Directives in Trustfall can be identified by their prefix: `@`.
+//! This module contains the logic for parsing Trustfall query directives.
 use std::{collections::HashSet, convert::TryFrom, num::NonZeroUsize, sync::Arc};
 
 use async_graphql_parser::{types::Directive, Positioned};
@@ -11,8 +11,8 @@ use crate::ir::{Operation, TransformationKind};
 
 use super::error::ParseError;
 
-/// An argument as passed to the `value` array, for example for a `@filter`
-/// directive (see [FilterDirective]).
+/// A value passed as an operator argument in a Trustfall query, for example as in 
+/// the `value` array of the `@filter` directive (see [FilterDirective]).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperatorArgument {
     /// Reference to a variable provided to the query. Variable names are always
@@ -24,9 +24,9 @@ pub enum OperatorArgument {
     TagRef(Arc<str>),
 }
 
-/// A GraphQL `@filter` directive.
+/// A Trustfall `@filter` directive.
 ///
-/// The following GraphQL filter directive and Rust instance would be
+/// The following Trustfall filter directive and Rust value would be
 /// equivalent:
 ///
 /// ```graphql
@@ -37,7 +37,7 @@ pub enum OperatorArgument {
 ///
 /// ```ignore
 /// FilterDirective {
-///     operation: Operation::GreaterThanOrEqual(OperatorArgument::VariableRef(Arc::new("$some_value"), 1))
+///     operation: Operation::GreaterThanOrEqual((), OperatorArgument::VariableRef(Arc::new("$some_value")))
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -178,9 +178,9 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
     }
 }
 
-/// A GraphQL `@output` directive.
+/// A Trustfall `@output` directive.
 ///
-/// For example, the following GraphQL and Rust would be equivalent:
+/// For example, the following Trustfall and Rust would be equivalent:
 /// ```graphql
 /// @output(name: "betterName")
 /// ```
@@ -253,9 +253,9 @@ impl TryFrom<&Positioned<Directive>> for OutputDirective {
     }
 }
 
-/// A GraphQL `@transform` directive.
+/// A Trustfall `@transform` directive.
 ///
-/// For example, the following GraphQL and Rust would be equivalent:
+/// For example, the following Trustfall and Rust would be equivalent:
 /// ```graphql
 /// @transform(op: "count")
 /// ```
@@ -329,9 +329,9 @@ impl TryFrom<&Positioned<Directive>> for TransformDirective {
     }
 }
 
-/// A GraphQL `@tag` directive.
+/// A Trustfall `@tag` directive.
 ///
-/// For example, the following GraphQL and Rust would be equivalent:
+/// For example, the following Trustfall and Rust would be equivalent:
 /// ```graphql
 /// @tag(name: "%tag_name")
 /// ```
@@ -401,7 +401,7 @@ impl TryFrom<&Positioned<Directive>> for TagDirective {
     }
 }
 
-/// A GraphQL `@optional` directive.
+/// A Trustfall `@optional` directive.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub(crate) struct OptionalDirective {}
 
@@ -422,7 +422,7 @@ impl TryFrom<&Positioned<Directive>> for OptionalDirective {
     }
 }
 
-/// A GraphQL `@fold` directive.
+/// A Trustfall `@fold` directive.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub(crate) struct FoldDirective {}
 
@@ -443,9 +443,9 @@ impl TryFrom<&Positioned<Directive>> for FoldDirective {
     }
 }
 
-/// A GraphQL `@recurse` directive.
+/// A Trustfall `@recurse` directive.
 ///
-/// For example, the following GraphQL and Rust would be equivalent:
+/// For example, the following Trustfall and Rust would be equivalent:
 /// ```graphql
 /// @recurse(depth: 1)
 /// ```

--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -19,8 +19,9 @@ pub enum OperatorArgument {
     /// prefixed with `$`.
     VariableRef(Arc<str>),
 
-    /// Reference to a `@tag`ed value encountered elsewhere
-    /// in the query. Tag names are always prefixed with `%`.
+    /// Reference to a tagged value encountered elsewhere
+    /// in the query and marked with the `@tag` directive -- see [TagDirective].
+    /// Tag names are always prefixed with `%`.
     TagRef(Arc<str>),
 }
 

--- a/trustfall_core/src/graphql_query/error.rs
+++ b/trustfall_core/src/graphql_query/error.rs
@@ -1,3 +1,4 @@
+//! Errors from parsing GraphQL
 use async_graphql_parser::Pos;
 use async_graphql_value::Value;
 use serde::{ser::Error as SerError, Deserialize, Serialize, Serializer};

--- a/trustfall_core/src/graphql_query/error.rs
+++ b/trustfall_core/src/graphql_query/error.rs
@@ -1,4 +1,4 @@
-//! Errors from parsing GraphQL
+//! Errors from parsing Trustfall queries
 use async_graphql_parser::Pos;
 use async_graphql_value::Value;
 use serde::{ser::Error as SerError, Deserialize, Serialize, Serializer};

--- a/trustfall_core/src/graphql_query/mod.rs
+++ b/trustfall_core/src/graphql_query/mod.rs
@@ -1,4 +1,5 @@
-//! Translating GraphQL queries to Rust types
+//! Parsing Trustfall queries into Rust types,
+//! which are then handed to the frontend for further processing.
 pub(crate) mod directives;
 pub mod error;
 pub(crate) mod query;

--- a/trustfall_core/src/graphql_query/mod.rs
+++ b/trustfall_core/src/graphql_query/mod.rs
@@ -1,3 +1,4 @@
+//! Translating GraphQL queries to Rust types
 pub(crate) mod directives;
 pub mod error;
 pub(crate) mod query;

--- a/trustfall_core/src/graphql_query/query.rs
+++ b/trustfall_core/src/graphql_query/query.rs
@@ -116,6 +116,10 @@ impl ParsedDirective {
     }
 }
 
+/// Attempts to extract the query root from an [ExecutableDocument]
+/// 
+/// May return [ParseError] if the query is empty, there is no query root, or
+/// the query root is not formatted properly
 fn try_get_query_root(document: &ExecutableDocument) -> Result<&Positioned<Field>, ParseError> {
     if let Some(v) = document.fragments.values().next() {
         return Err(ParseError::DocumentContainsNonInlineFragments(v.pos));
@@ -507,6 +511,7 @@ fn make_transform_group(
     })
 }
 
+/// Parses a query document. May fail if a query root is missing (see [try_get_query_root](try_get_query_root))
 pub(crate) fn parse_document(document: &ExecutableDocument) -> Result<Query, ParseError> {
     let query_root = try_get_query_root(document)?;
 

--- a/trustfall_core/src/graphql_query/query.rs
+++ b/trustfall_core/src/graphql_query/query.rs
@@ -117,7 +117,7 @@ impl ParsedDirective {
 }
 
 /// Attempts to extract the query root from an [ExecutableDocument]
-/// 
+///
 /// May return [ParseError] if the query is empty, there is no query root, or
 /// the query root is not formatted properly
 fn try_get_query_root(document: &ExecutableDocument) -> Result<&Positioned<Field>, ParseError> {


### PR DESCRIPTION
As discussed #136, this adds some minor documentation to graphql_query. There are still things to do, but these are the things I am somewhat confident writing about.