### PR TITLE
Makes links in README relative file links, fix some of them

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ etc. For a 10min video introduction to the project, see
 the ["How to Query (Almost) Everything" talk](https://www.hytradboi.com/2022/how-to-query-almost-everything)
 from the [HYTRADBOI 2022](https://www.hytradboi.com/) conference.
 
-![Terminal recording of running `cargo run --release -- query example_queries/actions_in_repos_with_min_10_hn_pts.ron` in the `demo-hytradboi` demo project. The system returns the first 20 results of the query in 6.36 seconds."](https://github.com/obi1kenobi/trustfall/raw/main/demo-hytradboi/query-demo.gif)
+![Terminal recording of running `cargo run --release -- query example_queries/actions_in_repos_with_min_10_hn_pts.ron` in the `demo-hytradboi` demo project. The system returns the first 20 results of the query in 6.36 seconds."](./demo-hytradboi/query-demo.gif)
 
 *Demo showing the execution of the cross-API query: "Which GitHub Actions are used in projects on the front page of HackerNews with >=10 points?"*
 
@@ -43,38 +43,43 @@ The demo executes the following query across the HackerNews and GitHub APIs and 
 }
 ```
 
-This demo is part of the ["How to Query (Almost) Everything" talk](https://www.hytradboi.com/2022/how-to-query-almost-everything)
-from the [HYTRADBOI 2022](https://www.hytradboi.com/) conference.
-Instructions for running the demo are available together with the source code
-in the `demo-hytradboi` directory:
-[link](https://github.com/obi1kenobi/trustfall/tree/main/demo-hytradboi).
+This demo is part of the ["How to Query (Almost) Everything"
+talk](https://www.hytradboi.com/2022/how-to-query-almost-everything) from the
+[HYTRADBOI 2022](https://www.hytradboi.com/) conference. Instructions for
+running the demo are available together with the source code in the
+`demo-hytradboi` directory: [link](./demo-hytradboi).
 
-For a brief overview of the query language and an example of using it to query APIs, check the
-`demo-hackernews` directory for a simpler demo only querying the HackerNews APIs: [link](https://github.com/obi1kenobi/trustfall/tree/main/demo-hackernews).
+For a brief overview of the query language and an example of using it to query
+APIs, check the `demo-hackernews` directory for a simpler demo only querying the
+HackerNews APIs: [link](./demo-hackernews).
 
 The easiest way to plug in a new data source is by implementing
 [the `BasicAdapter` trait](https://docs.rs/trustfall_core/latest/trustfall_core/interpreter/basic_adapter/trait.BasicAdapter.html).
 
-Python bindings are available, and are built automatically on every change to the engine;
-the most recent version may be downloaded [here](https://github.com/obi1kenobi/trustfall/releases). A getting started guide for Python is
-forthcoming ([tracking issue](https://github.com/obi1kenobi/trustfall/issues/16)); in the meantime,
-the best resource is the Python bindings'
-[test suite](https://github.com/obi1kenobi/trustfall/blob/main/pytrustfall/pytrustfall/tests/test_execution.py).
+Python bindings are available, and are built automatically on every change to
+the engine; the most recent version may be downloaded
+[here](https://github.com/obi1kenobi/trustfall/releases). A getting started
+guide for Python is forthcoming ([tracking
+issue](https://github.com/obi1kenobi/trustfall/issues/16)); in the meantime, the
+best resource is the Python bindings' [test suite](./pytrustfall/trustfall/tests/test_execution.py).
 
 ## Directory Registry
 
-- `trustfall_core` contains the query engine itself: [link](https://github.com/obi1kenobi/trustfall/tree/main/trustfall_core)
-- `pytrustfall` contains `pyo3`-based Python bindings for the `trustfall` engine: [link](https://github.com/obi1kenobi/trustfall/tree/main/pytrustfall)
-- `trustfall_wasm` is a WASM build of the `trustfall` engine: [link](https://github.com/obi1kenobi/trustfall/tree/main/trustfall_wasm)
-- `demo-hackernews` contains an example use case: querying the HackerNews APIs.
-- `demo-hytradboi` contains the demo code from the "How to Query (Almost) Everything" talk
-  at the [HYTRADBOI 2022](https://www.hytradboi.com/) conference.
-- `demo-feeds` is an example implementation querying RSS feeds using Rust and `trustfall`.
-- `demo-metar` is an example implementation querying METAR aviation weather reports using Rust
-  and `trustfall`.
-- `filetests_proc_macro` is a procedural macro used to generate test cases defined by files:
-  they ensure that the function under test, when given an input specified by one file,
-  produces an output equivalent to the contents of another file.
+- [`trustfall_core`](./trustfall_core/) contains the query engine itself
+- [`pytrustfall`](./pytrustfall/)
+ contains `pyo3`-based Python bindings for the `trustfall` engine
+- [`trustfall_wasm`](./trustfall_wasm/) is a WASM build of the `trustfall` engine
+- [`demo-hackernews`](./demo-hackernews/) contains an example use case: querying the HackerNews APIs.
+- [`demo-hytradboi`](./demo-hytradboi/) contains the demo code from the "How to
+  Query (Almost) Everything" talk at the [HYTRADBOI 2022](https://www.hytradboi.com/) conference.
+- [`demo-feeds`](./demo-feeds/) is an example implementation querying RSS feeds
+  using Rust and `trustfall`.
+- [`demo-metar`](./demo-metar/) is an example implementation querying METAR
+  aviation weather reports using Rust and `trustfall`.
+- [`trustfall_filetests_macros`](./trustfall_filetests_macros/) is a procedural
+  macro used to generate test cases defined by files: they ensure that the
+  function under test, when given an input specified by one file, produces an
+  output equivalent to the contents of another file.
 
 Copyright 2022-present Predrag Gruevski.
 


### PR DESCRIPTION
I think it makes more sense to link to local files than to link to GitHub. Also, some of them were outdated so I fixed them.

GitHub has support for this, see https://github.blog/2013-01-31-relative-links-in-markup-files/