### PR TITLE
Apply all the major breaking changes to Adapter and surrounding code

### DIFF
--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -2,8 +2,9 @@ use feed_rs::model::{Content, Entry, Feed, FeedType, Image, Link, Text};
 use trustfall_core::{
     field_property,
     interpreter::{
-        basic_adapter::{BasicAdapter, ContextIterator, ContextOutcomeIterator, VertexIterator},
+        basic_adapter::BasicAdapter,
         helpers::{resolve_neighbors_with as neighbors, resolve_property_with as property},
+        ContextIterator, ContextOutcomeIterator, VertexIterator,
     },
     ir::{EdgeParameters, FieldValue},
 };

--- a/demo-hackernews/README.md
+++ b/demo-hackernews/README.md
@@ -52,7 +52,7 @@ The project consists of the following components:
     - The `resolve_starting_vertices` method is what produces the initial iterator of `Token` vertices
       corresponding to the root edge at which querying starts (e.g. `FrontPage`).
     - The `resolve_property` method is used to get property values for each `Token` in an iterator.
-    - The `project_neighbors` method is used to get the neighboring vertices (`Token`s)
+    - The `resolve_neighbors` method is used to get the neighboring vertices (`Token`s)
       across a particular edge, for each `Token` in an iterator.
     - The `can_coerce_to_type` method is kind of like the Python `isinstance()` function:
       for each `Token` in an iterable, it checks whether that `Token`'s type can be narrowed

--- a/demo-hackernews/README.md
+++ b/demo-hackernews/README.md
@@ -54,10 +54,10 @@ The project consists of the following components:
     - The `resolve_property` method is used to get property values for each `Token` in an iterator.
     - The `resolve_neighbors` method is used to get the neighboring vertices (`Token`s)
       across a particular edge, for each `Token` in an iterator.
-    - The `can_coerce_to_type` method is kind of like the Python `isinstance()` function:
+    - The `resolve_coercion` method is kind of like the Python `isinstance()` function:
       for each `Token` in an iterable, it checks whether that `Token`'s type can be narrowed
       to a more derived type than it previously represented. For example, if the `Token` originally
-      represented `interface Animal`, `can_coerce_to_type` may be used to check whether the `Token`
+      represented `interface Animal`, `resolve_coercion` may be used to check whether the `Token`
       is actually of `type Dog implements Animal`.
 - `main.rs` is a simple CLI app that can execute query files in `ron` format.
 

--- a/demo-hackernews/README.md
+++ b/demo-hackernews/README.md
@@ -49,9 +49,9 @@ The project consists of the following components:
 - `adapter.rs` defines the `HackerNewsAdapter` struct, which implements
   the `trustfall_core::interpreter::Adapter` trait and connects the query engine
   to the HackerNews API.
-    - The `get_starting_tokens` method is what produces the initial iterator of `Token` vertices
+    - The `resolve_starting_vertices` method is what produces the initial iterator of `Token` vertices
       corresponding to the root edge at which querying starts (e.g. `FrontPage`).
-    - The `project_property` method is used to get property values for each `Token` in an iterator.
+    - The `resolve_property` method is used to get property values for each `Token` in an iterator.
     - The `project_neighbors` method is used to get the neighboring vertices (`Token`s)
       across a particular edge, for each `Token` in an iterator.
     - The `can_coerce_to_type` method is kind of like the Python `isinstance()` function:

--- a/demo-hackernews/src/adapter.rs
+++ b/demo-hackernews/src/adapter.rs
@@ -20,11 +20,11 @@ lazy_static! {
 pub struct HackerNewsAdapter;
 
 impl HackerNewsAdapter {
-    fn front_page(&self) -> Box<dyn Iterator<Item = Token>> {
+    fn front_page(&self) -> VertexIterator<'static, Token> {
         self.top(Some(30))
     }
 
-    fn top(&self, max: Option<usize>) -> Box<dyn Iterator<Item = Token>> {
+    fn top(&self, max: Option<usize>) -> VertexIterator<'static, Token> {
         let iterator = CLIENT
             .get_top_stories()
             .unwrap()
@@ -41,7 +41,7 @@ impl HackerNewsAdapter {
         Box::new(iterator)
     }
 
-    fn latest_stories(&self, max: Option<usize>) -> Box<dyn Iterator<Item = Token>> {
+    fn latest_stories(&self, max: Option<usize>) -> VertexIterator<'static, Token> {
         // Unfortunately, the HN crate we're using doesn't support getting the new stories,
         // so we're doing it manually here.
         let story_ids: Vec<u32> =
@@ -65,7 +65,7 @@ impl HackerNewsAdapter {
         Box::new(iterator)
     }
 
-    fn user(&self, username: &str) -> Box<dyn Iterator<Item = Token>> {
+    fn user(&self, username: &str) -> VertexIterator<'static, Token> {
         match CLIENT.get_user(username) {
             Ok(Some(user)) => {
                 // Found a user by that name.

--- a/demo-hackernews/src/adapter.rs
+++ b/demo-hackernews/src/adapter.rs
@@ -4,8 +4,9 @@ use hn_api::{types::Item, HnClient};
 use trustfall_core::{
     field_property,
     interpreter::{
-        basic_adapter::{BasicAdapter, ContextIterator, ContextOutcomeIterator, VertexIterator},
+        basic_adapter::BasicAdapter,
         helpers::{resolve_coercion_with, resolve_neighbors_with, resolve_property_with},
+        ContextIterator, ContextOutcomeIterator, VertexIterator,
     },
     ir::{EdgeParameters, FieldValue},
 };

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -693,7 +693,7 @@ impl Adapter<'static> for DemoAdapter {
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
@@ -707,7 +707,7 @@ impl Adapter<'static> for DemoAdapter {
             // This "match" is loop-invariant, and can be hoisted outside the map() call
             // at the cost of a bit of code repetition.
 
-            let can_coerce = match (type_name.as_ref(), coerce_to_type_name.as_ref()) {
+            let can_coerce = match (type_name.as_ref(), coerce_to_type.as_ref()) {
                 ("HackerNewsItem", "HackerNewsJob") => token.as_job().is_some(),
                 ("HackerNewsItem", "HackerNewsStory") => token.as_story().is_some(),
                 ("HackerNewsItem", "HackerNewsComment") => token.as_comment().is_some(),

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -366,7 +366,7 @@ impl Adapter<'static> for DemoAdapter {
         }
     }
 
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -191,14 +191,14 @@ macro_rules! impl_property {
 impl Adapter<'static> for DemoAdapter {
     type Vertex = Token;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = Self::Vertex>> {
-        match edge.as_ref() {
+        match edge_name.as_ref() {
             "HackerNewsFrontPage" => self.front_page(),
             "HackerNewsTop" => {
                 // TODO: This is unergonomic, build a more convenient API here.

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -53,11 +53,11 @@ impl DemoAdapter {
         Self
     }
 
-    fn front_page(&self) -> Box<dyn Iterator<Item = Token>> {
+    fn front_page(&self) -> VertexIterator<'static, Token> {
         self.top(Some(30))
     }
 
-    fn top(&self, max: Option<usize>) -> Box<dyn Iterator<Item = Token>> {
+    fn top(&self, max: Option<usize>) -> VertexIterator<'static, Token> {
         let iterator = HN_CLIENT
             .get_top_stories()
             .unwrap()
@@ -74,7 +74,7 @@ impl DemoAdapter {
         Box::new(iterator)
     }
 
-    fn latest_stories(&self, max: Option<usize>) -> Box<dyn Iterator<Item = Token>> {
+    fn latest_stories(&self, max: Option<usize>) -> VertexIterator<'static, Token> {
         // Unfortunately, the HN crate we're using doesn't support getting the new stories,
         // so we're doing it manually here.
         let story_ids: Vec<u32> =
@@ -98,7 +98,7 @@ impl DemoAdapter {
         Box::new(iterator)
     }
 
-    fn user(&self, username: &str) -> Box<dyn Iterator<Item = Token>> {
+    fn user(&self, username: &str) -> VertexIterator<'static, Token> {
         match HN_CLIENT.get_user(username) {
             Ok(Some(user)) => {
                 // Found a user by that name.
@@ -116,7 +116,7 @@ impl DemoAdapter {
         }
     }
 
-    fn most_downloaded_crates(&self) -> Box<dyn Iterator<Item = Token>> {
+    fn most_downloaded_crates(&self) -> VertexIterator<'static, Token> {
         Box::new(
             CratesPager::new(CRATES_CLIENT.deref())
                 .into_iter()
@@ -381,7 +381,7 @@ impl Adapter<'static> for DemoAdapter {
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("HackerNewsStory", "byUser") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let story = token.as_story().unwrap();
@@ -404,7 +404,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsStory", "comment") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let story = token.as_story().unwrap();
@@ -439,7 +439,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsStory", "link") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let story = token.as_story().unwrap();
@@ -457,7 +457,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsJob", "link") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let job = token.as_job().unwrap();
@@ -474,7 +474,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "byUser") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -497,7 +497,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "parent") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -521,7 +521,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "topmostAncestor") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -558,7 +558,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "reply") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -590,7 +590,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsUser", "submitted") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let user = token.as_user().unwrap();
@@ -615,7 +615,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("Crate", "repository") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let cr = token.as_crate().unwrap();
@@ -633,7 +633,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubRepository", "workflows") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => Box::new(
                         WorkflowsPager::new(GITHUB_CLIENT.clone(), token, RUNTIME.deref())
@@ -646,7 +646,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubWorkflow", "jobs") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let workflow = token.as_github_workflow().unwrap();
@@ -667,7 +667,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubActionsJob", "step") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(Token::GitHubActionsJob(job)) => get_steps_in_job(job),
                     _ => unreachable!(),
@@ -677,7 +677,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubActionsRunStep", "env") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
+                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(Token::GitHubActionsRunStep(s)) => get_env_for_run_step(s),
                     _ => unreachable!(),

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -227,15 +227,15 @@ impl Adapter<'static> for DemoAdapter {
         }
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
-        match (current_type_name.as_ref(), field_name.as_ref()) {
+        match (type_name.as_ref(), field_name.as_ref()) {
             (_, "__typename") => Box::new(data_contexts.map(|ctx| {
                 let value = match ctx.current_token.as_ref() {
                     Some(token) => token.typename().into(),
@@ -369,7 +369,7 @@ impl Adapter<'static> for DemoAdapter {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         _parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
@@ -383,7 +383,7 @@ impl Adapter<'static> for DemoAdapter {
             ),
         >,
     > {
-        match (current_type_name.as_ref(), edge_name.as_ref()) {
+        match (type_name.as_ref(), edge_name.as_ref()) {
             ("HackerNewsStory", "byUser") => Box::new(data_contexts.map(|ctx| {
                 let token = &ctx.current_token;
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
@@ -690,14 +690,14 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            _ => unreachable!("{} {}", current_type_name.as_ref(), edge_name.as_ref()),
+            _ => unreachable!("{} {}", type_name.as_ref(), edge_name.as_ref()),
         }
     }
 
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
@@ -712,7 +712,7 @@ impl Adapter<'static> for DemoAdapter {
             // This "match" is loop-invariant, and can be hoisted outside the map() call
             // at the cost of a bit of code repetition.
 
-            let can_coerce = match (current_type_name.as_ref(), coerce_to_type_name.as_ref()) {
+            let can_coerce = match (type_name.as_ref(), coerce_to_type_name.as_ref()) {
                 ("HackerNewsItem", "HackerNewsJob") => token.as_job().is_some(),
                 ("HackerNewsItem", "HackerNewsStory") => token.as_story().is_some(),
                 ("HackerNewsItem", "HackerNewsComment") => token.as_comment().is_some(),

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -195,8 +195,8 @@ impl Adapter<'static> for DemoAdapter {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> VertexIterator<'static, Self::Vertex> {
@@ -205,6 +205,7 @@ impl Adapter<'static> for DemoAdapter {
             "HackerNewsTop" => {
                 // TODO: This is unergonomic, build a more convenient API here.
                 let max = parameters
+                    .as_deref()
                     .unwrap()
                     .0
                     .get("max")
@@ -214,6 +215,7 @@ impl Adapter<'static> for DemoAdapter {
             "HackerNewsLatestStories" => {
                 // TODO: This is unergonomic, build a more convenient API here.
                 let max = parameters
+                    .as_deref()
                     .unwrap()
                     .0
                     .get("max")
@@ -232,12 +234,12 @@ impl Adapter<'static> for DemoAdapter {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
-        match (type_name.as_ref(), field_name.as_ref()) {
+        match (type_name.as_ref(), property_name.as_ref()) {
             (_, "__typename") => Box::new(contexts.map(|ctx| {
                 let value = match ctx.current_token.as_ref() {
                     Some(token) => token.typename().into(),
@@ -371,9 +373,9 @@ impl Adapter<'static> for DemoAdapter {
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        _parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        _parameters: &Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
         _edge_hint: Eid,
@@ -692,11 +694,13 @@ impl Adapter<'static> for DemoAdapter {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
+        let type_name = type_name.clone();
+        let coerce_to_type = coerce_to_type.clone();
         let iterator = contexts.map(move |ctx| {
             let token = match &ctx.current_token {
                 Some(t) => t,

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -189,7 +189,7 @@ macro_rules! impl_property {
 }
 
 impl Adapter<'static> for DemoAdapter {
-    type DataToken = Token;
+    type Vertex = Token;
 
     fn get_starting_tokens(
         &mut self,
@@ -197,7 +197,7 @@ impl Adapter<'static> for DemoAdapter {
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken>> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex>> {
         match edge.as_ref() {
             "HackerNewsFrontPage" => self.front_page(),
             "HackerNewsTop" => {
@@ -229,12 +229,12 @@ impl Adapter<'static> for DemoAdapter {
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
         match (current_type_name.as_ref(), field_name.as_ref()) {
             (_, "__typename") => Box::new(data_contexts.map(|ctx| {
                 let value = match ctx.current_token.as_ref() {
@@ -368,7 +368,7 @@ impl Adapter<'static> for DemoAdapter {
 
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         _parameters: Option<Arc<EdgeParameters>>,
@@ -378,15 +378,15 @@ impl Adapter<'static> for DemoAdapter {
     ) -> Box<
         dyn Iterator<
             Item = (
-                DataContext<Self::DataToken>,
-                Box<dyn Iterator<Item = Self::DataToken>>,
+                DataContext<Self::Vertex>,
+                Box<dyn Iterator<Item = Self::Vertex>>,
             ),
         >,
     > {
         match (current_type_name.as_ref(), edge_name.as_ref()) {
             ("HackerNewsStory", "byUser") => Box::new(data_contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let story = token.as_story().unwrap();
@@ -409,7 +409,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsStory", "comment") => Box::new(data_contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let story = token.as_story().unwrap();
@@ -444,7 +444,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsStory", "link") => Box::new(data_contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let story = token.as_story().unwrap();
@@ -462,7 +462,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsJob", "link") => Box::new(data_contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let job = token.as_job().unwrap();
@@ -479,7 +479,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "byUser") => Box::new(data_contexts.map(|ctx| {
                 let token = &ctx.current_token;
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -502,7 +502,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "parent") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -526,7 +526,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "topmostAncestor") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -563,7 +563,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "reply") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let comment = token.as_comment().unwrap();
@@ -595,7 +595,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsUser", "submitted") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let user = token.as_user().unwrap();
@@ -620,7 +620,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("Crate", "repository") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let cr = token.as_crate().unwrap();
@@ -638,7 +638,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubRepository", "workflows") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => Box::new(
                         WorkflowsPager::new(GITHUB_CLIENT.clone(), token, RUNTIME.deref())
@@ -651,7 +651,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubWorkflow", "jobs") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(token) => {
                         let workflow = token.as_github_workflow().unwrap();
@@ -672,7 +672,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubActionsJob", "step") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(Token::GitHubActionsJob(job)) => get_steps_in_job(job),
                     _ => unreachable!(),
@@ -682,7 +682,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubActionsRunStep", "env") => Box::new(data_contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
-                let neighbors: Box<dyn Iterator<Item = Self::DataToken>> = match token {
+                let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
                     Some(Token::GitHubActionsRunStep(s)) => get_env_for_run_step(s),
                     _ => unreachable!(),
@@ -696,12 +696,12 @@ impl Adapter<'static> for DemoAdapter {
 
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
         let iterator = data_contexts.map(move |ctx| {
             let token = match &ctx.current_token {
                 Some(t) => t,

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -694,7 +694,7 @@ impl Adapter<'static> for DemoAdapter {
         }
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -8,7 +8,9 @@ use lazy_static::__Deref;
 use octorust::types::{ContentFile, FullRepository};
 use tokio::runtime::Runtime;
 use trustfall_core::{
-    interpreter::{Adapter, DataContext, InterpretedQuery},
+    interpreter::{
+        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
+    },
     ir::{EdgeParameters, Eid, FieldValue, Vid},
 };
 
@@ -124,8 +126,8 @@ impl DemoAdapter {
 }
 
 macro_rules! impl_item_property {
-    ($data_contexts:ident, $attr:ident) => {
-        Box::new($data_contexts.map(|ctx| {
+    ($contexts:ident, $attr:ident) => {
+        Box::new($contexts.map(|ctx| {
             let token = ctx.current_token.as_ref();
             let value = match token {
                 None => FieldValue::Null,
@@ -151,8 +153,8 @@ macro_rules! impl_item_property {
 }
 
 macro_rules! impl_property {
-    ($data_contexts:ident, $conversion:ident, $attr:ident) => {
-        Box::new($data_contexts.map(|ctx| {
+    ($contexts:ident, $conversion:ident, $attr:ident) => {
+        Box::new($contexts.map(|ctx| {
             let token = ctx
                 .current_token
                 .as_ref()
@@ -169,8 +171,8 @@ macro_rules! impl_property {
         }))
     };
 
-    ($data_contexts:ident, $conversion:ident, $var:ident, $b:block) => {
-        Box::new($data_contexts.map(|ctx| {
+    ($contexts:ident, $conversion:ident, $var:ident, $b:block) => {
+        Box::new($contexts.map(|ctx| {
             let token = ctx
                 .current_token
                 .as_ref()
@@ -197,7 +199,7 @@ impl Adapter<'static> for DemoAdapter {
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex>> {
+    ) -> VertexIterator<'static, Self::Vertex> {
         match edge_name.as_ref() {
             "HackerNewsFrontPage" => self.front_page(),
             "HackerNewsTop" => {
@@ -229,14 +231,14 @@ impl Adapter<'static> for DemoAdapter {
 
     fn resolve_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         field_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         match (type_name.as_ref(), field_name.as_ref()) {
-            (_, "__typename") => Box::new(data_contexts.map(|ctx| {
+            (_, "__typename") => Box::new(contexts.map(|ctx| {
                 let value = match ctx.current_token.as_ref() {
                     Some(token) => token.typename().into(),
                     None => FieldValue::Null,
@@ -249,34 +251,34 @@ impl Adapter<'static> for DemoAdapter {
             (
                 "HackerNewsItem" | "HackerNewsStory" | "HackerNewsJob" | "HackerNewsComment",
                 "id",
-            ) => impl_item_property!(data_contexts, id),
+            ) => impl_item_property!(contexts, id),
             (
                 "HackerNewsItem" | "HackerNewsStory" | "HackerNewsJob" | "HackerNewsComment",
                 "unixTime",
             ) => {
-                impl_item_property!(data_contexts, time)
+                impl_item_property!(contexts, time)
             }
 
             // properties on HackerNewsJob
-            ("HackerNewsJob", "score") => impl_property!(data_contexts, as_job, score),
-            ("HackerNewsJob", "title") => impl_property!(data_contexts, as_job, title),
-            ("HackerNewsJob", "url") => impl_property!(data_contexts, as_job, url),
+            ("HackerNewsJob", "score") => impl_property!(contexts, as_job, score),
+            ("HackerNewsJob", "title") => impl_property!(contexts, as_job, title),
+            ("HackerNewsJob", "url") => impl_property!(contexts, as_job, url),
 
             // properties on HackerNewsStory
-            ("HackerNewsStory", "byUsername") => impl_property!(data_contexts, as_story, by),
-            ("HackerNewsStory", "text") => impl_property!(data_contexts, as_story, text),
+            ("HackerNewsStory", "byUsername") => impl_property!(contexts, as_story, by),
+            ("HackerNewsStory", "text") => impl_property!(contexts, as_story, text),
             ("HackerNewsStory", "commentsCount") => {
-                impl_property!(data_contexts, as_story, descendants)
+                impl_property!(contexts, as_story, descendants)
             }
-            ("HackerNewsStory", "score") => impl_property!(data_contexts, as_story, score),
-            ("HackerNewsStory", "title") => impl_property!(data_contexts, as_story, title),
-            ("HackerNewsStory", "url") => impl_property!(data_contexts, as_story, url),
+            ("HackerNewsStory", "score") => impl_property!(contexts, as_story, score),
+            ("HackerNewsStory", "title") => impl_property!(contexts, as_story, title),
+            ("HackerNewsStory", "url") => impl_property!(contexts, as_story, url),
 
             // properties on HackerNewsComment
-            ("HackerNewsComment", "byUsername") => impl_property!(data_contexts, as_comment, by),
-            ("HackerNewsComment", "text") => impl_property!(data_contexts, as_comment, text),
+            ("HackerNewsComment", "byUsername") => impl_property!(contexts, as_comment, by),
+            ("HackerNewsComment", "text") => impl_property!(contexts, as_comment, text),
             ("HackerNewsComment", "childCount") => {
-                impl_property!(data_contexts, as_comment, comment, {
+                impl_property!(contexts, as_comment, comment, {
                     comment
                         .kids
                         .as_ref()
@@ -287,78 +289,78 @@ impl Adapter<'static> for DemoAdapter {
             }
 
             // properties on HackerNewsUser
-            ("HackerNewsUser", "id") => impl_property!(data_contexts, as_user, id),
-            ("HackerNewsUser", "karma") => impl_property!(data_contexts, as_user, karma),
-            ("HackerNewsUser", "about") => impl_property!(data_contexts, as_user, about),
-            ("HackerNewsUser", "unixCreatedAt") => impl_property!(data_contexts, as_user, created),
-            ("HackerNewsUser", "delay") => impl_property!(data_contexts, as_user, delay),
+            ("HackerNewsUser", "id") => impl_property!(contexts, as_user, id),
+            ("HackerNewsUser", "karma") => impl_property!(contexts, as_user, karma),
+            ("HackerNewsUser", "about") => impl_property!(contexts, as_user, about),
+            ("HackerNewsUser", "unixCreatedAt") => impl_property!(contexts, as_user, created),
+            ("HackerNewsUser", "delay") => impl_property!(contexts, as_user, delay),
 
             // properties on Crate
-            ("Crate", "name") => impl_property!(data_contexts, as_crate, name),
-            ("Crate", "latestVersion") => impl_property!(data_contexts, as_crate, max_version),
+            ("Crate", "name") => impl_property!(contexts, as_crate, name),
+            ("Crate", "latestVersion") => impl_property!(contexts, as_crate, max_version),
 
             // properties on Webpage
             ("Webpage" | "Repository" | "GitHubRepository", "url") => {
-                impl_property!(data_contexts, as_webpage, url, { url.into() })
+                impl_property!(contexts, as_webpage, url, { url.into() })
             }
 
             // properties on GitHubRepository
             ("GitHubRepository", "owner") => {
-                impl_property!(data_contexts, as_github_repository, repo, {
+                impl_property!(contexts, as_github_repository, repo, {
                     let (owner, _) = get_owner_and_repo(repo);
                     owner.into()
                 })
             }
             ("GitHubRepository", "name") => {
-                impl_property!(data_contexts, as_github_repository, name)
+                impl_property!(contexts, as_github_repository, name)
             }
             ("GitHubRepository", "fullName") => {
-                impl_property!(data_contexts, as_github_repository, full_name)
+                impl_property!(contexts, as_github_repository, full_name)
             }
             ("GitHubRepository", "lastModified") => {
-                impl_property!(data_contexts, as_github_repository, updated_at)
+                impl_property!(contexts, as_github_repository, updated_at)
             }
 
             // properties on GitHubWorkflow
-            ("GitHubWorkflow", "name") => impl_property!(data_contexts, as_github_workflow, wf, {
+            ("GitHubWorkflow", "name") => impl_property!(contexts, as_github_workflow, wf, {
                 wf.workflow.name.as_str().into()
             }),
-            ("GitHubWorkflow", "path") => impl_property!(data_contexts, as_github_workflow, wf, {
+            ("GitHubWorkflow", "path") => impl_property!(contexts, as_github_workflow, wf, {
                 wf.workflow.path.as_str().into()
             }),
 
             // properties on GitHubActionsJob
             ("GitHubActionsJob", "name") => {
-                impl_property!(data_contexts, as_github_actions_job, name)
+                impl_property!(contexts, as_github_actions_job, name)
             }
             ("GitHubActionsJob", "runsOn") => {
-                impl_property!(data_contexts, as_github_actions_job, runs_on)
+                impl_property!(contexts, as_github_actions_job, runs_on)
             }
 
             // properties on GitHubActionsStep and its implementers
             (
                 "GitHubActionsStep" | "GitHubActionsImportedStep" | "GitHubActionsRunStep",
                 "name",
-            ) => impl_property!(data_contexts, as_github_actions_step, step_name, {
+            ) => impl_property!(contexts, as_github_actions_step, step_name, {
                 step_name.map(|x| x.to_string()).into()
             }),
 
             // properties on GitHubActionsImportedStep
             ("GitHubActionsImportedStep", "uses") => {
-                impl_property!(data_contexts, as_github_actions_imported_step, uses)
+                impl_property!(contexts, as_github_actions_imported_step, uses)
             }
 
             // properties on GitHubActionsRunStep
             ("GitHubActionsRunStep", "run") => {
-                impl_property!(data_contexts, as_github_actions_run_step, run)
+                impl_property!(contexts, as_github_actions_run_step, run)
             }
 
             // properties on NameValuePair
-            ("NameValuePair", "name") => impl_property!(data_contexts, as_name_value_pair, pair, {
+            ("NameValuePair", "name") => impl_property!(contexts, as_name_value_pair, pair, {
                 pair.0.clone().into()
             }),
             ("NameValuePair", "value") => {
-                impl_property!(data_contexts, as_name_value_pair, pair, {
+                impl_property!(contexts, as_name_value_pair, pair, {
                     pair.1.clone().into()
                 })
             }
@@ -368,23 +370,16 @@ impl Adapter<'static> for DemoAdapter {
 
     fn resolve_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         edge_name: Arc<str>,
         _parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
         _edge_hint: Eid,
-    ) -> Box<
-        dyn Iterator<
-            Item = (
-                DataContext<Self::Vertex>,
-                Box<dyn Iterator<Item = Self::Vertex>>,
-            ),
-        >,
-    > {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {
-            ("HackerNewsStory", "byUser") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsStory", "byUser") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -407,7 +402,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsStory", "comment") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsStory", "comment") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -442,7 +437,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsStory", "link") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsStory", "link") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -460,7 +455,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsJob", "link") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsJob", "link") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -477,7 +472,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsComment", "byUser") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsComment", "byUser") => Box::new(contexts.map(|ctx| {
                 let token = &ctx.current_token;
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -500,7 +495,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsComment", "parent") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsComment", "parent") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -524,7 +519,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsComment", "topmostAncestor") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsComment", "topmostAncestor") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -561,7 +556,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsComment", "reply") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsComment", "reply") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -593,7 +588,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("HackerNewsUser", "submitted") => Box::new(data_contexts.map(|ctx| {
+            ("HackerNewsUser", "submitted") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -618,7 +613,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("Crate", "repository") => Box::new(data_contexts.map(|ctx| {
+            ("Crate", "repository") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -636,7 +631,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("GitHubRepository", "workflows") => Box::new(data_contexts.map(|ctx| {
+            ("GitHubRepository", "workflows") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -649,7 +644,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("GitHubWorkflow", "jobs") => Box::new(data_contexts.map(|ctx| {
+            ("GitHubWorkflow", "jobs") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -670,7 +665,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("GitHubActionsJob", "step") => Box::new(data_contexts.map(|ctx| {
+            ("GitHubActionsJob", "step") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -680,7 +675,7 @@ impl Adapter<'static> for DemoAdapter {
 
                 (ctx, neighbors)
             })),
-            ("GitHubActionsRunStep", "env") => Box::new(data_contexts.map(|ctx| {
+            ("GitHubActionsRunStep", "env") => Box::new(contexts.map(|ctx| {
                 let token = ctx.current_token.clone();
                 let neighbors: Box<dyn Iterator<Item = Self::Vertex>> = match token {
                     None => Box::new(std::iter::empty()),
@@ -696,13 +691,13 @@ impl Adapter<'static> for DemoAdapter {
 
     fn resolve_coercion(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
-        let iterator = data_contexts.map(move |ctx| {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
+        let iterator = contexts.map(move |ctx| {
             let token = match &ctx.current_token {
                 Some(t) => t,
                 None => return (ctx, false),

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -164,7 +164,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     }
 
     #[allow(clippy::type_complexity)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         type_name: Arc<str>,

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -73,8 +73,8 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> VertexIterator<'a, Self::Vertex> {
@@ -106,14 +106,14 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'a, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         match type_name.as_ref() {
             "MetarReport" => {
-                match field_name.as_ref() {
+                match property_name.as_ref() {
                     // TODO: implement __typename
                     "stationId" => non_float_field!(contexts, Token::MetarReport, station_id),
                     "rawReport" => non_float_field!(contexts, Token::MetarReport, raw_report),
@@ -152,7 +152,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
                 }
             }
             "MetarCloudCover" => {
-                match field_name.as_ref() {
+                match property_name.as_ref() {
                     // TODO: implement __typename
                     "skyCover" => non_float_field!(contexts, Token::CloudCover, sky_cover),
                     "baseAltitude" => {
@@ -168,9 +168,9 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'a, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
         _edge_hint: Eid,
@@ -200,8 +200,8 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'a, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -201,7 +201,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         &mut self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -101,15 +101,15 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         }
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'a> {
-        match current_type_name.as_ref() {
+        match type_name.as_ref() {
             "MetarReport" => {
                 match field_name.as_ref() {
                     // TODO: implement __typename
@@ -167,7 +167,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
@@ -181,7 +181,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
                 ),
             > + 'a,
     > {
-        match (current_type_name.as_ref(), edge_name.as_ref()) {
+        match (type_name.as_ref(), edge_name.as_ref()) {
             ("MetarReport", "cloudCover") => {
                 assert!(parameters.is_none());
 
@@ -207,7 +207,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -204,7 +204,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     }
 
     #[allow(unused_variables)]
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         type_name: Arc<str>,

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -67,7 +67,7 @@ macro_rules! float_field {
 }
 
 impl<'a> Adapter<'a> for MetarAdapter<'a> {
-    type DataToken = Token<'a>;
+    type Vertex = Token<'a>;
 
     fn get_starting_tokens(
         &mut self,
@@ -75,7 +75,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken> + 'a> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'a> {
         match edge.as_ref() {
             "MetarReport" => Box::new(self.data.iter().map(|x| x.into())),
             "LatestMetarReportForAirport" => {
@@ -103,12 +103,12 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'a>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)> + 'a> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'a> {
         match current_type_name.as_ref() {
             "MetarReport" => {
                 match field_name.as_ref() {
@@ -166,7 +166,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     #[allow(clippy::type_complexity)]
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'a>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -176,8 +176,8 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     ) -> Box<
         dyn Iterator<
                 Item = (
-                    DataContext<Self::DataToken>,
-                    Box<dyn Iterator<Item = Self::DataToken> + 'a>,
+                    DataContext<Self::Vertex>,
+                    Box<dyn Iterator<Item = Self::Vertex> + 'a>,
                 ),
             > + 'a,
     > {
@@ -186,7 +186,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
                 assert!(parameters.is_none());
 
                 Box::new(data_contexts.map(|ctx| {
-                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                    let neighbors: Box<dyn Iterator<Item = Self::Vertex> + 'a> =
                         match &ctx.current_token {
                             Some(token) => match token {
                                 &Token::MetarReport(metar) => {
@@ -206,12 +206,12 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     #[allow(unused_variables)]
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'a>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)> + 'a> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'a> {
         todo!()
     }
 }

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -69,14 +69,14 @@ macro_rules! float_field {
 impl<'a> Adapter<'a> for MetarAdapter<'a> {
     type Vertex = Token<'a>;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = Self::Vertex> + 'a> {
-        match edge.as_ref() {
+        match edge_name.as_ref() {
             "MetarReport" => Box::new(self.data.iter().map(|x| x.into())),
             "LatestMetarReportForAirport" => {
                 let station_code = match parameters

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -547,10 +547,10 @@ export class MyAdapter implements Adapter<Vertex> {
   *canCoerceToType(
     contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
-    coerce_to_type_name: string
+    coerce_to_type: string
   ): IterableIterator<ContextAndBool> {
     if (type_name === 'Item' || type_name === 'Webpage') {
-      if (coerce_to_type_name === 'Item') {
+      if (coerce_to_type === 'Item') {
         // The Item type is abstract, we need to check if the vertex is any of the Item subtypes.
         for (const ctx of contexts) {
           const vertex = ctx.currentToken;
@@ -565,12 +565,12 @@ export class MyAdapter implements Adapter<Vertex> {
           const vertex = ctx.currentToken;
           yield {
             localId: ctx.localId,
-            value: vertex?.__typename === coerce_to_type_name,
+            value: vertex?.__typename === coerce_to_type,
           };
         }
       }
     } else {
-      throw new Error(`Unexpected coercion from ${type_name} to ${coerce_to_type_name}`);
+      throw new Error(`Unexpected coercion from ${type_name} to ${coerce_to_type}`);
     }
   }
 }

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -259,12 +259,12 @@ export class MyAdapter implements Adapter<Vertex> {
   }
 
   *projectProperty(
-    data_contexts: IterableIterator<JsContext<Vertex>>,
+    contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
     field_name: string
   ): IterableIterator<ContextAndValue> {
     if (field_name === '__typename') {
-      for (const ctx of data_contexts) {
+      for (const ctx of contexts) {
         yield {
           localId: ctx.localId,
           value: ctx.currentToken?.__typename || null,
@@ -281,7 +281,7 @@ export class MyAdapter implements Adapter<Vertex> {
     ) {
       switch (field_name) {
         case 'url': {
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
 
             let value = null;
@@ -299,7 +299,7 @@ export class MyAdapter implements Adapter<Vertex> {
         case 'textPlain': {
           const fieldKey = HNItemFieldMappings.textHtml;
 
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
 
             let value = null;
@@ -320,7 +320,7 @@ export class MyAdapter implements Adapter<Vertex> {
             throw new Error(`Unexpected property for type ${type_name}: ${field_name}`);
           }
 
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
 
             yield {
@@ -333,7 +333,7 @@ export class MyAdapter implements Adapter<Vertex> {
     } else if (type_name === 'User') {
       switch (field_name) {
         case 'url': {
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
 
             let value = null;
@@ -351,7 +351,7 @@ export class MyAdapter implements Adapter<Vertex> {
         case 'aboutPlain': {
           const fieldKey = HNUserFieldMappings.aboutHtml;
 
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
 
             let value = null;
@@ -372,7 +372,7 @@ export class MyAdapter implements Adapter<Vertex> {
             throw new Error(`Unexpected property for type ${type_name}: ${field_name}`);
           }
 
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
             yield {
               localId: ctx.localId,
@@ -383,7 +383,7 @@ export class MyAdapter implements Adapter<Vertex> {
       }
     } else if (type_name === 'Webpage') {
       if (field_name === 'url') {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           yield {
             localId: ctx.localId,
@@ -399,7 +399,7 @@ export class MyAdapter implements Adapter<Vertex> {
   }
 
   *projectNeighbors(
-    data_contexts: IterableIterator<JsContext<Vertex>>,
+    contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
     edge_name: string,
     parameters: JsEdgeParameters
@@ -413,7 +413,7 @@ export class MyAdapter implements Adapter<Vertex> {
         if (type_name === 'Story') {
           // Link submission stories have the submitted URL as a link.
           // Text submission stories can have multiple links in the text.
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
             let neighbors: IterableIterator<Vertex>;
             if (vertex) {
@@ -439,7 +439,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
         } else if (type_name === 'Comment') {
           // Comments can only have links in their text content.
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
             let neighbors: IterableIterator<Vertex>;
             if (vertex) {
@@ -454,7 +454,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
         } else if (type_name === 'Job') {
           // Jobs only have the submitted URL as a link.
-          for (const ctx of data_contexts) {
+          for (const ctx of contexts) {
             const vertex = ctx.currentToken;
             let neighbors: IterableIterator<Vertex> = [][Symbol.iterator]();
             if (vertex) {
@@ -472,7 +472,7 @@ export class MyAdapter implements Adapter<Vertex> {
           throw new Error(`Not implemented: ${type_name} ${edge_name} ${parameters}`);
         }
       } else if (edge_name === 'byUser') {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           if (vertex) {
             yield {
@@ -487,7 +487,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
         }
       } else if (edge_name === 'comment' || edge_name === 'reply') {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           yield {
             localId: ctx.localId,
@@ -495,7 +495,7 @@ export class MyAdapter implements Adapter<Vertex> {
           };
         }
       } else if (edge_name === 'parent') {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           const parent = vertex?.parent;
           if (parent) {
@@ -515,7 +515,7 @@ export class MyAdapter implements Adapter<Vertex> {
       }
     } else if (type_name === 'User') {
       if (edge_name === 'submitted') {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           const submitted = vertex?.submitted;
           yield {
@@ -524,7 +524,7 @@ export class MyAdapter implements Adapter<Vertex> {
           };
         }
       } else if (edge_name === 'link') {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           let neighbors: IterableIterator<Vertex> = [][Symbol.iterator]();
           const aboutHtml = vertex?.about;
@@ -545,14 +545,14 @@ export class MyAdapter implements Adapter<Vertex> {
   }
 
   *canCoerceToType(
-    data_contexts: IterableIterator<JsContext<Vertex>>,
+    contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
     coerce_to_type_name: string
   ): IterableIterator<ContextAndBool> {
     if (type_name === 'Item' || type_name === 'Webpage') {
       if (coerce_to_type_name === 'Item') {
         // The Item type is abstract, we need to check if the vertex is any of the Item subtypes.
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           const type = vertex?.__typename;
           yield {
@@ -561,7 +561,7 @@ export class MyAdapter implements Adapter<Vertex> {
           };
         }
       } else {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const vertex = ctx.currentToken;
           yield {
             localId: ctx.localId,

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -260,7 +260,7 @@ export class MyAdapter implements Adapter<Vertex> {
 
   *projectProperty(
     data_contexts: IterableIterator<JsContext<Vertex>>,
-    current_type_name: string,
+    type_name: string,
     field_name: string
   ): IterableIterator<ContextAndValue> {
     if (field_name === '__typename') {
@@ -274,10 +274,10 @@ export class MyAdapter implements Adapter<Vertex> {
     }
 
     if (
-      current_type_name === 'Item' ||
-      current_type_name === 'Story' ||
-      current_type_name === 'Job' ||
-      current_type_name === 'Comment'
+      type_name === 'Item' ||
+      type_name === 'Story' ||
+      type_name === 'Job' ||
+      type_name === 'Comment'
     ) {
       switch (field_name) {
         case 'url': {
@@ -317,7 +317,7 @@ export class MyAdapter implements Adapter<Vertex> {
         default: {
           const fieldKey = HNItemFieldMappings[field_name];
           if (fieldKey == undefined) {
-            throw new Error(`Unexpected property for type ${current_type_name}: ${field_name}`);
+            throw new Error(`Unexpected property for type ${type_name}: ${field_name}`);
           }
 
           for (const ctx of data_contexts) {
@@ -330,7 +330,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
         }
       }
-    } else if (current_type_name === 'User') {
+    } else if (type_name === 'User') {
       switch (field_name) {
         case 'url': {
           for (const ctx of data_contexts) {
@@ -369,7 +369,7 @@ export class MyAdapter implements Adapter<Vertex> {
         default: {
           const fieldKey = HNUserFieldMappings[field_name];
           if (fieldKey == undefined) {
-            throw new Error(`Unexpected property for type ${current_type_name}: ${field_name}`);
+            throw new Error(`Unexpected property for type ${type_name}: ${field_name}`);
           }
 
           for (const ctx of data_contexts) {
@@ -381,7 +381,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
         }
       }
-    } else if (current_type_name === 'Webpage') {
+    } else if (type_name === 'Webpage') {
       if (field_name === 'url') {
         for (const ctx of data_contexts) {
           const vertex = ctx.currentToken;
@@ -391,26 +391,26 @@ export class MyAdapter implements Adapter<Vertex> {
           };
         }
       } else {
-        throw new Error(`Unexpected property: ${current_type_name} ${field_name}`);
+        throw new Error(`Unexpected property: ${type_name} ${field_name}`);
       }
     } else {
-      throw new Error(`Unexpected type+property for type ${current_type_name}: ${field_name}`);
+      throw new Error(`Unexpected type+property for type ${type_name}: ${field_name}`);
     }
   }
 
   *projectNeighbors(
     data_contexts: IterableIterator<JsContext<Vertex>>,
-    current_type_name: string,
+    type_name: string,
     edge_name: string,
     parameters: JsEdgeParameters
   ): IterableIterator<ContextAndNeighborsIterator<Vertex>> {
     if (
-      current_type_name === 'Story' ||
-      current_type_name === 'Job' ||
-      current_type_name === 'Comment'
+      type_name === 'Story' ||
+      type_name === 'Job' ||
+      type_name === 'Comment'
     ) {
       if (edge_name === 'link') {
-        if (current_type_name === 'Story') {
+        if (type_name === 'Story') {
           // Link submission stories have the submitted URL as a link.
           // Text submission stories can have multiple links in the text.
           for (const ctx of data_contexts) {
@@ -437,7 +437,7 @@ export class MyAdapter implements Adapter<Vertex> {
               neighbors,
             };
           }
-        } else if (current_type_name === 'Comment') {
+        } else if (type_name === 'Comment') {
           // Comments can only have links in their text content.
           for (const ctx of data_contexts) {
             const vertex = ctx.currentToken;
@@ -452,7 +452,7 @@ export class MyAdapter implements Adapter<Vertex> {
               neighbors,
             };
           }
-        } else if (current_type_name === 'Job') {
+        } else if (type_name === 'Job') {
           // Jobs only have the submitted URL as a link.
           for (const ctx of data_contexts) {
             const vertex = ctx.currentToken;
@@ -469,7 +469,7 @@ export class MyAdapter implements Adapter<Vertex> {
             };
           }
         } else {
-          throw new Error(`Not implemented: ${current_type_name} ${edge_name} ${parameters}`);
+          throw new Error(`Not implemented: ${type_name} ${edge_name} ${parameters}`);
         }
       } else if (edge_name === 'byUser') {
         for (const ctx of data_contexts) {
@@ -511,9 +511,9 @@ export class MyAdapter implements Adapter<Vertex> {
           }
         }
       } else {
-        throw new Error(`Not implemented: ${current_type_name} ${edge_name} ${parameters}`);
+        throw new Error(`Not implemented: ${type_name} ${edge_name} ${parameters}`);
       }
-    } else if (current_type_name === 'User') {
+    } else if (type_name === 'User') {
       if (edge_name === 'submitted') {
         for (const ctx of data_contexts) {
           const vertex = ctx.currentToken;
@@ -537,19 +537,19 @@ export class MyAdapter implements Adapter<Vertex> {
           };
         }
       } else {
-        throw new Error(`Not implemented: ${current_type_name} ${edge_name} ${parameters}`);
+        throw new Error(`Not implemented: ${type_name} ${edge_name} ${parameters}`);
       }
     } else {
-      throw new Error(`Not implemented: ${current_type_name} ${edge_name} ${parameters}`);
+      throw new Error(`Not implemented: ${type_name} ${edge_name} ${parameters}`);
     }
   }
 
   *canCoerceToType(
     data_contexts: IterableIterator<JsContext<Vertex>>,
-    current_type_name: string,
+    type_name: string,
     coerce_to_type_name: string
   ): IterableIterator<ContextAndBool> {
-    if (current_type_name === 'Item' || current_type_name === 'Webpage') {
+    if (type_name === 'Item' || type_name === 'Webpage') {
       if (coerce_to_type_name === 'Item') {
         // The Item type is abstract, we need to check if the vertex is any of the Item subtypes.
         for (const ctx of data_contexts) {
@@ -570,7 +570,7 @@ export class MyAdapter implements Adapter<Vertex> {
         }
       }
     } else {
-      throw new Error(`Unexpected coercion from ${current_type_name} to ${coerce_to_type_name}`);
+      throw new Error(`Unexpected coercion from ${type_name} to ${coerce_to_type_name}`);
     }
   }
 }

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -584,7 +584,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         }
     }
 
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         type_name: Arc<str>,
@@ -634,7 +634,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, neighbors)
                 })),
                 _ => {
-                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
+                    unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "Crate" => {
@@ -693,7 +693,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
 
                         (ctx, neighbors)
                     })),
-                    _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
+                    _ => unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}"),
                 }
             }
             "Importable" | "ImplOwner" | "Struct" | "Enum" | "Trait" | "Function"
@@ -767,7 +767,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                             (ctx, neighbors)
                         }))
                     }
-                    _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
+                    _ => unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}"),
                 }
             }
             "Item" | "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant"
@@ -810,7 +810,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
 
                         (ctx, neighbors)
                     })),
-                    _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
+                    _ => unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}"),
                 }
             }
             "ImplOwner" | "Struct" | "Enum"
@@ -899,7 +899,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     }))
                 }
                 _ => {
-                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
+                    unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "Enum" => match edge_name.as_ref() {
@@ -935,7 +935,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     }))
                 }
                 _ => {
-                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
+                    unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "StructField" => match edge_name.as_ref() {
@@ -955,7 +955,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, neighbors)
                 })),
                 _ => {
-                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
+                    unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "Impl" => match edge_name.as_ref() {
@@ -1080,7 +1080,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     }))
                 }
                 _ => {
-                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
+                    unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "ImplementedTrait" => match edge_name.as_ref() {
@@ -1101,10 +1101,10 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, neighbors)
                 })),
                 _ => {
-                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
+                    unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
-            _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
+            _ => unreachable!("resolve_neighbors {type_name} {edge_name} {parameters:?}"),
         }
     }
 

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -1108,7 +1108,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         }
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
         type_name: Arc<str>,
@@ -1148,7 +1148,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, can_coerce)
                 }))
             }
-            _ => unreachable!("can_coerce_to_type {type_name} {coerce_to_type_name}"),
+            _ => unreachable!("resolve_coercion {type_name} {coerce_to_type_name}"),
         }
     }
 }

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -492,10 +492,10 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         }
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
@@ -509,7 +509,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 None => (ctx, FieldValue::Null),
             }))
         } else {
-            match current_type_name.as_ref() {
+            match type_name.as_ref() {
                 "Crate" => {
                     Box::new(data_contexts.map(move |ctx| {
                         property_mapper(ctx, field_name.as_ref(), get_crate_property)
@@ -579,7 +579,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         property_mapper(ctx, field_name.as_ref(), get_raw_type_property)
                     }))
                 }
-                _ => unreachable!("project_property {current_type_name} {field_name}"),
+                _ => unreachable!("resolve_property {type_name} {field_name}"),
             }
         }
     }
@@ -587,7 +587,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
@@ -601,7 +601,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 ),
             > + 'a,
     > {
-        match current_type_name.as_ref() {
+        match type_name.as_ref() {
             "CrateDiff" => match edge_name.as_ref() {
                 "current" => Box::new(data_contexts.map(move |ctx| {
                     let neighbors: Box<dyn Iterator<Item = Self::Vertex> + 'a> = match &ctx
@@ -634,7 +634,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, neighbors)
                 })),
                 _ => {
-                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "Crate" => {
@@ -693,9 +693,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
 
                         (ctx, neighbors)
                     })),
-                    _ => unreachable!(
-                        "project_neighbors {current_type_name} {edge_name} {parameters:?}"
-                    ),
+                    _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
                 }
             }
             "Importable" | "ImplOwner" | "Struct" | "Enum" | "Trait" | "Function"
@@ -769,9 +767,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                             (ctx, neighbors)
                         }))
                     }
-                    _ => unreachable!(
-                        "project_neighbors {current_type_name} {edge_name} {parameters:?}"
-                    ),
+                    _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
                 }
             }
             "Item" | "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant"
@@ -814,9 +810,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
 
                         (ctx, neighbors)
                     })),
-                    _ => unreachable!(
-                        "project_neighbors {current_type_name} {edge_name} {parameters:?}"
-                    ),
+                    _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
                 }
             }
             "ImplOwner" | "Struct" | "Enum"
@@ -905,7 +899,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     }))
                 }
                 _ => {
-                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "Enum" => match edge_name.as_ref() {
@@ -941,7 +935,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     }))
                 }
                 _ => {
-                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "StructField" => match edge_name.as_ref() {
@@ -961,7 +955,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, neighbors)
                 })),
                 _ => {
-                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "Impl" => match edge_name.as_ref() {
@@ -1086,7 +1080,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     }))
                 }
                 _ => {
-                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
             "ImplementedTrait" => match edge_name.as_ref() {
@@ -1107,22 +1101,22 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, neighbors)
                 })),
                 _ => {
-                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                    unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}")
                 }
             },
-            _ => unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}"),
+            _ => unreachable!("project_neighbors {type_name} {edge_name} {parameters:?}"),
         }
     }
 
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'a>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'a> {
-        match current_type_name.as_ref() {
+        match type_name.as_ref() {
             "Item" | "Variant" | "FunctionLike" | "Importable" | "ImplOwner" | "RawType"
             | "ResolvedPathType" => {
                 Box::new(data_contexts.map(move |ctx| {
@@ -1154,7 +1148,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, can_coerce)
                 }))
             }
-            _ => unreachable!("can_coerce_to_type {current_type_name} {coerce_to_type_name}"),
+            _ => unreachable!("can_coerce_to_type {type_name} {coerce_to_type_name}"),
         }
     }
 }

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -963,7 +963,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                 };
 
                                 let impl_token = token.as_impl().expect("not an Impl token");
-                                let provided_methods: Box<dyn Iterator<Item = &Id>> = if impl_token
+                                let provided_methods: VertexIterator<'a, &Id> = if impl_token
                                     .provided_trait_methods
                                     .is_empty()
                                 {

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -1093,7 +1093,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         &mut self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
@@ -1106,7 +1106,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         Some(token) => {
                             let actual_type_name = token.typename();
 
-                            match coerce_to_type_name.as_ref() {
+                            match coerce_to_type.as_ref() {
                                 "Variant" => matches!(
                                     actual_type_name,
                                     "PlainVariant" | "TupleVariant" | "StructVariant"
@@ -1120,7 +1120,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     // The remaining types are final (don't have any subtypes)
                                     // so we can just compare the actual type name to
                                     // the type we are attempting to coerce to.
-                                    actual_type_name == coerce_to_type_name.as_ref()
+                                    actual_type_name == coerce_to_type.as_ref()
                                 }
                             }
                         }
@@ -1129,7 +1129,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     (ctx, can_coerce)
                 }))
             }
-            _ => unreachable!("resolve_coercion {type_name} {coerce_to_type_name}"),
+            _ => unreachable!("resolve_coercion {type_name} {coerce_to_type}"),
         }
     }
 }

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -469,14 +469,14 @@ fn property_mapper<'a>(
 impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     type Vertex = Token<'a>;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         _parameters: Option<Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = Self::Vertex> + 'a> {
-        match edge.as_ref() {
+        match edge_name.as_ref() {
             "Crate" => Box::new(std::iter::once(Token::new_crate(
                 Origin::CurrentCrate,
                 self.current_crate,
@@ -488,7 +488,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     kind: TokenKind::CrateDiff((self.current_crate, previous_crate)),
                 }))
             }
-            _ => unreachable!("{edge}"),
+            _ => unreachable!("{edge_name}"),
         }
     }
 

--- a/pytrustfall/demo.ipynb
+++ b/pytrustfall/demo.ipynb
@@ -45,7 +45,7 @@
     "            max_value = parameters[\"max\"]\n",
     "            yield from range(0, max_value)\n",
     "        except Exception as e:\n",
-    "            print(\"get_starting_tokens error\", e)\n",
+    "            print(\"resolve_starting_vertices error\", e)\n",
     "            raise\n",
     "    \n",
     "    def resolve_property(\n",

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -264,11 +264,11 @@ impl BasicAdapter<'static> for AdapterShim {
 
     fn resolve_property(
         &mut self,
-        data_contexts: BaseContextIterator<'static, Self::Vertex>,
+        contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &str,
         property_name: &str,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
-        let contexts = ContextIterator::new(data_contexts);
+        let contexts = ContextIterator::new(contexts);
         Python::with_gil(|py| {
             let py_iterable = self
                 .adapter
@@ -287,12 +287,12 @@ impl BasicAdapter<'static> for AdapterShim {
 
     fn resolve_neighbors(
         &mut self,
-        data_contexts: BaseContextIterator<'static, Self::Vertex>,
+        contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
         parameters: Option<&EdgeParameters>,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
-        let contexts = ContextIterator::new(data_contexts);
+        let contexts = ContextIterator::new(contexts);
         Python::with_gil(|py| {
             let parameter_data: Option<BTreeMap<String, Py<PyAny>>> = parameters.map(|x| {
                 x.0.iter()
@@ -317,11 +317,11 @@ impl BasicAdapter<'static> for AdapterShim {
 
     fn resolve_coercion(
         &mut self,
-        data_contexts: BaseContextIterator<'static, Self::Vertex>,
+        contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &str,
         coerce_to_type: &str,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
-        let contexts = ContextIterator::new(data_contexts);
+        let contexts = ContextIterator::new(contexts);
         Python::with_gil(|py| {
             let py_iterable = self
                 .adapter
@@ -431,7 +431,6 @@ impl PythonProjectNeighborsIterator {
 }
 
 impl Iterator for PythonProjectNeighborsIterator {
-    #[allow(clippy::type_complexity)]
     type Item = (
         DataContext<Arc<Py<PyAny>>>,
         Box<dyn Iterator<Item = Arc<Py<PyAny>>>>,

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -5,12 +5,9 @@ use pyo3::{exceptions::PyStopIteration, prelude::*, wrap_pyfunction};
 use trustfall_core::{
     frontend::{error::FrontendError, parse},
     interpreter::{
-        basic_adapter::{
-            BasicAdapter, ContextIterator as BaseContextIterator, ContextOutcomeIterator,
-            VertexIterator,
-        },
-        execution::interpret_ir,
-        DataContext,
+        basic_adapter::BasicAdapter, execution::interpret_ir,
+        ContextIterator as BaseContextIterator, ContextOutcomeIterator, DataContext,
+        VertexIterator,
     },
     ir::{EdgeParameters, FieldValue},
 };

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -214,10 +214,10 @@ impl Context {
 }
 
 #[pyclass(unsendable)]
-pub struct ContextIterator(Box<dyn Iterator<Item = Context>>);
+pub struct ContextIterator(VertexIterator<'static, Context>);
 
 impl ContextIterator {
-    fn new(inner: Box<dyn Iterator<Item = DataContext<Arc<Py<PyAny>>>>>) -> Self {
+    fn new(inner: VertexIterator<'static, DataContext<Arc<Py<PyAny>>>>) -> Self {
         Self(Box::new(inner.map(Context)))
     }
 }
@@ -433,7 +433,7 @@ impl PythonProjectNeighborsIterator {
 impl Iterator for PythonProjectNeighborsIterator {
     type Item = (
         DataContext<Arc<Py<PyAny>>>,
-        Box<dyn Iterator<Item = Arc<Py<PyAny>>>>,
+        VertexIterator<'static, Arc<Py<PyAny>>>,
     );
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -454,7 +454,7 @@ impl Iterator for PythonProjectNeighborsIterator {
                     // Iterators return self when __iter__() is called.
                     let neighbors_iter = make_iterator(py, neighbors_iterable).unwrap();
 
-                    let neighbors: Box<dyn Iterator<Item = Arc<Py<PyAny>>>> =
+                    let neighbors: VertexIterator<'static, Arc<Py<PyAny>>> =
                         Box::new(PythonTokenIterator::new(neighbors_iter));
                     Some((context.0, neighbors))
                 }

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -336,7 +336,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     }
 
     #[allow(clippy::type_complexity)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -256,14 +256,14 @@ fn directory_subdirectory_handler(
 impl Adapter<'static> for FilesystemInterpreter {
     type Vertex = FilesystemToken;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = FilesystemToken>> {
-        assert!(edge.as_ref() == "OriginDirectory");
+        assert!(edge_name.as_ref() == "OriginDirectory");
         assert!(parameters.is_none());
         let token = DirectoryToken {
             name: "<origin>".to_owned(),

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -254,7 +254,7 @@ fn directory_subdirectory_handler(
 
 #[allow(unused_variables)]
 impl Adapter<'static> for FilesystemInterpreter {
-    type DataToken = FilesystemToken;
+    type Vertex = FilesystemToken;
 
     fn get_starting_tokens(
         &mut self,
@@ -274,7 +274,7 @@ impl Adapter<'static> for FilesystemInterpreter {
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
@@ -338,7 +338,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     #[allow(clippy::type_complexity)]
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -348,8 +348,8 @@ impl Adapter<'static> for FilesystemInterpreter {
     ) -> Box<
         dyn Iterator<
             Item = (
-                DataContext<Self::DataToken>,
-                Box<dyn Iterator<Item = Self::DataToken>>,
+                DataContext<Self::Vertex>,
+                Box<dyn Iterator<Item = Self::Vertex>>,
             ),
         >,
     > {
@@ -376,12 +376,12 @@ impl Adapter<'static> for FilesystemInterpreter {
 
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
         todo!()
     }
 }

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -372,7 +372,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -272,15 +272,15 @@ impl Adapter<'static> for FilesystemInterpreter {
         Box::new(OriginIterator::new(token))
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = ContextAndValue>> {
-        match current_type_name.as_ref() {
+        match type_name.as_ref() {
             "Directory" => match field_name.as_ref() {
                 "name" => Box::new(data_contexts.map(|context| match context.current_token {
                     None => (context, FieldValue::Null),
@@ -339,7 +339,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
@@ -353,7 +353,7 @@ impl Adapter<'static> for FilesystemInterpreter {
             ),
         >,
     > {
-        match (current_type_name.as_ref(), edge_name.as_ref()) {
+        match (type_name.as_ref(), edge_name.as_ref()) {
             ("Directory", "out_Directory_ContainsFile") => {
                 let iterator: ContextIterator = ContextIterator::new(
                     self.origin.clone(),
@@ -377,7 +377,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -260,8 +260,8 @@ impl Adapter<'static> for FilesystemInterpreter {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'static, Self::Vertex> {
@@ -277,13 +277,13 @@ impl Adapter<'static> for FilesystemInterpreter {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         match type_name.as_ref() {
-            "Directory" => match field_name.as_ref() {
+            "Directory" => match property_name.as_ref() {
                 "name" => Box::new(contexts.map(|context| match context.current_token {
                     None => (context, FieldValue::Null),
                     Some(FilesystemToken::Directory(ref x)) => {
@@ -302,7 +302,7 @@ impl Adapter<'static> for FilesystemInterpreter {
                 })),
                 _ => todo!(),
             },
-            "File" => match field_name.as_ref() {
+            "File" => match property_name.as_ref() {
                 "name" => Box::new(contexts.map(|context| match context.current_token {
                     None => (context, FieldValue::Null),
                     Some(FilesystemToken::File(ref x)) => {
@@ -340,9 +340,9 @@ impl Adapter<'static> for FilesystemInterpreter {
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
@@ -371,8 +371,8 @@ impl Adapter<'static> for FilesystemInterpreter {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -166,22 +166,22 @@ impl Iterator for SubdirectoryIterator {
 pub type ContextAndValue = (DataContext<FilesystemToken>, FieldValue);
 
 type IndividualEdgeResolver =
-    fn(Rc<String>, &FilesystemToken) -> Box<dyn Iterator<Item = FilesystemToken>>;
+    fn(Rc<String>, &FilesystemToken) -> VertexIterator<'static, FilesystemToken>;
 type ContextAndIterableOfEdges = (
     DataContext<FilesystemToken>,
-    Box<dyn Iterator<Item = FilesystemToken>>,
+    VertexIterator<'static, FilesystemToken>,
 );
 
 struct EdgeResolverIterator {
     origin: Rc<String>,
-    contexts: Box<dyn Iterator<Item = DataContext<FilesystemToken>>>,
+    contexts: VertexIterator<'static, DataContext<FilesystemToken>>,
     edge_resolver: IndividualEdgeResolver,
 }
 
 impl EdgeResolverIterator {
     pub fn new(
         origin: Rc<String>,
-        contexts: Box<dyn Iterator<Item = DataContext<FilesystemToken>>>,
+        contexts: VertexIterator<'static, DataContext<FilesystemToken>>,
         edge_resolver: IndividualEdgeResolver,
     ) -> Self {
         Self {
@@ -195,7 +195,7 @@ impl EdgeResolverIterator {
 impl Iterator for EdgeResolverIterator {
     type Item = (
         DataContext<FilesystemToken>,
-        Box<dyn Iterator<Item = FilesystemToken>>,
+        VertexIterator<'static, FilesystemToken>,
     );
 
     fn next(&mut self) -> Option<ContextAndIterableOfEdges> {
@@ -235,7 +235,7 @@ pub struct FileToken {
 fn directory_contains_file_handler(
     origin: Rc<String>,
     token: &FilesystemToken,
-) -> Box<dyn Iterator<Item = FilesystemToken>> {
+) -> VertexIterator<'static, FilesystemToken> {
     let directory_token = match token {
         FilesystemToken::Directory(dir) => dir,
         _ => unreachable!(),
@@ -246,7 +246,7 @@ fn directory_contains_file_handler(
 fn directory_subdirectory_handler(
     origin: Rc<String>,
     token: &FilesystemToken,
-) -> Box<dyn Iterator<Item = FilesystemToken>> {
+) -> VertexIterator<'static, FilesystemToken> {
     let directory_token = match token {
         FilesystemToken::Directory(dir) => dir,
         _ => unreachable!(),

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -374,7 +374,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         }
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -600,7 +600,6 @@ fn make_duplicated_output_names_error(
     vec![FrontendError::MultipleOutputsWithSameName(conflict_info)]
 }
 
-#[allow(clippy::type_complexity)]
 fn check_for_duplicate_output_names(
     maybe_duplicated_outputs: BTreeMap<Arc<str>, Vec<FieldRef>>,
 ) -> Result<BTreeMap<Arc<str>, FieldRef>, BTreeMap<Arc<str>, Vec<FieldRef>>> {
@@ -642,7 +641,7 @@ where
     let mut property_names_by_vertex: BTreeMap<Vid, Vec<Arc<str>>> = Default::default();
 
     // (Vid, property name) -> (property name, property type, nodes that represent the property)
-    #[allow(clippy::type_complexity)]
+
     let mut properties: BTreeMap<
         (Vid, Arc<str>),
         (Arc<str>, &'schema Type, SmallVec<[&'query FieldNode; 1]>),
@@ -920,7 +919,7 @@ fn get_recurse_implicit_coercion(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::type_complexity)]
+
 fn make_vertex<'schema, 'query>(
     schema: &'schema Schema,
     property_names_by_vertex: &BTreeMap<Vid, Vec<Arc<str>>>,
@@ -1018,7 +1017,7 @@ fn make_vertex<'schema, 'query>(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::type_complexity)]
+
 fn fill_in_vertex_data<'schema, 'query, V, E>(
     schema: &'schema Schema,
     query: &'query Query,

--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -600,6 +600,7 @@ fn make_duplicated_output_names_error(
     vec![FrontendError::MultipleOutputsWithSameName(conflict_info)]
 }
 
+#[allow(clippy::type_complexity)]
 fn check_for_duplicate_output_names(
     maybe_duplicated_outputs: BTreeMap<Arc<str>, Vec<FieldRef>>,
 ) -> Result<BTreeMap<Arc<str>, FieldRef>, BTreeMap<Arc<str>, Vec<FieldRef>>> {
@@ -641,7 +642,7 @@ where
     let mut property_names_by_vertex: BTreeMap<Vid, Vec<Arc<str>>> = Default::default();
 
     // (Vid, property name) -> (property name, property type, nodes that represent the property)
-
+    #[allow(clippy::type_complexity)]
     let mut properties: BTreeMap<
         (Vid, Arc<str>),
         (Arc<str>, &'schema Type, SmallVec<[&'query FieldNode; 1]>),
@@ -919,7 +920,7 @@ fn get_recurse_implicit_coercion(
 }
 
 #[allow(clippy::too_many_arguments)]
-
+#[allow(clippy::type_complexity)]
 fn make_vertex<'schema, 'query>(
     schema: &'schema Schema,
     property_names_by_vertex: &BTreeMap<Vid, Vec<Arc<str>>>,
@@ -1017,7 +1018,7 @@ fn make_vertex<'schema, 'query>(
 }
 
 #[allow(clippy::too_many_arguments)]
-
+#[allow(clippy::type_complexity)]
 fn fill_in_vertex_data<'schema, 'query, V, E>(
     schema: &'schema Schema,
     query: &'query Query,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -2,32 +2,9 @@ use std::fmt::Debug;
 
 use crate::ir::{EdgeParameters, Eid, FieldValue, Vid};
 
-use super::{Adapter, DataContext, InterpretedQuery};
-
-/// An iterator of vertices representing data points we are querying.
-pub type VertexIterator<'vertex, VertexT> = Box<dyn Iterator<Item = VertexT> + 'vertex>;
-
-/// An iterator of query contexts: bookkeeping structs we use to build up the query results.
-///
-/// Each context represents a possible result of the query. At each query processing step,
-/// all the contexts at that step have fulfilled all the query conditions thus far.
-///
-/// This type is usually an input to adapter resolver functions. Calling those functions
-/// asks them to resolve a property, edge, or type coercion for the particular vertex
-/// the context is currently processing at that point in the query.
-pub type ContextIterator<'vertex, VertexT> =
-    Box<dyn Iterator<Item = DataContext<VertexT>> + 'vertex>;
-
-/// Iterator of (context, outcome) tuples: the output type of most resolver functions.
-///
-/// Resolver functions produce an output value for each context:
-/// - resolve_property() produces that property's value;
-/// - resolve_neighbors() produces an iterator of neighboring vertices along an edge;
-/// - resolve_coercion() gives a bool representing whether the vertex is of the desired type.
-///
-/// This type lets us write those output types in a slightly more readable way.
-pub type ContextOutcomeIterator<'vertex, VertexT, OutcomeT> =
-    Box<dyn Iterator<Item = (DataContext<VertexT>, OutcomeT)> + 'vertex>;
+use super::{
+    Adapter, ContextIterator, ContextOutcomeIterator, DataContext, InterpretedQuery, VertexIterator,
+};
 
 pub trait BasicAdapter<'vertex> {
     /// The type of vertices in the dataset this adapter queries.
@@ -164,16 +141,16 @@ where
 {
     type Vertex = T::Vertex;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: std::sync::Arc<str>,
+        edge_name: std::sync::Arc<str>,
         parameters: Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = Self::Vertex> + 'token> {
         <Self as BasicAdapter>::resolve_starting_vertices(
             self,
-            edge.as_ref(),
+            edge_name.as_ref(),
             parameters.as_deref(),
         )
     }

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -155,10 +155,10 @@ where
         )
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: std::sync::Arc<str>,
+        type_name: std::sync::Arc<str>,
         field_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
@@ -166,7 +166,7 @@ where
         <Self as BasicAdapter>::resolve_property(
             self,
             contexts,
-            current_type_name.as_ref(),
+            type_name.as_ref(),
             field_name.as_ref(),
         )
     }
@@ -174,7 +174,7 @@ where
     fn project_neighbors(
         &mut self,
         contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: std::sync::Arc<str>,
+        type_name: std::sync::Arc<str>,
         edge_name: std::sync::Arc<str>,
         parameters: Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
@@ -191,7 +191,7 @@ where
         <Self as BasicAdapter>::resolve_neighbors(
             self,
             contexts,
-            current_type_name.as_ref(),
+            type_name.as_ref(),
             edge_name.as_ref(),
             parameters.as_deref(),
         )
@@ -200,7 +200,7 @@ where
     fn can_coerce_to_type(
         &mut self,
         contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: std::sync::Arc<str>,
+        type_name: std::sync::Arc<str>,
         coerce_to_type_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
@@ -208,7 +208,7 @@ where
         <Self as BasicAdapter>::resolve_coercion(
             self,
             contexts,
-            current_type_name.as_ref(),
+            type_name.as_ref(),
             coerce_to_type_name.as_ref(),
         )
     }

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -162,7 +162,7 @@ impl<'token, T> Adapter<'token> for T
 where
     T: BasicAdapter<'token>,
 {
-    type DataToken = T::Vertex;
+    type Vertex = T::Vertex;
 
     fn get_starting_tokens(
         &mut self,
@@ -170,7 +170,7 @@ where
         parameters: Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken> + 'token> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'token> {
         <Self as BasicAdapter>::resolve_starting_vertices(
             self,
             edge.as_ref(),
@@ -180,12 +180,12 @@ where
 
     fn project_property(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'token>,
+        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         current_type_name: std::sync::Arc<str>,
         field_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)> + 'token> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'token> {
         <Self as BasicAdapter>::resolve_property(
             self,
             contexts,
@@ -196,7 +196,7 @@ where
 
     fn project_neighbors(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'token>,
+        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         current_type_name: std::sync::Arc<str>,
         edge_name: std::sync::Arc<str>,
         parameters: Option<std::sync::Arc<EdgeParameters>>,
@@ -206,8 +206,8 @@ where
     ) -> Box<
         dyn Iterator<
                 Item = (
-                    DataContext<Self::DataToken>,
-                    Box<dyn Iterator<Item = Self::DataToken> + 'token>,
+                    DataContext<Self::Vertex>,
+                    Box<dyn Iterator<Item = Self::Vertex> + 'token>,
                 ),
             > + 'token,
     > {
@@ -222,12 +222,12 @@ where
 
     fn can_coerce_to_type(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'token>,
+        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         current_type_name: std::sync::Arc<str>,
         coerce_to_type_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)> + 'token> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'token> {
         <Self as BasicAdapter>::resolve_coercion(
             self,
             contexts,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -192,7 +192,7 @@ where
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: std::sync::Arc<str>,
-        coerce_to_type_name: std::sync::Arc<str>,
+        coerce_to_type: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool> {
@@ -200,7 +200,7 @@ where
             self,
             contexts,
             type_name.as_ref(),
-            coerce_to_type_name.as_ref(),
+            coerce_to_type.as_ref(),
         )
     }
 }

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -197,7 +197,7 @@ where
         )
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         type_name: std::sync::Arc<str>,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -135,9 +135,9 @@ pub trait BasicAdapter<'vertex> {
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool>;
 }
 
-impl<'token, T> Adapter<'token> for T
+impl<'vertex, T> Adapter<'vertex> for T
 where
-    T: BasicAdapter<'token>,
+    T: BasicAdapter<'vertex>,
 {
     type Vertex = T::Vertex;
 
@@ -147,7 +147,7 @@ where
         parameters: Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'token> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'vertex> {
         <Self as BasicAdapter>::resolve_starting_vertices(
             self,
             edge_name.as_ref(),
@@ -157,12 +157,12 @@ where
 
     fn resolve_property(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
+        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
         type_name: std::sync::Arc<str>,
         field_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'token> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'vertex> {
         <Self as BasicAdapter>::resolve_property(
             self,
             contexts,
@@ -173,7 +173,7 @@ where
 
     fn resolve_neighbors(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
+        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
         type_name: std::sync::Arc<str>,
         edge_name: std::sync::Arc<str>,
         parameters: Option<std::sync::Arc<EdgeParameters>>,
@@ -184,9 +184,9 @@ where
         dyn Iterator<
                 Item = (
                     DataContext<Self::Vertex>,
-                    Box<dyn Iterator<Item = Self::Vertex> + 'token>,
+                    Box<dyn Iterator<Item = Self::Vertex> + 'vertex>,
                 ),
-            > + 'token,
+            > + 'vertex,
     > {
         <Self as BasicAdapter>::resolve_neighbors(
             self,
@@ -199,12 +199,12 @@ where
 
     fn resolve_coercion(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
+        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
         type_name: std::sync::Arc<str>,
         coerce_to_type_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'token> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'vertex> {
         <Self as BasicAdapter>::resolve_coercion(
             self,
             contexts,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -141,8 +141,8 @@ where
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: std::sync::Arc<str>,
-        parameters: Option<std::sync::Arc<EdgeParameters>>,
+        edge_name: &std::sync::Arc<str>,
+        parameters: &Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> VertexIterator<'vertex, Self::Vertex> {
@@ -156,8 +156,8 @@ where
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: std::sync::Arc<str>,
-        field_name: std::sync::Arc<str>,
+        type_name: &std::sync::Arc<str>,
+        property_name: &std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
@@ -165,16 +165,16 @@ where
             self,
             contexts,
             type_name.as_ref(),
-            field_name.as_ref(),
+            property_name.as_ref(),
         )
     }
 
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: std::sync::Arc<str>,
-        edge_name: std::sync::Arc<str>,
-        parameters: Option<std::sync::Arc<EdgeParameters>>,
+        type_name: &std::sync::Arc<str>,
+        edge_name: &std::sync::Arc<str>,
+        parameters: &Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
         _edge_hint: Eid,
@@ -191,8 +191,8 @@ where
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: std::sync::Arc<str>,
-        coerce_to_type: std::sync::Arc<str>,
+        type_name: &std::sync::Arc<str>,
+        coerce_to_type: &std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool> {

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -2,9 +2,7 @@ use std::fmt::Debug;
 
 use crate::ir::{EdgeParameters, Eid, FieldValue, Vid};
 
-use super::{
-    Adapter, ContextIterator, ContextOutcomeIterator, DataContext, InterpretedQuery, VertexIterator,
-};
+use super::{Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator};
 
 pub trait BasicAdapter<'vertex> {
     /// The type of vertices in the dataset this adapter queries.
@@ -147,7 +145,7 @@ where
         parameters: Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'vertex> {
+    ) -> VertexIterator<'vertex, Self::Vertex> {
         <Self as BasicAdapter>::resolve_starting_vertices(
             self,
             edge_name.as_ref(),
@@ -157,12 +155,12 @@ where
 
     fn resolve_property(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: std::sync::Arc<str>,
         field_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'vertex> {
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
         <Self as BasicAdapter>::resolve_property(
             self,
             contexts,
@@ -173,21 +171,14 @@ where
 
     fn resolve_neighbors(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: std::sync::Arc<str>,
         edge_name: std::sync::Arc<str>,
         parameters: Option<std::sync::Arc<EdgeParameters>>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
         _edge_hint: Eid,
-    ) -> Box<
-        dyn Iterator<
-                Item = (
-                    DataContext<Self::Vertex>,
-                    Box<dyn Iterator<Item = Self::Vertex> + 'vertex>,
-                ),
-            > + 'vertex,
-    > {
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>> {
         <Self as BasicAdapter>::resolve_neighbors(
             self,
             contexts,
@@ -199,12 +190,12 @@ where
 
     fn resolve_coercion(
         &mut self,
-        contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: std::sync::Arc<str>,
         coerce_to_type_name: std::sync::Arc<str>,
         _query_hint: InterpretedQuery,
         _vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'vertex> {
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool> {
         <Self as BasicAdapter>::resolve_coercion(
             self,
             contexts,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -171,7 +171,7 @@ where
         )
     }
 
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         type_name: std::sync::Arc<str>,

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -405,7 +405,7 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
     let activated_vertex_iterator: Box<dyn Iterator<Item = DataContext<Vertex>> + 'query> =
         Box::new(iterator.map(move |x| x.activate_token(&expanding_from_vid)));
     let type_name = &expanding_from.type_name;
-    let edge_iterator = adapter_ref.project_neighbors(
+    let edge_iterator = adapter_ref.resolve_neighbors(
         activated_vertex_iterator,
         type_name.clone(),
         fold.edge_name.clone(),
@@ -1033,7 +1033,7 @@ impl<'query, Vertex: Clone + Debug + 'query> Iterator for EdgeExpander<'query, V
         self.ended = true;
 
         // If there's no current token, there couldn't possibly be neighbors.
-        // If this assertion trips, the adapter's project_neighbors() implementation illegally
+        // If this assertion trips, the adapter's resolve_neighbors() implementation illegally
         // returned neighbors for a non-existent vertex.
         if self.context.current_token.is_none() {
             assert!(!self.has_neighbors);
@@ -1118,7 +1118,7 @@ fn expand_non_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
 
     let type_name = &expanding_from.type_name;
     let mut adapter_ref = adapter.borrow_mut();
-    let edge_iterator = adapter_ref.project_neighbors(
+    let edge_iterator = adapter_ref.resolve_neighbors(
         expanding_vertex_iterator,
         type_name.clone(),
         edge_name.clone(),
@@ -1261,7 +1261,7 @@ fn perform_one_recursive_edge_expansion<'query, Vertex: Clone + Debug + 'query>(
     iterator: Box<dyn Iterator<Item = DataContext<Vertex>> + 'query>,
 ) -> Box<dyn Iterator<Item = DataContext<Vertex>> + 'query> {
     let mut adapter_ref = adapter.borrow_mut();
-    let edge_iterator = adapter_ref.project_neighbors(
+    let edge_iterator = adapter_ref.resolve_neighbors(
         iterator,
         expanding_from_type,
         edge_name.clone(),
@@ -1337,7 +1337,7 @@ impl<'query, Vertex: Clone + Debug + 'query> Iterator for RecursiveEdgeExpander<
                 self.neighbors_ended = true;
 
                 // If there's no current token, there couldn't possibly be neighbors.
-                // If this assertion trips, the adapter's project_neighbors() implementation
+                // If this assertion trips, the adapter's resolve_neighbors() implementation
                 // illegally returned neighbors for a non-existent vertex.
                 if let Some(context) = &self.context {
                     if context.current_token.is_none() {

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -95,13 +95,8 @@ where
     Vertex: Clone + Debug + 'query,
 {
     let mut adapter_ref = adapter.borrow_mut();
-    let coercion_iter = adapter_ref.can_coerce_to_type(
-        iterator,
-        coerced_from,
-        coerce_to,
-        query.clone(),
-        vertex.vid,
-    );
+    let coercion_iter =
+        adapter_ref.resolve_coercion(iterator, coerced_from, coerce_to, query.clone(), vertex.vid);
 
     Box::new(coercion_iter.filter_map(
         |(ctx, can_coerce)| {
@@ -1210,7 +1205,7 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
     for _ in 2..=max_depth {
         if let Some(coerce_to) = recursive.coerce_to.as_ref() {
             let mut adapter_ref = adapter.borrow_mut();
-            let coercion_iter = adapter_ref.can_coerce_to_type(
+            let coercion_iter = adapter_ref.resolve_coercion(
                 recursion_iterator,
                 edge_endpoint_type.clone(),
                 coerce_to.clone(),

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -49,8 +49,8 @@ where
     let mut iterator: ContextIterator<'query, Vertex> = Box::new(
         adapter_ref
             .resolve_starting_vertices(
-                root_edge.clone(),
-                root_edge_parameters.clone(),
+                root_edge,
+                root_edge_parameters,
                 query.clone(),
                 ir_query.root_component.root,
             )
@@ -79,8 +79,8 @@ where
             adapter,
             query,
             vertex,
-            coerced_from.clone(),
-            vertex.type_name.clone(),
+            coerced_from,
+            &vertex.type_name,
             iterator,
         ),
     }
@@ -90,8 +90,8 @@ fn perform_coercion<'query, Vertex>(
     adapter: &RefCell<impl Adapter<'query, Vertex = Vertex> + 'query>,
     query: &InterpretedQuery,
     vertex: &IRVertex,
-    coerced_from: Arc<str>,
-    coerce_to: Arc<str>,
+    coerced_from: &Arc<str>,
+    coerce_to: &Arc<str>,
     iterator: ContextIterator<'query, Vertex>,
 ) -> ContextIterator<'query, Vertex>
 where
@@ -223,8 +223,8 @@ fn construct_outputs<'query, Vertex: Clone + Debug + 'query>(
         let mut adapter_ref = adapter.borrow_mut();
         let field_data_iterator = adapter_ref.resolve_property(
             moved_iterator,
-            type_name.clone(),
-            context_field.field_name.clone(),
+            type_name,
+            &context_field.field_name,
             query.clone(),
             vertex_id,
         );
@@ -363,8 +363,8 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
                 let type_name = &field_vertex.type_name;
                 let context_and_value_iterator = adapter_ref.resolve_property(
                     activated_vertex_iterator,
-                    type_name.clone(),
-                    field.field_name.clone(),
+                    type_name,
+                    &field.field_name,
                     query.clone(),
                     field.vertex_id,
                 );
@@ -404,9 +404,9 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
     let type_name = &expanding_from.type_name;
     let edge_iterator = adapter_ref.resolve_neighbors(
         activated_vertex_iterator,
-        type_name.clone(),
-        fold.edge_name.clone(),
-        fold.parameters.clone(),
+        type_name,
+        &fold.edge_name,
+        &fold.parameters,
         query.clone(),
         expanding_from.vid,
         fold.eid,
@@ -545,8 +545,8 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
                 let mut adapter_ref = cloned_adapter.borrow_mut();
                 let field_data_iterator = adapter_ref.resolve_property(
                     moved_iterator,
-                    fold.component.vertices[&vertex_id].type_name.clone(),
-                    context_field.field_name.clone(),
+                    &fold.component.vertices[&vertex_id].type_name,
+                    &context_field.field_name,
                     cloned_query.clone(),
                     vertex_id,
                 );
@@ -915,8 +915,8 @@ fn compute_context_field<'query, Vertex: Clone + Debug + 'query>(
         let mut adapter_ref = adapter.borrow_mut();
         let context_and_value_iterator = adapter_ref.resolve_property(
             Box::new(moved_iterator),
-            type_name.clone(),
-            context_field.field_name.clone(),
+            type_name,
+            &context_field.field_name,
             query.clone(),
             vertex_id,
         );
@@ -969,8 +969,8 @@ fn compute_local_field<'query, Vertex: Clone + Debug + 'query>(
     let mut adapter_ref = adapter.borrow_mut();
     let context_and_value_iterator = adapter_ref.resolve_property(
         iterator,
-        type_name.clone(),
-        local_field.field_name.clone(),
+        type_name,
+        &local_field.field_name,
         query.clone(),
         current_vid,
     );
@@ -1117,9 +1117,9 @@ fn expand_non_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
     let mut adapter_ref = adapter.borrow_mut();
     let edge_iterator = adapter_ref.resolve_neighbors(
         expanding_vertex_iterator,
-        type_name.clone(),
-        edge_name.clone(),
-        edge_parameters.clone(),
+        type_name,
+        edge_name,
+        edge_parameters,
         query.clone(),
         expanding_from.vid,
         edge_id,
@@ -1189,7 +1189,7 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
         adapter.clone(),
         query,
         component,
-        expanding_from.type_name.clone(),
+        &expanding_from.type_name,
         expanding_from,
         expanding_to,
         edge_id,
@@ -1209,8 +1209,8 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
             let mut adapter_ref = adapter.borrow_mut();
             let coercion_iter = adapter_ref.resolve_coercion(
                 recursion_iterator,
-                edge_endpoint_type.clone(),
-                coerce_to.clone(),
+                edge_endpoint_type,
+                coerce_to,
                 query.clone(),
                 expanding_from_vid,
             );
@@ -1231,7 +1231,7 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
             adapter.clone(),
             query,
             component,
-            recursing_from.clone(),
+            recursing_from,
             expanding_from,
             expanding_to,
             edge_id,
@@ -1249,7 +1249,7 @@ fn perform_one_recursive_edge_expansion<'query, Vertex: Clone + Debug + 'query>(
     adapter: Rc<RefCell<impl Adapter<'query, Vertex = Vertex> + 'query>>,
     query: &InterpretedQuery,
     _component: &IRQueryComponent,
-    expanding_from_type: Arc<str>,
+    expanding_from_type: &Arc<str>,
     expanding_from: &IRVertex,
     _expanding_to: &IRVertex,
     edge_id: Eid,
@@ -1261,8 +1261,8 @@ fn perform_one_recursive_edge_expansion<'query, Vertex: Clone + Debug + 'query>(
     let edge_iterator = adapter_ref.resolve_neighbors(
         iterator,
         expanding_from_type,
-        edge_name.clone(),
-        edge_parameters.clone(),
+        edge_name,
+        edge_parameters,
         query.clone(),
         expanding_from.vid,
         edge_id,

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -45,7 +45,7 @@ where
     let mut adapter_ref = adapter.borrow_mut();
     let mut iterator: Box<dyn Iterator<Item = DataContext<Vertex>> + 'query> = Box::new(
         adapter_ref
-            .get_starting_tokens(
+            .resolve_starting_vertices(
                 root_edge.clone(),
                 root_edge_parameters.clone(),
                 query.clone(),

--- a/trustfall_core/src/interpreter/helpers.rs
+++ b/trustfall_core/src/interpreter/helpers.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::ir::FieldValue;
 
-use super::basic_adapter::{ContextIterator, ContextOutcomeIterator, VertexIterator};
+use super::{ContextIterator, ContextOutcomeIterator, VertexIterator};
 
 /// Helper for implementing [`BasicAdapter::resolve_property`] and equivalents.
 ///

--- a/trustfall_core/src/interpreter/helpers.rs
+++ b/trustfall_core/src/interpreter/helpers.rs
@@ -81,7 +81,8 @@ pub fn resolve_coercion_with<'vertex, Vertex: Debug + Clone + 'vertex>(
 /// # use trustfall_core::{
 /// #     field_property,
 /// #     interpreter::{
-/// #         basic_adapter::{ContextIterator, ContextOutcomeIterator},
+/// #         ContextIterator,
+/// #         ContextOutcomeIterator,
 /// #         helpers::resolve_property_with,
 /// #     },
 /// #     ir::FieldValue,
@@ -118,7 +119,8 @@ pub fn resolve_coercion_with<'vertex, Vertex: Debug + Clone + 'vertex>(
 /// # use trustfall_core::{
 /// #     field_property,
 /// #     interpreter::{
-/// #         basic_adapter::{ContextIterator, ContextOutcomeIterator},
+/// #         ContextIterator,
+/// #         ContextOutcomeIterator,
 /// #         helpers::resolve_property_with,
 /// #     },
 /// #     ir::FieldValue,
@@ -212,7 +214,8 @@ macro_rules! field_property {
 /// #     accessor_property,
 /// #     field_property,
 /// #     interpreter::{
-/// #         basic_adapter::{ContextIterator, ContextOutcomeIterator},
+/// #         ContextIterator,
+/// #         ContextOutcomeIterator,
 /// #         helpers::resolve_property_with,
 /// #     },
 /// #     ir::FieldValue,

--- a/trustfall_core/src/interpreter/macros.rs
+++ b/trustfall_core/src/interpreter/macros.rs
@@ -121,7 +121,7 @@ macro_rules! resolve_property {
 macro_rules! neighbor_stub {
     ($ctxs:ident, $lt:lifetime, $token_variant:path $(| $other_variant:path)*, $token:ident, $impl:tt) => {
         Box::new($ctxs.map(move |ctx| {
-            let neighbors: Box<dyn Iterator<Item = <Self as Adapter>::Vertex> + $lt> =
+            let neighbors: VertexIterator<$lt, <Self as Adapter>::Vertex>> =
                 match &ctx.current_token {
                     Some($token_variant($token)) => $impl,
                     $( Some($other_variant($token)) => $impl, )*

--- a/trustfall_core/src/interpreter/macros.rs
+++ b/trustfall_core/src/interpreter/macros.rs
@@ -224,7 +224,7 @@ macro_rules! neighbor_group {
 }
 
 #[macro_export]
-macro_rules! project_neighbors {
+macro_rules! resolve_neighbors {
     ($ctxs:ident, $lt:lifetime, $type_name_var:ident, $edge_name_var:ident,
         [
             $(
@@ -250,7 +250,7 @@ macro_rules! project_neighbors {
 }
 
 #[macro_export]
-macro_rules! project_neighbors2_match_arm {
+macro_rules! resolve_neighbors2_match_arm {
     // token field is same as edge name, so this is just reading the next variant
     ($ctxs:ident, $lt:lifetime, $edge_name:ident, $token_variant:path $(| $other_variant:path)*, $next_variant:path $(,)?) => {
         $crate::neighbor_stub!(
@@ -277,7 +277,7 @@ macro_rules! project_neighbors2_match_arm {
 
 // TODO: figure out whether we want both this macro and the other neighbors macro, or just one
 #[macro_export]
-macro_rules! project_neighbors2 {
+macro_rules! resolve_neighbors2 {
     ($ctxs:ident, $lt:lifetime, $type_name_var:ident, $edge_name_var:ident,
         [
             $(
@@ -293,7 +293,7 @@ macro_rules! project_neighbors2 {
         match ($edge_name_var.as_ref(), $type_name_var.as_ref()) {
             $(
                 (stringify!($edge_name), stringify!($type_option)) $(| (stringify!($edge_name), stringify!($other_type_option)))* => {
-                    $crate::project_neighbors2_match_arm!($ctxs, $lt, $edge_name, $token_variant $(| $other_variant)*, $rest )
+                    $crate::resolve_neighbors2_match_arm!($ctxs, $lt, $edge_name, $token_variant $(| $other_variant)*, $rest )
                 }
             )+
             _ => unreachable!(

--- a/trustfall_core/src/interpreter/macros.rs
+++ b/trustfall_core/src/interpreter/macros.rs
@@ -92,7 +92,7 @@ macro_rules! property_group {
 }
 
 #[macro_export]
-macro_rules! project_property {
+macro_rules! resolve_property {
     ($ctxs:ident, $type_name:ident, $field_name:ident,
         [
             $(

--- a/trustfall_core/src/interpreter/macros.rs
+++ b/trustfall_core/src/interpreter/macros.rs
@@ -121,7 +121,7 @@ macro_rules! project_property {
 macro_rules! neighbor_stub {
     ($ctxs:ident, $lt:lifetime, $token_variant:path $(| $other_variant:path)*, $token:ident, $impl:tt) => {
         Box::new($ctxs.map(move |ctx| {
-            let neighbors: Box<dyn Iterator<Item = <Self as Adapter>::DataToken> + $lt> =
+            let neighbors: Box<dyn Iterator<Item = <Self as Adapter>::Vertex> + $lt> =
                 match &ctx.current_token {
                     Some($token_variant($token)) => $impl,
                     $( Some($other_variant($token)) => $impl, )*

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -385,10 +385,10 @@ pub trait Adapter<'token> {
     ) -> Box<dyn Iterator<Item = Self::Vertex> + 'token>;
 
     #[allow(clippy::type_complexity)]
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
@@ -399,7 +399,7 @@ pub trait Adapter<'token> {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
@@ -417,7 +417,7 @@ pub trait Adapter<'token> {
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -382,44 +382,35 @@ pub trait Adapter<'vertex> {
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'vertex>;
+    ) -> VertexIterator<'vertex, Self::Vertex>;
 
-    #[allow(clippy::type_complexity)]
     fn resolve_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'vertex>;
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue>;
 
-    #[allow(clippy::type_complexity)]
     #[allow(clippy::too_many_arguments)]
     fn resolve_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
-    ) -> Box<
-        dyn Iterator<
-                Item = (
-                    DataContext<Self::Vertex>,
-                    Box<dyn Iterator<Item = Self::Vertex> + 'vertex>,
-                ),
-            > + 'vertex,
-    >;
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>>;
 
     fn resolve_coercion(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'vertex>;
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool>;
 }

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -414,7 +414,7 @@ pub trait Adapter<'token> {
             > + 'token,
     >;
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         type_name: Arc<str>,

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -408,7 +408,7 @@ pub trait Adapter<'vertex> {
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool>;

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -23,6 +23,31 @@ pub mod macros;
 pub mod replay;
 pub mod trace;
 
+/// An iterator of vertices representing data points we are querying.
+pub type VertexIterator<'vertex, VertexT> = Box<dyn Iterator<Item = VertexT> + 'vertex>;
+
+/// An iterator of query contexts: bookkeeping structs we use to build up the query results.
+///
+/// Each context represents a possible result of the query. At each query processing step,
+/// all the contexts at that step have fulfilled all the query conditions thus far.
+///
+/// This type is usually an input to adapter resolver functions. Calling those functions
+/// asks them to resolve a property, edge, or type coercion for the particular vertex
+/// the context is currently processing at that point in the query.
+pub type ContextIterator<'vertex, VertexT> =
+    Box<dyn Iterator<Item = DataContext<VertexT>> + 'vertex>;
+
+/// Iterator of (context, outcome) tuples: the output type of most resolver functions.
+///
+/// Resolver functions produce an output value for each context:
+/// - resolve_property() produces that property's value;
+/// - resolve_neighbors() produces an iterator of neighboring vertices along an edge;
+/// - resolve_coercion() gives a bool representing whether the vertex is of the desired type.
+///
+/// This type lets us write those output types in a slightly more readable way.
+pub type ContextOutcomeIterator<'vertex, VertexT, OutcomeT> =
+    Box<dyn Iterator<Item = (DataContext<VertexT>, OutcomeT)> + 'vertex>;
+
 #[derive(Debug, Clone)]
 pub struct DataContext<Vertex: Clone + Debug> {
     pub current_token: Option<Vertex>,
@@ -351,9 +376,9 @@ fn validate_argument_type(
 pub trait Adapter<'token> {
     type Vertex: Clone + Debug + 'token;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -373,8 +373,8 @@ fn validate_argument_type(
     }
 }
 
-pub trait Adapter<'token> {
-    type Vertex: Clone + Debug + 'token;
+pub trait Adapter<'vertex> {
+    type Vertex: Clone + Debug + 'vertex;
 
     fn resolve_starting_vertices(
         &mut self,
@@ -382,23 +382,23 @@ pub trait Adapter<'token> {
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'token>;
+    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'vertex>;
 
     #[allow(clippy::type_complexity)]
     fn resolve_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
         type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'token>;
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'vertex>;
 
     #[allow(clippy::type_complexity)]
     #[allow(clippy::too_many_arguments)]
     fn resolve_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
         type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -409,17 +409,17 @@ pub trait Adapter<'token> {
         dyn Iterator<
                 Item = (
                     DataContext<Self::Vertex>,
-                    Box<dyn Iterator<Item = Self::Vertex> + 'token>,
+                    Box<dyn Iterator<Item = Self::Vertex> + 'vertex>,
                 ),
-            > + 'token,
+            > + 'vertex,
     >;
 
     fn resolve_coercion(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'vertex>,
         type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'token>;
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'vertex>;
 }

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -377,8 +377,8 @@ pub trait Adapter<'vertex> {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'vertex, Self::Vertex>;
@@ -386,8 +386,8 @@ pub trait Adapter<'vertex> {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue>;
@@ -396,9 +396,9 @@ pub trait Adapter<'vertex> {
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
@@ -407,8 +407,8 @@ pub trait Adapter<'vertex> {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool>;

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -396,7 +396,7 @@ pub trait Adapter<'token> {
 
     #[allow(clippy::type_complexity)]
     #[allow(clippy::too_many_arguments)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         type_name: Arc<str>,

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -34,8 +34,7 @@ pub type VertexIterator<'vertex, VertexT> = Box<dyn Iterator<Item = VertexT> + '
 /// This type is usually an input to adapter resolver functions. Calling those functions
 /// asks them to resolve a property, edge, or type coercion for the particular vertex
 /// the context is currently processing at that point in the query.
-pub type ContextIterator<'vertex, VertexT> =
-    Box<dyn Iterator<Item = DataContext<VertexT>> + 'vertex>;
+pub type ContextIterator<'vertex, VertexT> = VertexIterator<'vertex, DataContext<VertexT>>;
 
 /// Iterator of (context, outcome) tuples: the output type of most resolver functions.
 ///

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -392,9 +392,9 @@ where
 {
     type Vertex = Vertex;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -488,7 +488,7 @@ where
         }
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
         type_name: Arc<str>,
@@ -497,7 +497,7 @@ where
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'trace> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
-            .expect("Expected a can_coerce_to_type() call operation, but found none.");
+            .expect("Expected a resolve_coercion() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
 
         if let TraceOpContent::Call(FunctionCall::CanCoerceToType(vid, from_type, to_type)) =

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -482,7 +482,7 @@ where
         &mut self,
         contexts: ContextIterator<'trace, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'trace, Self::Vertex, bool> {
@@ -495,7 +495,7 @@ where
         {
             assert_eq!(*vid, vertex_hint);
             assert_eq!(*from_type, type_name);
-            assert_eq!(*to_type, coerce_to_type_name);
+            assert_eq!(*to_type, coerce_to_type);
 
             Box::new(TraceReaderCanCoerceIter {
                 exhausted: false,

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -448,7 +448,7 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
         type_name: Arc<str>,

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -19,12 +19,12 @@ use super::{
 };
 
 #[derive(Clone, Debug)]
-struct TraceReaderAdapter<'trace, DataToken>
+struct TraceReaderAdapter<'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
-    next_op: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<DataToken>>>>,
+    next_op: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
 }
 
 fn advance_ref_iter<T, Iter: Iterator<Item = T>>(iter: &RefCell<Iter>) -> Option<T> {
@@ -34,23 +34,23 @@ fn advance_ref_iter<T, Iter: Iterator<Item = T>>(iter: &RefCell<Iter>) -> Option
 }
 
 #[derive(Debug)]
-struct TraceReaderStartingTokensIter<'trace, DataToken>
+struct TraceReaderStartingTokensIter<'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
     exhausted: bool,
     parent_opid: Opid,
-    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<DataToken>>>>,
+    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
 }
 
 #[allow(unused_variables)]
-impl<'trace, DataToken> Iterator for TraceReaderStartingTokensIter<'trace, DataToken>
+impl<'trace, Vertex> Iterator for TraceReaderStartingTokensIter<'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
-    type Item = DataToken;
+    type Item = Vertex;
 
     fn next(&mut self) -> Option<Self::Item> {
         assert!(!self.exhausted);
@@ -78,25 +78,25 @@ where
     }
 }
 
-struct TraceReaderProjectPropertiesIter<'trace, DataToken>
+struct TraceReaderProjectPropertiesIter<'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
     exhausted: bool,
     parent_opid: Opid,
-    data_contexts: Box<dyn Iterator<Item = DataContext<DataToken>> + 'trace>,
-    input_batch: VecDeque<DataContext<DataToken>>,
-    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<DataToken>>>>,
+    data_contexts: Box<dyn Iterator<Item = DataContext<Vertex>> + 'trace>,
+    input_batch: VecDeque<DataContext<Vertex>>,
+    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
 }
 
 #[allow(unused_variables)]
-impl<'trace, DataToken> Iterator for TraceReaderProjectPropertiesIter<'trace, DataToken>
+impl<'trace, Vertex> Iterator for TraceReaderProjectPropertiesIter<'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
-    type Item = (DataContext<DataToken>, FieldValue);
+    type Item = (DataContext<Vertex>, FieldValue);
 
     fn next(&mut self) -> Option<Self::Item> {
         assert!(!self.exhausted);
@@ -158,27 +158,27 @@ where
     }
 }
 
-struct TraceReaderCanCoerceIter<'query, 'trace, DataToken>
+struct TraceReaderCanCoerceIter<'query, 'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
     exhausted: bool,
     parent_opid: Opid,
-    data_contexts: Box<dyn Iterator<Item = DataContext<DataToken>> + 'query>,
-    input_batch: VecDeque<DataContext<DataToken>>,
-    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<DataToken>>>>,
+    data_contexts: Box<dyn Iterator<Item = DataContext<Vertex>> + 'query>,
+    input_batch: VecDeque<DataContext<Vertex>>,
+    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
 }
 
 #[allow(unused_variables)]
-impl<'query, 'trace, DataToken> Iterator for TraceReaderCanCoerceIter<'query, 'trace, DataToken>
+impl<'query, 'trace, Vertex> Iterator for TraceReaderCanCoerceIter<'query, 'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
-    type Item = (DataContext<DataToken>, bool);
+    type Item = (DataContext<Vertex>, bool);
 
     fn next(&mut self) -> Option<Self::Item> {
         assert!(!self.exhausted);
@@ -241,29 +241,28 @@ where
     }
 }
 
-struct TraceReaderProjectNeighborsIter<'query, 'trace, DataToken>
+struct TraceReaderProjectNeighborsIter<'query, 'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
     exhausted: bool,
     parent_opid: Opid,
-    data_contexts: Box<dyn Iterator<Item = DataContext<DataToken>> + 'query>,
-    input_batch: VecDeque<DataContext<DataToken>>,
-    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<DataToken>>>>,
+    data_contexts: Box<dyn Iterator<Item = DataContext<Vertex>> + 'query>,
+    input_batch: VecDeque<DataContext<Vertex>>,
+    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
 }
 
-impl<'query, 'trace, DataToken> Iterator
-    for TraceReaderProjectNeighborsIter<'query, 'trace, DataToken>
+impl<'query, 'trace, Vertex> Iterator for TraceReaderProjectNeighborsIter<'query, 'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
     type Item = (
-        DataContext<DataToken>,
-        Box<dyn Iterator<Item = DataToken> + 'query>,
+        DataContext<Vertex>,
+        Box<dyn Iterator<Item = Vertex> + 'query>,
     );
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -335,26 +334,26 @@ where
     }
 }
 
-struct TraceReaderNeighborIter<'query, 'trace, DataToken>
+struct TraceReaderNeighborIter<'query, 'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
     exhausted: bool,
     parent_iterator_opid: Opid,
     next_index: usize,
-    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<DataToken>>>>,
+    inner: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
     _phantom: PhantomData<&'query ()>,
 }
 
-impl<'query, 'trace, DataToken> Iterator for TraceReaderNeighborIter<'query, 'trace, DataToken>
+impl<'query, 'trace, Vertex> Iterator for TraceReaderNeighborIter<'query, 'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
-    type Item = DataToken;
+    type Item = Vertex;
 
     fn next(&mut self) -> Option<Self::Item> {
         let (_, trace_op) = advance_ref_iter(self.inner.as_ref())
@@ -386,12 +385,12 @@ where
 }
 
 #[allow(unused_variables)]
-impl<'trace, DataToken> Adapter<'trace> for TraceReaderAdapter<'trace, DataToken>
+impl<'trace, Vertex> Adapter<'trace> for TraceReaderAdapter<'trace, Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
-    type DataToken = DataToken;
+    type Vertex = Vertex;
 
     fn get_starting_tokens(
         &mut self,
@@ -399,7 +398,7 @@ where
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken> + 'trace> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'trace> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
             .expect("Expected a get_starting_tokens() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
@@ -419,12 +418,12 @@ where
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'trace>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)> + 'trace> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'trace> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
             .expect("Expected a project_property() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
@@ -451,7 +450,7 @@ where
     #[allow(clippy::type_complexity)]
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'trace>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -461,8 +460,8 @@ where
     ) -> Box<
         dyn Iterator<
                 Item = (
-                    DataContext<Self::DataToken>,
-                    Box<dyn Iterator<Item = Self::DataToken> + 'trace>,
+                    DataContext<Self::Vertex>,
+                    Box<dyn Iterator<Item = Self::Vertex> + 'trace>,
                 ),
             > + 'trace,
     > {
@@ -491,12 +490,12 @@ where
 
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'trace>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)> + 'trace> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'trace> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
             .expect("Expected a can_coerce_to_type() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
@@ -522,13 +521,13 @@ where
 }
 
 #[allow(dead_code)]
-pub fn assert_interpreted_results<'query, 'trace, DataToken>(
-    trace: &Trace<DataToken>,
+pub fn assert_interpreted_results<'query, 'trace, Vertex>(
+    trace: &Trace<Vertex>,
     expected_results: &[BTreeMap<Arc<str>, FieldValue>],
     complete: bool,
 ) where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
+    for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
     let next_op = Rc::new(RefCell::new(trace.ops.iter()));

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -261,10 +261,7 @@ where
     for<'de2> Vertex: Deserialize<'de2>,
     'trace: 'query,
 {
-    type Item = (
-        DataContext<Vertex>,
-        Box<dyn Iterator<Item = Vertex> + 'query>,
-    );
+    type Item = (DataContext<Vertex>, VertexIterator<'query, Vertex>);
 
     fn next(&mut self) -> Option<Self::Item> {
         assert!(!self.exhausted);

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -400,7 +400,7 @@ where
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = Self::Vertex> + 'trace> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
-            .expect("Expected a get_starting_tokens() call operation, but found none.");
+            .expect("Expected a resolve_starting_vertices() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
 
         if let TraceOpContent::Call(FunctionCall::GetStartingTokens(vid)) = trace_op.content {
@@ -416,23 +416,23 @@ where
         }
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'trace> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
-            .expect("Expected a project_property() call operation, but found none.");
+            .expect("Expected a resolve_property() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
 
-        if let TraceOpContent::Call(FunctionCall::ProjectProperty(vid, type_name, property)) =
+        if let TraceOpContent::Call(FunctionCall::ProjectProperty(vid, op_type_name, property)) =
             &trace_op.content
         {
             assert_eq!(*vid, vertex_hint);
-            assert_eq!(*type_name, current_type_name);
+            assert_eq!(*op_type_name, type_name);
             assert_eq!(*property, field_name);
 
             Box::new(TraceReaderProjectPropertiesIter {
@@ -451,7 +451,7 @@ where
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
@@ -466,14 +466,14 @@ where
             > + 'trace,
     > {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
-            .expect("Expected a project_property() call operation, but found none.");
+            .expect("Expected a resolve_property() call operation, but found none.");
         assert_eq!(None, trace_op.parent_opid);
 
-        if let TraceOpContent::Call(FunctionCall::ProjectNeighbors(vid, type_name, eid)) =
+        if let TraceOpContent::Call(FunctionCall::ProjectNeighbors(vid, op_type_name, eid)) =
             &trace_op.content
         {
             assert_eq!(vid, &vertex_hint);
-            assert_eq!(type_name, &current_type_name);
+            assert_eq!(op_type_name, &type_name);
             assert_eq!(eid, &edge_hint);
 
             Box::new(TraceReaderProjectNeighborsIter {
@@ -491,7 +491,7 @@ where
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'trace>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
@@ -504,7 +504,7 @@ where
             &trace_op.content
         {
             assert_eq!(*vid, vertex_hint);
-            assert_eq!(*from_type, current_type_name);
+            assert_eq!(*from_type, type_name);
             assert_eq!(*to_type, coerce_to_type_name);
 
             Box::new(TraceReaderCanCoerceIter {

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -392,8 +392,8 @@ where
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'trace, Self::Vertex> {
@@ -417,8 +417,8 @@ where
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'trace, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'trace, Self::Vertex, FieldValue> {
@@ -430,8 +430,8 @@ where
             &trace_op.content
         {
             assert_eq!(*vid, vertex_hint);
-            assert_eq!(*op_type_name, type_name);
-            assert_eq!(*property, field_name);
+            assert_eq!(op_type_name, type_name);
+            assert_eq!(property, property_name);
 
             Box::new(TraceReaderProjectPropertiesIter {
                 exhausted: false,
@@ -448,9 +448,9 @@ where
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'trace, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
@@ -463,7 +463,7 @@ where
             &trace_op.content
         {
             assert_eq!(vid, &vertex_hint);
-            assert_eq!(op_type_name, &type_name);
+            assert_eq!(op_type_name, type_name);
             assert_eq!(eid, &edge_hint);
 
             Box::new(TraceReaderProjectNeighborsIter {
@@ -481,8 +481,8 @@ where
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'trace, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'trace, Self::Vertex, bool> {
@@ -494,8 +494,8 @@ where
             &trace_op.content
         {
             assert_eq!(*vid, vertex_hint);
-            assert_eq!(*from_type, type_name);
-            assert_eq!(*to_type, coerce_to_type);
+            assert_eq!(from_type, type_name);
+            assert_eq!(to_type, coerce_to_type);
 
             Box::new(TraceReaderCanCoerceIter {
                 exhausted: false,

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -272,10 +272,10 @@ where
         )
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
@@ -284,7 +284,7 @@ where
         let call_opid = trace.record(
             TraceOpContent::Call(FunctionCall::ProjectProperty(
                 vertex_hint,
-                current_type_name.clone(),
+                type_name.clone(),
                 field_name.clone(),
             )),
             None,
@@ -314,9 +314,9 @@ where
                 context
             }),
         );
-        let inner_iter = self.inner.project_property(
+        let inner_iter = self.inner.resolve_property(
             wrapped_contexts,
-            current_type_name,
+            type_name,
             field_name,
             query_hint,
             vertex_hint,
@@ -348,7 +348,7 @@ where
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
@@ -366,7 +366,7 @@ where
         let call_opid = trace.record(
             TraceOpContent::Call(FunctionCall::ProjectNeighbors(
                 vertex_hint,
-                current_type_name.clone(),
+                type_name.clone(),
                 edge_hint,
             )),
             None,
@@ -398,7 +398,7 @@ where
         );
         let inner_iter = self.inner.project_neighbors(
             wrapped_contexts,
-            current_type_name,
+            type_name,
             edge_name,
             parameters,
             query_hint,
@@ -452,7 +452,7 @@ where
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
@@ -461,7 +461,7 @@ where
         let call_opid = trace.record(
             TraceOpContent::Call(FunctionCall::CanCoerceToType(
                 vertex_hint,
-                current_type_name.clone(),
+                type_name.clone(),
                 coerce_to_type_name.clone(),
             )),
             None,
@@ -493,7 +493,7 @@ where
         );
         let inner_iter = self.inner.can_coerce_to_type(
             wrapped_contexts,
-            current_type_name,
+            type_name,
             coerce_to_type_name,
             query_hint,
             vertex_hint,

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -428,7 +428,7 @@ where
                 });
 
                 let tracer_ref_7 = tracer_ref_5.clone();
-                let final_neighbor_iter: Box<dyn Iterator<Item = Vertex> + 'vertex> =
+                let final_neighbor_iter: VertexIterator<'vertex, Vertex> =
                     Box::new(make_iter_with_end_action(tapped_neighbor_iter, move || {
                         tracer_ref_7.borrow_mut().record(
                             TraceOpContent::OutputIteratorExhausted,

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -236,7 +236,7 @@ where
 {
     type Vertex = Vertex;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -252,7 +252,7 @@ where
 
         let inner_iter =
             self.inner
-                .get_starting_tokens(edge_name, parameters, query_hint, vertex_hint);
+                .resolve_starting_vertices(edge_name, parameters, query_hint, vertex_hint);
         let tracer_ref_1 = self.tracer.clone();
         let tracer_ref_2 = self.tracer.clone();
         Box::new(

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -449,7 +449,7 @@ where
         )
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         type_name: Arc<str>,
@@ -491,7 +491,7 @@ where
                 context
             }),
         );
-        let inner_iter = self.inner.can_coerce_to_type(
+        let inner_iter = self.inner.resolve_coercion(
             wrapped_contexts,
             type_name,
             coerce_to_type_name,

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -238,8 +238,8 @@ where
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'vertex, Self::Vertex> {
@@ -275,8 +275,8 @@ where
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
@@ -285,7 +285,7 @@ where
             TraceOpContent::Call(FunctionCall::ProjectProperty(
                 vertex_hint,
                 type_name.clone(),
-                field_name.clone(),
+                property_name.clone(),
             )),
             None,
         );
@@ -317,7 +317,7 @@ where
         let inner_iter = self.inner.resolve_property(
             wrapped_contexts,
             type_name,
-            field_name,
+            property_name,
             query_hint,
             vertex_hint,
         );
@@ -347,9 +347,9 @@ where
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
@@ -444,8 +444,8 @@ where
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool> {

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -445,7 +445,7 @@ where
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool> {
@@ -454,7 +454,7 @@ where
             TraceOpContent::Call(FunctionCall::CanCoerceToType(
                 vertex_hint,
                 type_name.clone(),
-                coerce_to_type_name.clone(),
+                coerce_to_type.clone(),
             )),
             None,
         );
@@ -486,7 +486,7 @@ where
         let inner_iter = self.inner.resolve_coercion(
             wrapped_contexts,
             type_name,
-            coerce_to_type_name,
+            coerce_to_type,
             query_hint,
             vertex_hint,
         );

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -345,7 +345,7 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'token>,
         type_name: Arc<str>,
@@ -396,7 +396,7 @@ where
                 context
             }),
         );
-        let inner_iter = self.inner.project_neighbors(
+        let inner_iter = self.inner.resolve_neighbors(
             wrapped_contexts,
             type_name,
             edge_name,

--- a/trustfall_core/src/main.rs
+++ b/trustfall_core/src/main.rs
@@ -117,8 +117,8 @@ fn check_fuzzed(path: &str, schema_name: &str) {
 fn trace_with_adapter<'a, AdapterT>(adapter: AdapterT, test_query: TestIRQuery)
 where
     AdapterT: Adapter<'a> + Clone + 'a,
-    AdapterT::DataToken: Clone + Debug + PartialEq + Eq + Serialize,
-    for<'de> AdapterT::DataToken: Deserialize<'de>,
+    AdapterT::Vertex: Clone + Debug + PartialEq + Eq + Serialize,
+    for<'de> AdapterT::Vertex: Deserialize<'de>,
 {
     let query = Arc::new(test_query.ir_query.clone().try_into().unwrap());
     let arguments: Arc<BTreeMap<_, _>> = Arc::new(

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -15,7 +15,7 @@ pub(crate) struct NullablesAdapter;
 
 #[allow(unused_variables)]
 impl Adapter<'static> for NullablesAdapter {
-    type DataToken = NullablesToken;
+    type Vertex = NullablesToken;
 
     fn get_starting_tokens(
         &mut self,
@@ -23,25 +23,25 @@ impl Adapter<'static> for NullablesAdapter {
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken>> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex>> {
         unimplemented!()
     }
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
         unimplemented!()
     }
 
     #[allow(clippy::type_complexity)]
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -51,8 +51,8 @@ impl Adapter<'static> for NullablesAdapter {
     ) -> Box<
         dyn Iterator<
             Item = (
-                DataContext<Self::DataToken>,
-                Box<dyn Iterator<Item = Self::DataToken>>,
+                DataContext<Self::Vertex>,
+                Box<dyn Iterator<Item = Self::Vertex>>,
             ),
         >,
     > {
@@ -61,12 +61,12 @@ impl Adapter<'static> for NullablesAdapter {
 
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
         unimplemented!()
     }
 }

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -17,9 +17,9 @@ pub(crate) struct NullablesAdapter;
 impl Adapter<'static> for NullablesAdapter {
     type Vertex = NullablesToken;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -21,8 +21,8 @@ impl Adapter<'static> for NullablesAdapter {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'static, Self::Vertex> {
@@ -32,8 +32,8 @@ impl Adapter<'static> for NullablesAdapter {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
@@ -43,9 +43,9 @@ impl Adapter<'static> for NullablesAdapter {
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
@@ -56,8 +56,8 @@ impl Adapter<'static> for NullablesAdapter {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    interpreter::{Adapter, DataContext, InterpretedQuery},
+    interpreter::{
+        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
+    },
     ir::{EdgeParameters, Eid, FieldValue, Vid},
 };
 
@@ -23,50 +25,42 @@ impl Adapter<'static> for NullablesAdapter {
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex>> {
+    ) -> VertexIterator<'static, Self::Vertex> {
         unimplemented!()
     }
 
     fn resolve_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         unimplemented!()
     }
 
-    #[allow(clippy::type_complexity)]
     fn resolve_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
-    ) -> Box<
-        dyn Iterator<
-            Item = (
-                DataContext<Self::Vertex>,
-                Box<dyn Iterator<Item = Self::Vertex>>,
-            ),
-        >,
-    > {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         unimplemented!()
     }
 
     fn resolve_coercion(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         unimplemented!()
     }
 }

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -57,7 +57,7 @@ impl Adapter<'static> for NullablesAdapter {
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -27,10 +27,10 @@ impl Adapter<'static> for NullablesAdapter {
         unimplemented!()
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
@@ -42,7 +42,7 @@ impl Adapter<'static> for NullablesAdapter {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
@@ -62,7 +62,7 @@ impl Adapter<'static> for NullablesAdapter {
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -39,7 +39,7 @@ impl Adapter<'static> for NullablesAdapter {
     }
 
     #[allow(clippy::type_complexity)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -59,7 +59,7 @@ impl Adapter<'static> for NullablesAdapter {
         unimplemented!()
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -173,7 +173,7 @@ pub(crate) struct NumbersAdapter;
 
 #[allow(unused_variables)]
 impl Adapter<'static> for NumbersAdapter {
-    type DataToken = NumbersToken;
+    type Vertex = NumbersToken;
 
     fn get_starting_tokens(
         &mut self,
@@ -181,7 +181,7 @@ impl Adapter<'static> for NumbersAdapter {
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken>> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex>> {
         let mut primes = btreeset![2, 3];
         match edge.as_ref() {
             "Zero" => Box::new(std::iter::once(make_number_token(&mut primes, 0))),
@@ -213,12 +213,12 @@ impl Adapter<'static> for NumbersAdapter {
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
         match (current_type_name.as_ref(), field_name.as_ref()) {
             ("Number" | "Prime" | "Composite" | "Neither", "value") => {
                 resolve_property_with(data_contexts, |vertex| vertex.value().into())
@@ -241,7 +241,7 @@ impl Adapter<'static> for NumbersAdapter {
     #[allow(clippy::type_complexity)]
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
@@ -251,8 +251,8 @@ impl Adapter<'static> for NumbersAdapter {
     ) -> Box<
         dyn Iterator<
             Item = (
-                DataContext<Self::DataToken>,
-                Box<dyn Iterator<Item = Self::DataToken>>,
+                DataContext<Self::Vertex>,
+                Box<dyn Iterator<Item = Self::Vertex>>,
             ),
         >,
     > {
@@ -366,12 +366,12 @@ impl Adapter<'static> for NumbersAdapter {
 
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>>>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)>> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
         match (current_type_name.as_ref(), coerce_to_type_name.as_ref()) {
             ("Number", "Prime") => resolve_coercion_with(data_contexts, |vertex| {
                 matches!(vertex, NumbersToken::Prime(..))

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -360,11 +360,11 @@ impl Adapter<'static> for NumbersAdapter {
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
-        match (type_name.as_ref(), coerce_to_type_name.as_ref()) {
+        match (type_name.as_ref(), coerce_to_type.as_ref()) {
             ("Number", "Prime") => {
                 resolve_coercion_with(contexts, |vertex| matches!(vertex, NumbersToken::Prime(..)))
             }
@@ -374,7 +374,7 @@ impl Adapter<'static> for NumbersAdapter {
             _ => unimplemented!(
                 "Unexpected coercion attempted: {} {}",
                 type_name,
-                coerce_to_type_name
+                coerce_to_type
             ),
         }
     }

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     interpreter::{
         helpers::{resolve_coercion_with, resolve_neighbors_with, resolve_property_with},
-        Adapter, DataContext, InterpretedQuery,
+        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
     },
     ir::{EdgeParameters, Eid, FieldValue, Vid},
 };
@@ -181,7 +181,7 @@ impl Adapter<'static> for NumbersAdapter {
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::Vertex>> {
+    ) -> VertexIterator<'static, Self::Vertex> {
         let mut primes = btreeset![2, 3];
         match edge_name.as_ref() {
             "Zero" => Box::new(std::iter::once(make_number_token(&mut primes, 0))),
@@ -213,24 +213,24 @@ impl Adapter<'static> for NumbersAdapter {
 
     fn resolve_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         match (type_name.as_ref(), field_name.as_ref()) {
             ("Number" | "Prime" | "Composite" | "Neither", "value") => {
-                resolve_property_with(data_contexts, |vertex| vertex.value().into())
+                resolve_property_with(contexts, |vertex| vertex.value().into())
             }
             ("Number" | "Prime" | "Composite" | "Neither", "name") => {
-                resolve_property_with(data_contexts, |vertex| vertex.name().into())
+                resolve_property_with(contexts, |vertex| vertex.name().into())
             }
             ("Number" | "Prime" | "Composite" | "Neither", "vowelsInName") => {
-                resolve_property_with(data_contexts, |vertex| vertex.vowels_in_name().into())
+                resolve_property_with(contexts, |vertex| vertex.vowels_in_name().into())
             }
             ("Number" | "Prime" | "Composite" | "Neither", "__typename") => {
-                resolve_property_with(data_contexts, |vertex| vertex.typename().into())
+                resolve_property_with(contexts, |vertex| vertex.typename().into())
             }
             (type_name, property_name) => {
                 unreachable!("failed to resolve type {type_name} property {property_name}")
@@ -238,28 +238,20 @@ impl Adapter<'static> for NumbersAdapter {
         }
     }
 
-    #[allow(clippy::type_complexity)]
     fn resolve_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
-    ) -> Box<
-        dyn Iterator<
-            Item = (
-                DataContext<Self::Vertex>,
-                Box<dyn Iterator<Item = Self::Vertex>>,
-            ),
-        >,
-    > {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let mut primes = btreeset![2, 3];
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("Number" | "Prime" | "Composite", "predecessor") => {
-                resolve_neighbors_with(data_contexts, move |vertex| {
+                resolve_neighbors_with(contexts, move |vertex| {
                     let value = match &vertex {
                         NumbersToken::Neither(inner) => inner.value(),
                         NumbersToken::Prime(inner) => inner.value(),
@@ -273,7 +265,7 @@ impl Adapter<'static> for NumbersAdapter {
                 })
             }
             ("Number" | "Prime" | "Composite", "successor") => {
-                resolve_neighbors_with(data_contexts, move |vertex| {
+                resolve_neighbors_with(contexts, move |vertex| {
                     let value = match &vertex {
                         NumbersToken::Neither(inner) => inner.value(),
                         NumbersToken::Prime(inner) => inner.value(),
@@ -283,7 +275,7 @@ impl Adapter<'static> for NumbersAdapter {
                 })
             }
             ("Number" | "Prime" | "Composite", "multiple") => {
-                resolve_neighbors_with(data_contexts, move |vertex| {
+                resolve_neighbors_with(contexts, move |vertex| {
                     match vertex {
                         NumbersToken::Neither(..) => Box::new(std::iter::empty()),
                         NumbersToken::Prime(vertex) => {
@@ -317,7 +309,7 @@ impl Adapter<'static> for NumbersAdapter {
                 })
             }
             ("Composite", "primeFactor") => {
-                resolve_neighbors_with(data_contexts, move |vertex| match vertex {
+                resolve_neighbors_with(contexts, move |vertex| match vertex {
                     NumbersToken::Composite(vertex) => {
                         let factors = &vertex.1;
                         Box::new(
@@ -332,7 +324,7 @@ impl Adapter<'static> for NumbersAdapter {
                 })
             }
             ("Composite", "divisor") => {
-                resolve_neighbors_with(data_contexts, move |vertex| match vertex {
+                resolve_neighbors_with(contexts, move |vertex| match vertex {
                     NumbersToken::Composite(vertex) => {
                         let value = vertex.0;
                         if value <= 0 {
@@ -366,17 +358,17 @@ impl Adapter<'static> for NumbersAdapter {
 
     fn resolve_coercion(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
+        contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
+    ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         match (type_name.as_ref(), coerce_to_type_name.as_ref()) {
-            ("Number", "Prime") => resolve_coercion_with(data_contexts, |vertex| {
-                matches!(vertex, NumbersToken::Prime(..))
-            }),
-            ("Number", "Composite") => resolve_coercion_with(data_contexts, |vertex| {
+            ("Number", "Prime") => {
+                resolve_coercion_with(contexts, |vertex| matches!(vertex, NumbersToken::Prime(..)))
+            }
+            ("Number", "Composite") => resolve_coercion_with(contexts, |vertex| {
                 matches!(vertex, NumbersToken::Composite(..))
             }),
             _ => unimplemented!(

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -211,15 +211,15 @@ impl Adapter<'static> for NumbersAdapter {
         }
     }
 
-    fn project_property(
+    fn resolve_property(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)>> {
-        match (current_type_name.as_ref(), field_name.as_ref()) {
+        match (type_name.as_ref(), field_name.as_ref()) {
             ("Number" | "Prime" | "Composite" | "Neither", "value") => {
                 resolve_property_with(data_contexts, |vertex| vertex.value().into())
             }
@@ -242,7 +242,7 @@ impl Adapter<'static> for NumbersAdapter {
     fn project_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
@@ -257,7 +257,7 @@ impl Adapter<'static> for NumbersAdapter {
         >,
     > {
         let mut primes = btreeset![2, 3];
-        match (current_type_name.as_ref(), edge_name.as_ref()) {
+        match (type_name.as_ref(), edge_name.as_ref()) {
             ("Number" | "Prime" | "Composite", "predecessor") => {
                 resolve_neighbors_with(data_contexts, move |vertex| {
                     let value = match &vertex {
@@ -358,7 +358,7 @@ impl Adapter<'static> for NumbersAdapter {
             _ => {
                 unreachable!(
                     "Unexpected edge {} on vertex type {}",
-                    &edge_name, &current_type_name
+                    &edge_name, &type_name
                 );
             }
         }
@@ -367,12 +367,12 @@ impl Adapter<'static> for NumbersAdapter {
     fn can_coerce_to_type(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
-        current_type_name: Arc<str>,
+        type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)>> {
-        match (current_type_name.as_ref(), coerce_to_type_name.as_ref()) {
+        match (type_name.as_ref(), coerce_to_type_name.as_ref()) {
             ("Number", "Prime") => resolve_coercion_with(data_contexts, |vertex| {
                 matches!(vertex, NumbersToken::Prime(..))
             }),
@@ -381,7 +381,7 @@ impl Adapter<'static> for NumbersAdapter {
             }),
             _ => unimplemented!(
                 "Unexpected coercion attempted: {} {}",
-                current_type_name,
+                type_name,
                 coerce_to_type_name
             ),
         }

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -177,8 +177,8 @@ impl Adapter<'static> for NumbersAdapter {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'static, Self::Vertex> {
@@ -189,7 +189,7 @@ impl Adapter<'static> for NumbersAdapter {
             "Two" => Box::new(std::iter::once(make_number_token(&mut primes, 2))),
             "Four" => Box::new(std::iter::once(make_number_token(&mut primes, 4))),
             "Number" | "NumberImplicitNullDefault" => {
-                let parameters = &parameters.unwrap().0;
+                let parameters = &parameters.as_deref().unwrap().0;
                 let min_value = parameters
                     .get("min")
                     .and_then(FieldValue::as_i64)
@@ -214,12 +214,12 @@ impl Adapter<'static> for NumbersAdapter {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
-        match (type_name.as_ref(), field_name.as_ref()) {
+        match (type_name.as_ref(), property_name.as_ref()) {
             ("Number" | "Prime" | "Composite" | "Neither", "value") => {
                 resolve_property_with(contexts, |vertex| vertex.value().into())
             }
@@ -241,14 +241,15 @@ impl Adapter<'static> for NumbersAdapter {
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<EdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let mut primes = btreeset![2, 3];
+        let parameters = parameters.clone();
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("Number" | "Prime" | "Composite", "predecessor") => {
                 resolve_neighbors_with(contexts, move |vertex| {
@@ -359,8 +360,8 @@ impl Adapter<'static> for NumbersAdapter {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -364,7 +364,7 @@ impl Adapter<'static> for NumbersAdapter {
         }
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -175,15 +175,15 @@ pub(crate) struct NumbersAdapter;
 impl Adapter<'static> for NumbersAdapter {
     type Vertex = NumbersToken;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<EdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> Box<dyn Iterator<Item = Self::Vertex>> {
         let mut primes = btreeset![2, 3];
-        match edge.as_ref() {
+        match edge_name.as_ref() {
             "Zero" => Box::new(std::iter::once(make_number_token(&mut primes, 0))),
             "One" => Box::new(std::iter::once(make_number_token(&mut primes, 1))),
             "Two" => Box::new(std::iter::once(make_number_token(&mut primes, 2))),
@@ -207,7 +207,7 @@ impl Adapter<'static> for NumbersAdapter {
                     )
                 }
             }
-            _ => unimplemented!("{}", edge),
+            _ => unimplemented!("{edge_name}"),
         }
     }
 

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -239,7 +239,7 @@ impl Adapter<'static> for NumbersAdapter {
     }
 
     #[allow(clippy::type_complexity)]
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>>>,
         type_name: Arc<str>,

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -700,7 +700,6 @@ fn get_vertex_type_implements(vertex: &TypeDefinition) -> &[Positioned<Name>] {
     }
 }
 
-#[allow(clippy::type_complexity)]
 fn get_field_origins(
     vertex_types: &HashMap<Arc<str>, TypeDefinition>,
 ) -> Result<BTreeMap<(Arc<str>, Arc<str>), FieldOrigin>, InvalidSchemaError> {

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -700,6 +700,7 @@ fn get_vertex_type_implements(vertex: &TypeDefinition) -> &[Positioned<Name>] {
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn get_field_origins(
     vertex_types: &HashMap<Arc<str>, TypeDefinition>,
 ) -> Result<BTreeMap<(Arc<str>, Arc<str>), FieldOrigin>, InvalidSchemaError> {

--- a/trustfall_core/src/util.rs
+++ b/trustfall_core/src/util.rs
@@ -188,15 +188,15 @@ pub(crate) struct TestIRQuery {
 pub(crate) type TestIRQueryResult = Result<TestIRQuery, FrontendError>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "DataToken: Serialize, for<'de2> DataToken: Deserialize<'de2>")]
-pub(crate) struct TestInterpreterOutputTrace<DataToken>
+#[serde(bound = "Vertex: Serialize, for<'de2> Vertex: Deserialize<'de2>")]
+pub(crate) struct TestInterpreterOutputTrace<Vertex>
 where
-    DataToken: Clone + Debug + PartialEq + Eq + Serialize,
-    for<'de2> DataToken: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize,
+    for<'de2> Vertex: Deserialize<'de2>,
 {
     pub(crate) schema_name: String,
 
-    pub(crate) trace: Trace<DataToken>,
+    pub(crate) trace: Trace<Vertex>,
 
     pub(crate) results: Vec<BTreeMap<Arc<str>, FieldValue>>,
 }

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -258,9 +258,9 @@ impl AdapterShim {
 impl Adapter<'static> for AdapterShim {
     type Vertex = JsValue;
 
-    fn get_starting_tokens(
+    fn resolve_starting_vertices(
         &mut self,
-        edge: Arc<str>,
+        edge_name: Arc<str>,
         parameters: Option<Arc<CoreEdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
@@ -268,7 +268,7 @@ impl Adapter<'static> for AdapterShim {
         let parameters: JsEdgeParameters = parameters.into();
         let js_iter = self
             .inner
-            .get_starting_tokens(edge.as_ref(), parameters.into_js_dict());
+            .get_starting_tokens(edge_name.as_ref(), parameters.into_js_dict());
         Box::new(TokenIterator::new(js_iter.into_iter()))
     }
 

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -41,7 +41,7 @@ extern "C" {
     ) -> js_sys::Iterator;
 
     #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
-    pub fn can_coerce_to_type(
+    pub fn resolve_coercion(
         this: &JsAdapter,
         data_contexts: ContextIterator,
         type_name: &str,
@@ -322,7 +322,7 @@ impl Adapter<'static> for AdapterShim {
         ))
     }
 
-    fn can_coerce_to_type(
+    fn resolve_coercion(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'static>,
         type_name: Arc<str>,
@@ -332,11 +332,9 @@ impl Adapter<'static> for AdapterShim {
     ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'static> {
         let ctx_iter = ContextIterator::new(data_contexts);
         let registry = ctx_iter.registry.clone();
-        let js_iter = self.inner.can_coerce_to_type(
-            ctx_iter,
-            type_name.as_ref(),
-            coerce_to_type_name.as_ref(),
-        );
+        let js_iter =
+            self.inner
+                .resolve_coercion(ctx_iter, type_name.as_ref(), coerce_to_type_name.as_ref());
         Box::new(ContextAndBoolIterator::new(js_iter, registry))
     }
 }

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -256,7 +256,7 @@ impl AdapterShim {
 
 #[allow(unused_variables)]
 impl Adapter<'static> for AdapterShim {
-    type DataToken = JsValue;
+    type Vertex = JsValue;
 
     fn get_starting_tokens(
         &mut self,
@@ -264,7 +264,7 @@ impl Adapter<'static> for AdapterShim {
         parameters: Option<Arc<CoreEdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = Self::DataToken> + 'static> {
+    ) -> Box<dyn Iterator<Item = Self::Vertex> + 'static> {
         let parameters: JsEdgeParameters = parameters.into();
         let js_iter = self
             .inner
@@ -274,12 +274,12 @@ impl Adapter<'static> for AdapterShim {
 
     fn project_property(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'static>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'static>,
         current_type_name: Arc<str>,
         field_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)> + 'static> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, FieldValue)> + 'static> {
         let ctx_iter = ContextIterator::new(data_contexts);
         let registry = ctx_iter.registry.clone();
         let js_iter =
@@ -290,7 +290,7 @@ impl Adapter<'static> for AdapterShim {
 
     fn project_neighbors(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'static>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'static>,
         current_type_name: Arc<str>,
         edge_name: Arc<str>,
         parameters: Option<Arc<CoreEdgeParameters>>,
@@ -300,8 +300,8 @@ impl Adapter<'static> for AdapterShim {
     ) -> Box<
         dyn Iterator<
                 Item = (
-                    DataContext<Self::DataToken>,
-                    Box<dyn Iterator<Item = Self::DataToken> + 'static>,
+                    DataContext<Self::Vertex>,
+                    Box<dyn Iterator<Item = Self::Vertex> + 'static>,
                 ),
             > + 'static,
     > {
@@ -324,12 +324,12 @@ impl Adapter<'static> for AdapterShim {
 
     fn can_coerce_to_type(
         &mut self,
-        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'static>,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'static>,
         current_type_name: Arc<str>,
         coerce_to_type_name: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
-    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)> + 'static> {
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::Vertex>, bool)> + 'static> {
         let ctx_iter = ContextIterator::new(data_contexts);
         let registry = ctx_iter.registry.clone();
         let js_iter = self.inner.can_coerce_to_type(

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -150,10 +150,7 @@ impl ContextAndNeighborsIterator {
 }
 
 impl Iterator for ContextAndNeighborsIterator {
-    type Item = (
-        DataContext<JsValue>,
-        Box<dyn Iterator<Item = JsValue> + 'static>,
-    );
+    type Item = (DataContext<JsValue>, VertexIterator<'static, JsValue>);
 
     fn next(&mut self) -> Option<Self::Item> {
         let iter_next = self

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -260,12 +260,12 @@ impl Adapter<'static> for AdapterShim {
 
     fn resolve_starting_vertices(
         &mut self,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<CoreEdgeParameters>>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<CoreEdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> VertexIterator<'static, Self::Vertex> {
-        let parameters: JsEdgeParameters = parameters.into();
+        let parameters: JsEdgeParameters = parameters.clone().into();
         let js_iter = self
             .inner
             .resolve_starting_vertices(edge_name.as_ref(), parameters.into_js_dict());
@@ -275,8 +275,8 @@ impl Adapter<'static> for AdapterShim {
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        field_name: Arc<str>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
@@ -284,23 +284,23 @@ impl Adapter<'static> for AdapterShim {
         let registry = ctx_iter.registry.clone();
         let js_iter =
             self.inner
-                .resolve_property(ctx_iter, type_name.as_ref(), field_name.as_ref());
+                .resolve_property(ctx_iter, type_name.as_ref(), property_name.as_ref());
         Box::new(ContextAndValueIterator::new(js_iter, registry))
     }
 
     fn resolve_neighbors(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        edge_name: Arc<str>,
-        parameters: Option<Arc<CoreEdgeParameters>>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &Option<Arc<CoreEdgeParameters>>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
         edge_hint: Eid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let ctx_iter = JsContextIterator::new(contexts);
         let registry = ctx_iter.registry.clone();
-        let parameters: JsEdgeParameters = parameters.into();
+        let parameters: JsEdgeParameters = parameters.clone().into();
 
         let js_iter = self.inner.resolve_neighbors(
             ctx_iter,
@@ -318,8 +318,8 @@ impl Adapter<'static> for AdapterShim {
     fn resolve_coercion(
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
-        type_name: Arc<str>,
-        coerce_to_type: Arc<str>,
+        type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -48,7 +48,7 @@ extern "C" {
         this: &JsAdapter,
         contexts: JsContextIterator,
         type_name: &str,
-        coerce_to_type_name: &str,
+        coerce_to_type: &str,
     ) -> js_sys::Iterator;
 }
 
@@ -319,7 +319,7 @@ impl Adapter<'static> for AdapterShim {
         &mut self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: Arc<str>,
-        coerce_to_type_name: Arc<str>,
+        coerce_to_type: Arc<str>,
         query_hint: InterpretedQuery,
         vertex_hint: Vid,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
@@ -327,7 +327,7 @@ impl Adapter<'static> for AdapterShim {
         let registry = ctx_iter.registry.clone();
         let js_iter =
             self.inner
-                .resolve_coercion(ctx_iter, type_name.as_ref(), coerce_to_type_name.as_ref());
+                .resolve_coercion(ctx_iter, type_name.as_ref(), coerce_to_type.as_ref());
         Box::new(ContextAndBoolIterator::new(js_iter, registry))
     }
 }

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -32,7 +32,7 @@ extern "C" {
     ) -> js_sys::Iterator;
 
     #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
-    pub fn project_neighbors(
+    pub fn resolve_neighbors(
         this: &JsAdapter,
         data_contexts: ContextIterator,
         type_name: &str,
@@ -288,7 +288,7 @@ impl Adapter<'static> for AdapterShim {
         Box::new(ContextAndValueIterator::new(js_iter, registry))
     }
 
-    fn project_neighbors(
+    fn resolve_neighbors(
         &mut self,
         data_contexts: Box<dyn Iterator<Item = DataContext<Self::Vertex>> + 'static>,
         type_name: Arc<str>,
@@ -309,7 +309,7 @@ impl Adapter<'static> for AdapterShim {
         let registry = ctx_iter.registry.clone();
         let parameters: JsEdgeParameters = parameters.into();
 
-        let js_iter = self.inner.project_neighbors(
+        let js_iter = self.inner.resolve_neighbors(
             ctx_iter,
             type_name.as_ref(),
             edge_name.as_ref(),

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -205,7 +205,7 @@ impl ContextIterator {
 }
 
 /// The (context, value) iterator item returned by the WASM version
-/// of the project_property() adapter method.
+/// of the resolve_property() adapter method.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReturnedContextIdAndValue {
     #[serde(rename = "localId")]

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -3,7 +3,10 @@ use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use trustfall_core::{interpreter::DataContext, ir::FieldValue};
+use trustfall_core::{
+    interpreter::{DataContext, VertexIterator},
+    ir::FieldValue,
+};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -142,7 +145,7 @@ impl JsStringConstants {
 
 #[wasm_bindgen]
 pub struct JsContextIterator {
-    iter: Box<dyn Iterator<Item = DataContext<JsValue>>>,
+    iter: VertexIterator<'static, DataContext<JsValue>>,
     pub(super) registry: Rc<RefCell<BTreeMap<u32, DataContext<JsValue>>>>,
     next_item: u32,
 }
@@ -175,7 +178,7 @@ impl ContextIteratorItem {
 
 #[wasm_bindgen]
 impl JsContextIterator {
-    pub(super) fn new(iter: Box<dyn Iterator<Item = DataContext<JsValue>>>) -> Self {
+    pub(super) fn new(iter: VertexIterator<'static, DataContext<JsValue>>) -> Self {
         Self {
             iter,
             registry: Rc::from(RefCell::new(Default::default())),

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -214,7 +214,7 @@ pub struct ReturnedContextIdAndValue {
 }
 
 /// The (context, can_coerce) iterator item returned by the WASM version
-/// of the can_coerce_to_type() adapter method.
+/// of the resolve_coercion() adapter method.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReturnedContextIdAndBool {
     #[serde(rename = "localId")]

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -141,7 +141,7 @@ impl JsStringConstants {
 }
 
 #[wasm_bindgen]
-pub struct ContextIterator {
+pub struct JsContextIterator {
     iter: Box<dyn Iterator<Item = DataContext<JsValue>>>,
     pub(super) registry: Rc<RefCell<BTreeMap<u32, DataContext<JsValue>>>>,
     next_item: u32,
@@ -174,7 +174,7 @@ impl ContextIteratorItem {
 }
 
 #[wasm_bindgen]
-impl ContextIterator {
+impl JsContextIterator {
     pub(super) fn new(iter: Box<dyn Iterator<Item = DataContext<JsValue>>>) -> Self {
         Self {
             iter,

--- a/trustfall_wasm/src/trustfall_wasm.d.ts
+++ b/trustfall_wasm/src/trustfall_wasm.d.ts
@@ -30,20 +30,20 @@ export interface Adapter<T> {
     ): IterableIterator<T>;
 
     projectProperty(
-        data_contexts: IterableIterator<JsContext<T>>,
+        contexts: IterableIterator<JsContext<T>>,
         type_name: string,
         field_name: string
     ): IterableIterator<ContextAndValue>;
 
     projectNeighbors(
-        data_contexts: IterableIterator<JsContext<T>>,
+        contexts: IterableIterator<JsContext<T>>,
         type_name: string,
         edge_name: string,
         parameters: JsEdgeParameters,
     ): IterableIterator<ContextAndNeighborsIterator<T>>;
 
     canCoerceToType(
-        data_contexts: IterableIterator<JsContext<T>>,
+        contexts: IterableIterator<JsContext<T>>,
         type_name: string,
         coerce_to_type_name: string
     ): IterableIterator<ContextAndBool>;

--- a/trustfall_wasm/src/trustfall_wasm.d.ts
+++ b/trustfall_wasm/src/trustfall_wasm.d.ts
@@ -45,7 +45,7 @@ export interface Adapter<T> {
     canCoerceToType(
         contexts: IterableIterator<JsContext<T>>,
         type_name: string,
-        coerce_to_type_name: string
+        coerce_to_type: string
     ): IterableIterator<ContextAndBool>;
 }
 

--- a/trustfall_wasm/src/trustfall_wasm.d.ts
+++ b/trustfall_wasm/src/trustfall_wasm.d.ts
@@ -31,20 +31,20 @@ export interface Adapter<T> {
 
     projectProperty(
         data_contexts: IterableIterator<JsContext<T>>,
-        current_type_name: string,
+        type_name: string,
         field_name: string
     ): IterableIterator<ContextAndValue>;
 
     projectNeighbors(
         data_contexts: IterableIterator<JsContext<T>>,
-        current_type_name: string,
+        type_name: string,
         edge_name: string,
         parameters: JsEdgeParameters,
     ): IterableIterator<ContextAndNeighborsIterator<T>>;
 
     canCoerceToType(
         data_contexts: IterableIterator<JsContext<T>>,
-        current_type_name: string,
+        type_name: string,
         coerce_to_type_name: string
     ): IterableIterator<ContextAndBool>;
 }

--- a/trustfall_wasm/src/util.rs
+++ b/trustfall_wasm/src/util.rs
@@ -1,7 +1,7 @@
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
-use crate::shim::{ContextIterator, QueryResultIterator};
+use crate::shim::{JsContextIterator, QueryResultIterator};
 
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
@@ -65,7 +65,7 @@ pub fn initialize() -> Result<(), JsValue> {
     //
     // One day, it might not be required to instantiate an object and patch its prototype
     // through Javascript. That will be a day to celebrate.
-    let x = ContextIterator::new(Box::new(std::iter::empty()));
+    let x = JsContextIterator::new(Box::new(std::iter::empty()));
     iterify(&Object::get_prototype_of(&x.into()));
 
     let x: QueryResultIterator = QueryResultIterator::new(Box::new(std::iter::empty()));

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -81,7 +81,7 @@ use wasm_bindgen::prelude::*;
 
         /*
         #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
-        pub fn can_coerce_to_type(
+        pub fn resolve_coercion(
             this: &JsAdapter,
             data_contexts: ContextIterator,
             type_name: &str,

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -53,7 +53,7 @@ use wasm_bindgen::prelude::*;
 
         /*
         #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
-        pub fn project_neighbors(
+        pub fn resolve_neighbors(
             this: &JsAdapter,
             data_contexts: ContextIterator,
             type_name: &str,

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -28,15 +28,15 @@ use wasm_bindgen::prelude::*;
         #[wasm_bindgen(structural, method, js_name = "projectProperty")]
         pub fn resolve_property(
             this: &JsAdapter,
-            data_contexts: ContextIterator,
+            contexts: ContextIterator,
             type_name: &str,
             field_name: &str,
         ) -> js_sys::Iterator;
         */
-        *projectProperty(data_contexts, type_name, field_name) {
+        *projectProperty(contexts, type_name, field_name) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (field_name === "value") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
                             value: ctx.currentToken,
@@ -55,16 +55,16 @@ use wasm_bindgen::prelude::*;
         #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
         pub fn resolve_neighbors(
             this: &JsAdapter,
-            data_contexts: ContextIterator,
+            contexts: ContextIterator,
             type_name: &str,
             edge_name: &str,
             parameters: Option<EdgeParameters>,
         ) -> js_sys::Iterator;
         */
-        *projectNeighbors(data_contexts, type_name, edge_name, parameters) {
+        *projectNeighbors(contexts, type_name, edge_name, parameters) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (edge_name === "successor") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
                             neighbors: [ctx.currentToken + 1],
@@ -83,12 +83,12 @@ use wasm_bindgen::prelude::*;
         #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
         pub fn resolve_coercion(
             this: &JsAdapter,
-            data_contexts: ContextIterator,
+            contexts: ContextIterator,
             type_name: &str,
             coerce_to_type_name: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(data_contexts, type_name, coerce_to_type_name) {
+        *canCoerceToType(contexts, type_name, coerce_to_type_name) {
             const primes = {
                 2: null,
                 3: null,
@@ -98,7 +98,7 @@ use wasm_bindgen::prelude::*;
             };
             if (type_name === "Number") {
                 if (coerce_to_type_name === "Prime") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         var can_coerce = false;
                         if (ctx.currentToken in primes) {
                             can_coerce = true;
@@ -110,7 +110,7 @@ use wasm_bindgen::prelude::*;
                         yield val;
                     }
                 } else if (coerce_to_type_name === "Composite") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         var can_coerce = false;
                         if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
                             can_coerce = true;

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
     class JsNumbersAdapter {
         /*
         #[wasm_bindgen(structural, method, js_name = "getStartingTokens")]
-        pub fn get_starting_tokens(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
+        pub fn resolve_starting_vertices(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
         */
         *getStartingTokens(edge, parameters) {
             if (edge === "Number") {
@@ -26,15 +26,15 @@ use wasm_bindgen::prelude::*;
 
         /*
         #[wasm_bindgen(structural, method, js_name = "projectProperty")]
-        pub fn project_property(
+        pub fn resolve_property(
             this: &JsAdapter,
             data_contexts: ContextIterator,
-            current_type_name: &str,
+            type_name: &str,
             field_name: &str,
         ) -> js_sys::Iterator;
         */
-        *projectProperty(data_contexts, current_type_name, field_name) {
-            if (current_type_name === "Number" || current_type_name === "Prime" || current_type_name === "Composite") {
+        *projectProperty(data_contexts, type_name, field_name) {
+            if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (field_name === "value") {
                     for (const ctx of data_contexts) {
                         const val = {
@@ -44,10 +44,10 @@ use wasm_bindgen::prelude::*;
                         yield val;
                     }
                 } else {
-                    throw `unreachable field name: ${current_type_name} ${field_name}`;
+                    throw `unreachable field name: ${type_name} ${field_name}`;
                 }
             } else {
-                throw `unreachable type name: ${current_type_name} ${field_name}`;
+                throw `unreachable type name: ${type_name} ${field_name}`;
             }
         }
 
@@ -56,13 +56,13 @@ use wasm_bindgen::prelude::*;
         pub fn project_neighbors(
             this: &JsAdapter,
             data_contexts: ContextIterator,
-            current_type_name: &str,
+            type_name: &str,
             edge_name: &str,
             parameters: Option<EdgeParameters>,
         ) -> js_sys::Iterator;
         */
-        *projectNeighbors(data_contexts, current_type_name, edge_name, parameters) {
-            if (current_type_name === "Number" || current_type_name === "Prime" || current_type_name === "Composite") {
+        *projectNeighbors(data_contexts, type_name, edge_name, parameters) {
+            if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (edge_name === "successor") {
                     for (const ctx of data_contexts) {
                         const val = {
@@ -72,10 +72,10 @@ use wasm_bindgen::prelude::*;
                         yield val;
                     }
                 } else {
-                    throw `unreachable neighbor name: ${current_type_name} ${field_name}`;
+                    throw `unreachable neighbor name: ${type_name} ${field_name}`;
                 }
             } else {
-                throw `unreachable type name: ${current_type_name} ${field_name}`;
+                throw `unreachable type name: ${type_name} ${field_name}`;
             }
         }
 
@@ -84,11 +84,11 @@ use wasm_bindgen::prelude::*;
         pub fn can_coerce_to_type(
             this: &JsAdapter,
             data_contexts: ContextIterator,
-            current_type_name: &str,
+            type_name: &str,
             coerce_to_type_name: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(data_contexts, current_type_name, coerce_to_type_name) {
+        *canCoerceToType(data_contexts, type_name, coerce_to_type_name) {
             const primes = {
                 2: null,
                 3: null,
@@ -96,7 +96,7 @@ use wasm_bindgen::prelude::*;
                 7: null,
                 11: null,
             };
-            if (current_type_name === "Number") {
+            if (type_name === "Number") {
                 if (coerce_to_type_name === "Prime") {
                     for (const ctx of data_contexts) {
                         var can_coerce = false;
@@ -122,10 +122,10 @@ use wasm_bindgen::prelude::*;
                         yield val;
                     }
                 } else {
-                    throw `unreachable coercion type name: ${current_type_name} ${coerce_to_type_name}`;
+                    throw `unreachable coercion type name: ${type_name} ${coerce_to_type_name}`;
                 }
             } else {
-                throw `unreachable type name: ${current_type_name} ${coerce_to_type_name}`;
+                throw `unreachable type name: ${type_name} ${coerce_to_type_name}`;
             }
         }
     }

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -85,10 +85,10 @@ use wasm_bindgen::prelude::*;
             this: &JsAdapter,
             contexts: ContextIterator,
             type_name: &str,
-            coerce_to_type_name: &str,
+            coerce_to_type: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(contexts, type_name, coerce_to_type_name) {
+        *canCoerceToType(contexts, type_name, coerce_to_type) {
             const primes = {
                 2: null,
                 3: null,
@@ -97,7 +97,7 @@ use wasm_bindgen::prelude::*;
                 11: null,
             };
             if (type_name === "Number") {
-                if (coerce_to_type_name === "Prime") {
+                if (coerce_to_type === "Prime") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
                         if (ctx.currentToken in primes) {
@@ -109,7 +109,7 @@ use wasm_bindgen::prelude::*;
                         };
                         yield val;
                     }
-                } else if (coerce_to_type_name === "Composite") {
+                } else if (coerce_to_type === "Composite") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
                         if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
@@ -122,10 +122,10 @@ use wasm_bindgen::prelude::*;
                         yield val;
                     }
                 } else {
-                    throw `unreachable coercion type name: ${type_name} ${coerce_to_type_name}`;
+                    throw `unreachable coercion type name: ${type_name} ${coerce_to_type}`;
                 }
             } else {
-                throw `unreachable type name: ${type_name} ${coerce_to_type_name}`;
+                throw `unreachable type name: ${type_name} ${coerce_to_type}`;
             }
         }
     }

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -113,15 +113,15 @@ type Letter implements Named {
         #[wasm_bindgen(structural, method, js_name = "projectProperty")]
         pub fn resolve_property(
             this: &JsAdapter,
-            data_contexts: ContextIterator,
+            contexts: ContextIterator,
             type_name: &str,
             field_name: &str,
         ) -> js_sys::Iterator;
         */
-        *projectProperty(data_contexts, type_name, field_name) {
+        *projectProperty(contexts, type_name, field_name) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (field_name === "value") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
                             value: ctx.currentToken,
@@ -140,16 +140,16 @@ type Letter implements Named {
         #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
         pub fn resolve_neighbors(
             this: &JsAdapter,
-            data_contexts: ContextIterator,
+            contexts: ContextIterator,
             type_name: &str,
             edge_name: &str,
             parameters: Option<EdgeParameters>,
         ) -> js_sys::Iterator;
         */
-        *projectNeighbors(data_contexts, type_name, edge_name, parameters) {
+        *projectNeighbors(contexts, type_name, edge_name, parameters) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (edge_name === "successor") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
                             neighbors: [ctx.currentToken + 1],
@@ -168,12 +168,12 @@ type Letter implements Named {
         #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
         pub fn resolve_coercion(
             this: &JsAdapter,
-            data_contexts: ContextIterator,
+            contexts: ContextIterator,
             type_name: &str,
             coerce_to_type_name: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(data_contexts, type_name, coerce_to_type_name) {
+        *canCoerceToType(contexts, type_name, coerce_to_type_name) {
             const primes = {
                 2: null,
                 3: null,
@@ -183,7 +183,7 @@ type Letter implements Named {
             };
             if (type_name === "Number") {
                 if (coerce_to_type_name === "Prime") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         var can_coerce = false;
                         if (ctx.currentToken in primes) {
                             can_coerce = true;
@@ -195,7 +195,7 @@ type Letter implements Named {
                         yield val;
                     }
                 } else if (coerce_to_type_name === "Composite") {
-                    for (const ctx of data_contexts) {
+                    for (const ctx of contexts) {
                         var can_coerce = false;
                         if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
                             can_coerce = true;

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -170,10 +170,10 @@ type Letter implements Named {
             this: &JsAdapter,
             contexts: ContextIterator,
             type_name: &str,
-            coerce_to_type_name: &str,
+            coerce_to_type: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(contexts, type_name, coerce_to_type_name) {
+        *canCoerceToType(contexts, type_name, coerce_to_type) {
             const primes = {
                 2: null,
                 3: null,
@@ -182,7 +182,7 @@ type Letter implements Named {
                 11: null,
             };
             if (type_name === "Number") {
-                if (coerce_to_type_name === "Prime") {
+                if (coerce_to_type === "Prime") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
                         if (ctx.currentToken in primes) {
@@ -194,7 +194,7 @@ type Letter implements Named {
                         };
                         yield val;
                     }
-                } else if (coerce_to_type_name === "Composite") {
+                } else if (coerce_to_type === "Composite") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
                         if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
@@ -207,10 +207,10 @@ type Letter implements Named {
                         yield val;
                     }
                 } else {
-                    throw `unreachable coercion type name: ${type_name} ${coerce_to_type_name}`;
+                    throw `unreachable coercion type name: ${type_name} ${coerce_to_type}`;
                 }
             } else {
-                throw `unreachable type name: ${type_name} ${coerce_to_type_name}`;
+                throw `unreachable type name: ${type_name} ${coerce_to_type}`;
             }
         }
     }

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -138,7 +138,7 @@ type Letter implements Named {
 
         /*
         #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
-        pub fn project_neighbors(
+        pub fn resolve_neighbors(
             this: &JsAdapter,
             data_contexts: ContextIterator,
             type_name: &str,

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -96,7 +96,7 @@ type Letter implements Named {
     class JsNumbersAdapter {
         /*
         #[wasm_bindgen(structural, method, js_name = "getStartingTokens")]
-        pub fn get_starting_tokens(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
+        pub fn resolve_starting_vertices(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
         */
         *getStartingTokens(edge, parameters) {
             if (edge === "Number") {
@@ -111,15 +111,15 @@ type Letter implements Named {
 
         /*
         #[wasm_bindgen(structural, method, js_name = "projectProperty")]
-        pub fn project_property(
+        pub fn resolve_property(
             this: &JsAdapter,
             data_contexts: ContextIterator,
-            current_type_name: &str,
+            type_name: &str,
             field_name: &str,
         ) -> js_sys::Iterator;
         */
-        *projectProperty(data_contexts, current_type_name, field_name) {
-            if (current_type_name === "Number" || current_type_name === "Prime" || current_type_name === "Composite") {
+        *projectProperty(data_contexts, type_name, field_name) {
+            if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (field_name === "value") {
                     for (const ctx of data_contexts) {
                         const val = {
@@ -129,10 +129,10 @@ type Letter implements Named {
                         yield val;
                     }
                 } else {
-                    throw `unreachable field name: ${current_type_name} ${field_name}`;
+                    throw `unreachable field name: ${type_name} ${field_name}`;
                 }
             } else {
-                throw `unreachable type name: ${current_type_name} ${field_name}`;
+                throw `unreachable type name: ${type_name} ${field_name}`;
             }
         }
 
@@ -141,13 +141,13 @@ type Letter implements Named {
         pub fn project_neighbors(
             this: &JsAdapter,
             data_contexts: ContextIterator,
-            current_type_name: &str,
+            type_name: &str,
             edge_name: &str,
             parameters: Option<EdgeParameters>,
         ) -> js_sys::Iterator;
         */
-        *projectNeighbors(data_contexts, current_type_name, edge_name, parameters) {
-            if (current_type_name === "Number" || current_type_name === "Prime" || current_type_name === "Composite") {
+        *projectNeighbors(data_contexts, type_name, edge_name, parameters) {
+            if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (edge_name === "successor") {
                     for (const ctx of data_contexts) {
                         const val = {
@@ -157,10 +157,10 @@ type Letter implements Named {
                         yield val;
                     }
                 } else {
-                    throw `unreachable neighbor name: ${current_type_name} ${field_name}`;
+                    throw `unreachable neighbor name: ${type_name} ${field_name}`;
                 }
             } else {
-                throw `unreachable type name: ${current_type_name} ${field_name}`;
+                throw `unreachable type name: ${type_name} ${field_name}`;
             }
         }
 
@@ -169,11 +169,11 @@ type Letter implements Named {
         pub fn can_coerce_to_type(
             this: &JsAdapter,
             data_contexts: ContextIterator,
-            current_type_name: &str,
+            type_name: &str,
             coerce_to_type_name: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(data_contexts, current_type_name, coerce_to_type_name) {
+        *canCoerceToType(data_contexts, type_name, coerce_to_type_name) {
             const primes = {
                 2: null,
                 3: null,
@@ -181,7 +181,7 @@ type Letter implements Named {
                 7: null,
                 11: null,
             };
-            if (current_type_name === "Number") {
+            if (type_name === "Number") {
                 if (coerce_to_type_name === "Prime") {
                     for (const ctx of data_contexts) {
                         var can_coerce = false;
@@ -207,10 +207,10 @@ type Letter implements Named {
                         yield val;
                     }
                 } else {
-                    throw `unreachable coercion type name: ${current_type_name} ${coerce_to_type_name}`;
+                    throw `unreachable coercion type name: ${type_name} ${coerce_to_type_name}`;
                 }
             } else {
-                throw `unreachable type name: ${current_type_name} ${coerce_to_type_name}`;
+                throw `unreachable type name: ${type_name} ${coerce_to_type_name}`;
             }
         }
     }

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -166,7 +166,7 @@ type Letter implements Named {
 
         /*
         #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
-        pub fn can_coerce_to_type(
+        pub fn resolve_coercion(
             this: &JsAdapter,
             data_contexts: ContextIterator,
             type_name: &str,

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -133,7 +133,7 @@ class JsNumbersAdapter {
 
   /*
   #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
-  pub fn can_coerce_to_type(
+  pub fn resolve_coercion(
       this: &JsAdapter,
       data_contexts: ContextIterator,
       type_name: &str,

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -63,7 +63,7 @@ type Letter implements Named {
 class JsNumbersAdapter {
   /*
   #[wasm_bindgen(structural, method, js_name = "getStartingTokens")]
-  pub fn get_starting_tokens(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
+  pub fn resolve_starting_vertices(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
   */
   *getStartingTokens(edge, parameters) {
     if (edge === "Number") {
@@ -78,15 +78,15 @@ class JsNumbersAdapter {
 
   /*
   #[wasm_bindgen(structural, method, js_name = "projectProperty")]
-  pub fn project_property(
+  pub fn resolve_property(
       this: &JsAdapter,
       data_contexts: ContextIterator,
-      current_type_name: &str,
+      type_name: &str,
       field_name: &str,
   ) -> js_sys::Iterator;
   */
-  *projectProperty(data_contexts, current_type_name, field_name) {
-    if (current_type_name === "Number" || current_type_name === "Prime" || current_type_name === "Composite") {
+  *projectProperty(data_contexts, type_name, field_name) {
+    if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
       if (field_name === "value") {
         for (const ctx of data_contexts) {
           const val = {
@@ -96,10 +96,10 @@ class JsNumbersAdapter {
           yield val;
         }
       } else {
-        throw `unreachable field name: ${current_type_name} ${field_name}`;
+        throw `unreachable field name: ${type_name} ${field_name}`;
       }
     } else {
-      throw `unreachable type name: ${current_type_name} ${field_name}`;
+      throw `unreachable type name: ${type_name} ${field_name}`;
     }
   }
 
@@ -108,13 +108,13 @@ class JsNumbersAdapter {
   pub fn project_neighbors(
       this: &JsAdapter,
       data_contexts: ContextIterator,
-      current_type_name: &str,
+      type_name: &str,
       edge_name: &str,
       parameters: Option<EdgeParameters>,
   ) -> js_sys::Iterator;
   */
-  *projectNeighbors(data_contexts, current_type_name, edge_name, parameters) {
-    if (current_type_name === "Number" || current_type_name === "Prime" || current_type_name === "Composite") {
+  *projectNeighbors(data_contexts, type_name, edge_name, parameters) {
+    if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
       if (edge_name === "successor") {
         for (const ctx of data_contexts) {
           const val = {
@@ -124,10 +124,10 @@ class JsNumbersAdapter {
           yield val;
         }
       } else {
-        throw `unreachable neighbor name: ${current_type_name} ${field_name}`;
+        throw `unreachable neighbor name: ${type_name} ${field_name}`;
       }
     } else {
-      throw `unreachable type name: ${current_type_name} ${field_name}`;
+      throw `unreachable type name: ${type_name} ${field_name}`;
     }
   }
 
@@ -136,11 +136,11 @@ class JsNumbersAdapter {
   pub fn can_coerce_to_type(
       this: &JsAdapter,
       data_contexts: ContextIterator,
-      current_type_name: &str,
+      type_name: &str,
       coerce_to_type_name: &str,
   ) -> js_sys::Iterator;
   */
-  *canCoerceToType(data_contexts, current_type_name, coerce_to_type_name) {
+  *canCoerceToType(data_contexts, type_name, coerce_to_type_name) {
     const primes = {
       2: null,
       3: null,
@@ -148,7 +148,7 @@ class JsNumbersAdapter {
       7: null,
       11: null,
     };
-    if (current_type_name === "Number") {
+    if (type_name === "Number") {
       if (coerce_to_type_name === "Prime") {
         for (const ctx of data_contexts) {
           var can_coerce = false;
@@ -174,10 +174,10 @@ class JsNumbersAdapter {
           yield val;
         }
       } else {
-        throw `unreachable coercion type name: ${current_type_name} ${coerce_to_type_name}`;
+        throw `unreachable coercion type name: ${type_name} ${coerce_to_type_name}`;
       }
     } else {
-      throw `unreachable type name: ${current_type_name} ${coerce_to_type_name}`;
+      throw `unreachable type name: ${type_name} ${coerce_to_type_name}`;
     }
   }
 }

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -80,15 +80,15 @@ class JsNumbersAdapter {
   #[wasm_bindgen(structural, method, js_name = "projectProperty")]
   pub fn resolve_property(
       this: &JsAdapter,
-      data_contexts: ContextIterator,
+      contexts: ContextIterator,
       type_name: &str,
       field_name: &str,
   ) -> js_sys::Iterator;
   */
-  *projectProperty(data_contexts, type_name, field_name) {
+  *projectProperty(contexts, type_name, field_name) {
     if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
       if (field_name === "value") {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const val = {
             localId: ctx.localId,
             value: ctx.currentToken,
@@ -107,16 +107,16 @@ class JsNumbersAdapter {
   #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
   pub fn resolve_neighbors(
       this: &JsAdapter,
-      data_contexts: ContextIterator,
+      contexts: ContextIterator,
       type_name: &str,
       edge_name: &str,
       parameters: Option<EdgeParameters>,
   ) -> js_sys::Iterator;
   */
-  *projectNeighbors(data_contexts, type_name, edge_name, parameters) {
+  *projectNeighbors(contexts, type_name, edge_name, parameters) {
     if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
       if (edge_name === "successor") {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           const val = {
             localId: ctx.localId,
             neighbors: [ctx.currentToken + 1],
@@ -135,12 +135,12 @@ class JsNumbersAdapter {
   #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
   pub fn resolve_coercion(
       this: &JsAdapter,
-      data_contexts: ContextIterator,
+      contexts: ContextIterator,
       type_name: &str,
       coerce_to_type_name: &str,
   ) -> js_sys::Iterator;
   */
-  *canCoerceToType(data_contexts, type_name, coerce_to_type_name) {
+  *canCoerceToType(contexts, type_name, coerce_to_type_name) {
     const primes = {
       2: null,
       3: null,
@@ -150,7 +150,7 @@ class JsNumbersAdapter {
     };
     if (type_name === "Number") {
       if (coerce_to_type_name === "Prime") {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           var can_coerce = false;
           if (ctx.currentToken in primes) {
             can_coerce = true;
@@ -162,7 +162,7 @@ class JsNumbersAdapter {
           yield val;
         }
       } else if (coerce_to_type_name === "Composite") {
-        for (const ctx of data_contexts) {
+        for (const ctx of contexts) {
           var can_coerce = false;
           if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
             can_coerce = true;

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -137,10 +137,10 @@ class JsNumbersAdapter {
       this: &JsAdapter,
       contexts: ContextIterator,
       type_name: &str,
-      coerce_to_type_name: &str,
+      coerce_to_type: &str,
   ) -> js_sys::Iterator;
   */
-  *canCoerceToType(contexts, type_name, coerce_to_type_name) {
+  *canCoerceToType(contexts, type_name, coerce_to_type) {
     const primes = {
       2: null,
       3: null,
@@ -149,7 +149,7 @@ class JsNumbersAdapter {
       11: null,
     };
     if (type_name === "Number") {
-      if (coerce_to_type_name === "Prime") {
+      if (coerce_to_type === "Prime") {
         for (const ctx of contexts) {
           var can_coerce = false;
           if (ctx.currentToken in primes) {
@@ -161,7 +161,7 @@ class JsNumbersAdapter {
           };
           yield val;
         }
-      } else if (coerce_to_type_name === "Composite") {
+      } else if (coerce_to_type === "Composite") {
         for (const ctx of contexts) {
           var can_coerce = false;
           if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
@@ -174,10 +174,10 @@ class JsNumbersAdapter {
           yield val;
         }
       } else {
-        throw `unreachable coercion type name: ${type_name} ${coerce_to_type_name}`;
+        throw `unreachable coercion type name: ${type_name} ${coerce_to_type}`;
       }
     } else {
-      throw `unreachable type name: ${type_name} ${coerce_to_type_name}`;
+      throw `unreachable type name: ${type_name} ${coerce_to_type}`;
     }
   }
 }

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -105,7 +105,7 @@ class JsNumbersAdapter {
 
   /*
   #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
-  pub fn project_neighbors(
+  pub fn resolve_neighbors(
       this: &JsAdapter,
       data_contexts: ContextIterator,
       type_name: &str,


### PR DESCRIPTION
- Rename all the `Adapter` methods, lifetime, and associated type to match the new names in `BasicAdapter`.
- Move the `ContextIterator, ContextOutcomeIterator, VertexIterator` to `trustfall_core::interpreter`.
- Use the above type aliases wherever possible.