### PR TITLE
Add `QueryInfo` argument instead of adapters' old hints arguments.

### DIFF
--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -8,10 +8,8 @@ use lazy_static::__Deref;
 use octorust::types::{ContentFile, FullRepository};
 use tokio::runtime::Runtime;
 use trustfall_core::{
-    interpreter::{
-        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
-    },
-    ir::{EdgeParameters, Eid, FieldValue, Vid},
+    interpreter::{Adapter, ContextIterator, ContextOutcomeIterator, QueryInfo, VertexIterator},
+    ir::{EdgeParameters, FieldValue},
 };
 
 use crate::{
@@ -197,8 +195,7 @@ impl Adapter<'static> for DemoAdapter {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         match edge_name.as_ref() {
             "HackerNewsFrontPage" => self.front_page(),
@@ -236,8 +233,7 @@ impl Adapter<'static> for DemoAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         match (type_name.as_ref(), property_name.as_ref()) {
             (_, "__typename") => Box::new(contexts.map(|ctx| {
@@ -376,9 +372,7 @@ impl Adapter<'static> for DemoAdapter {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         _parameters: &Option<Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
-        _edge_hint: Eid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("HackerNewsStory", "byUser") => Box::new(contexts.map(|ctx| {
@@ -696,8 +690,7 @@ impl Adapter<'static> for DemoAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         let type_name = type_name.clone();
         let coerce_to_type = coerce_to_type.clone();

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -1,10 +1,8 @@
 use std::{iter, sync::Arc};
 
 use trustfall_core::{
-    interpreter::{
-        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
-    },
-    ir::{EdgeParameters, Eid, FieldValue, Vid},
+    interpreter::{Adapter, ContextIterator, ContextOutcomeIterator, QueryInfo, VertexIterator},
+    ir::{EdgeParameters, FieldValue},
 };
 
 use crate::metar::{MetarCloudCover, MetarReport};
@@ -75,8 +73,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
             "MetarReport" => Box::new(self.data.iter().map(|x| x.into())),
@@ -108,8 +105,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         match type_name.as_ref() {
             "MetarReport" => {
@@ -171,9 +167,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
-        _edge_hint: Eid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("MetarReport", "cloudCover") => {
@@ -202,8 +196,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         todo!()
     }

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -6,10 +6,9 @@ use rustdoc_types::{
 };
 use trustfall_core::{
     interpreter::{
-        Adapter, ContextIterator, ContextOutcomeIterator, DataContext, InterpretedQuery,
-        VertexIterator,
+        Adapter, ContextIterator, ContextOutcomeIterator, DataContext, QueryInfo, VertexIterator,
     },
-    ir::{EdgeParameters, Eid, FieldValue, Vid},
+    ir::{EdgeParameters, FieldValue},
     schema::Schema,
 };
 
@@ -476,8 +475,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         &mut self,
         edge_name: &Arc<str>,
         _parameters: &Option<Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
             "Crate" => Box::new(std::iter::once(Token::new_crate(
@@ -500,8 +498,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         if property_name.as_ref() == "__typename" {
             Box::new(contexts.map(|ctx| match &ctx.current_token {
@@ -582,9 +579,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
-        _edge_hint: Eid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match type_name.as_ref() {
             "CrateDiff" => match edge_name.as_ref() {
@@ -1083,8 +1078,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         let coerce_to_type = coerce_to_type.clone();
         match type_name.as_ref() {

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -3,9 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::interpreter::{
-    Adapter, ContextIterator, ContextOutcomeIterator, DataContext, InterpretedQuery, VertexIterator,
+    Adapter, ContextIterator, ContextOutcomeIterator, DataContext, QueryInfo, VertexIterator,
 };
-use crate::ir::{EdgeParameters, Eid, FieldValue, Vid};
+use crate::ir::{EdgeParameters, FieldValue};
 use std::fs::{self, ReadDir};
 use std::iter;
 use std::path::{Path, PathBuf};
@@ -262,8 +262,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         assert!(edge_name.as_ref() == "OriginDirectory");
         assert!(parameters.is_none());
@@ -279,8 +278,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         match type_name.as_ref() {
             "Directory" => match property_name.as_ref() {
@@ -343,9 +341,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
-        edge_hint: Eid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("Directory", "out_Directory_ContainsFile") => {
@@ -373,8 +369,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         todo!()
     }

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
-use crate::ir::{EdgeParameters, Eid, FieldValue, Vid};
+use crate::ir::{EdgeParameters, FieldValue};
 
-use super::{Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator};
+use super::{hints::QueryInfo, Adapter, ContextIterator, ContextOutcomeIterator, VertexIterator};
 
 pub trait BasicAdapter<'vertex> {
     /// The type of vertices in the dataset this adapter queries.
@@ -143,8 +143,7 @@ where
         &mut self,
         edge_name: &std::sync::Arc<str>,
         parameters: &Option<std::sync::Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> VertexIterator<'vertex, Self::Vertex> {
         <Self as BasicAdapter>::resolve_starting_vertices(
             self,
@@ -158,8 +157,7 @@ where
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &std::sync::Arc<str>,
         property_name: &std::sync::Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
         <Self as BasicAdapter>::resolve_property(
             self,
@@ -175,9 +173,7 @@ where
         type_name: &std::sync::Arc<str>,
         edge_name: &std::sync::Arc<str>,
         parameters: &Option<std::sync::Arc<EdgeParameters>>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
-        _edge_hint: Eid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>> {
         <Self as BasicAdapter>::resolve_neighbors(
             self,
@@ -193,8 +189,7 @@ where
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &std::sync::Arc<str>,
         coerce_to_type: &std::sync::Arc<str>,
-        _query_hint: InterpretedQuery,
-        _vertex_hint: Vid,
+        _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool> {
         <Self as BasicAdapter>::resolve_coercion(
             self,

--- a/trustfall_core/src/interpreter/hints/mod.rs
+++ b/trustfall_core/src/interpreter/hints/mod.rs
@@ -4,6 +4,7 @@ use crate::ir::{Eid, FieldValue, IRQuery, Vid};
 
 use super::InterpretedQuery;
 
+/// Information about the query being processed.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct QueryInfo {
@@ -35,10 +36,12 @@ impl QueryInfo {
         &self.query.arguments
     }
 
+    /// The unique ID of the vertex at the query location where this [`QueryInfo`] was provided.
     pub fn origin_vid(&self) -> Vid {
         self.current_vertex
     }
 
+    /// If the query location of this [`QueryInfo`] was at an edge, this is the edge's unique ID.
     pub fn origin_crossing_eid(&self) -> Option<Eid> {
         self.crossing_eid
     }

--- a/trustfall_core/src/interpreter/hints/mod.rs
+++ b/trustfall_core/src/interpreter/hints/mod.rs
@@ -1,0 +1,45 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use crate::ir::{Eid, FieldValue, IRQuery, Vid};
+
+use super::InterpretedQuery;
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct QueryInfo {
+    query: InterpretedQuery,
+    current_vertex: Vid,
+    crossing_eid: Option<Eid>,
+}
+
+impl QueryInfo {
+    pub(crate) fn new(
+        query: InterpretedQuery,
+        current_vertex: Vid,
+        crossing_eid: Option<Eid>,
+    ) -> Self {
+        Self {
+            query,
+            current_vertex,
+            crossing_eid,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn ir_query(&self) -> &IRQuery {
+        &self.query.indexed_query.ir_query
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn arguments(&self) -> &Arc<BTreeMap<Arc<str>, FieldValue>> {
+        &self.query.arguments
+    }
+
+    pub fn origin_vid(&self) -> Vid {
+        self.current_vertex
+    }
+
+    pub fn origin_crossing_eid(&self) -> Option<Eid> {
+        self.crossing_eid
+    }
+}

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -19,9 +19,12 @@ pub mod error;
 pub mod execution;
 mod filtering;
 pub mod helpers;
+mod hints;
 pub mod macros;
 pub mod replay;
 pub mod trace;
+
+pub use hints::QueryInfo;
 
 /// An iterator of vertices representing data points we are querying.
 pub type VertexIterator<'vertex, VertexT> = Box<dyn Iterator<Item = VertexT> + 'vertex>;
@@ -379,8 +382,7 @@ pub trait Adapter<'vertex> {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> VertexIterator<'vertex, Self::Vertex>;
 
     fn resolve_property(
@@ -388,8 +390,7 @@ pub trait Adapter<'vertex> {
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue>;
 
     #[allow(clippy::too_many_arguments)]
@@ -399,9 +400,7 @@ pub trait Adapter<'vertex> {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
-        edge_hint: Eid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>>;
 
     fn resolve_coercion(
@@ -409,7 +408,6 @@ pub trait Adapter<'vertex> {
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool>;
 }

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -3,10 +3,8 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    interpreter::{
-        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
-    },
-    ir::{EdgeParameters, Eid, FieldValue, Vid},
+    interpreter::{Adapter, ContextIterator, ContextOutcomeIterator, QueryInfo, VertexIterator},
+    ir::{EdgeParameters, FieldValue},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -23,8 +21,7 @@ impl Adapter<'static> for NullablesAdapter {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         unimplemented!()
     }
@@ -34,8 +31,7 @@ impl Adapter<'static> for NullablesAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         unimplemented!()
     }
@@ -46,9 +42,7 @@ impl Adapter<'static> for NullablesAdapter {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
-        edge_hint: Eid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         unimplemented!()
     }
@@ -58,8 +52,7 @@ impl Adapter<'static> for NullablesAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         unimplemented!()
     }

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     interpreter::{
         helpers::{resolve_coercion_with, resolve_neighbors_with, resolve_property_with},
-        Adapter, ContextIterator, ContextOutcomeIterator, InterpretedQuery, VertexIterator,
+        Adapter, ContextIterator, ContextOutcomeIterator, QueryInfo, VertexIterator,
     },
-    ir::{EdgeParameters, Eid, FieldValue, Vid},
+    ir::{EdgeParameters, FieldValue},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,8 +179,7 @@ impl Adapter<'static> for NumbersAdapter {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         let mut primes = btreeset![2, 3];
         match edge_name.as_ref() {
@@ -216,8 +215,7 @@ impl Adapter<'static> for NumbersAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         match (type_name.as_ref(), property_name.as_ref()) {
             ("Number" | "Prime" | "Composite" | "Neither", "value") => {
@@ -244,9 +242,7 @@ impl Adapter<'static> for NumbersAdapter {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<EdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
-        edge_hint: Eid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let mut primes = btreeset![2, 3];
         let parameters = parameters.clone();
@@ -362,8 +358,7 @@ impl Adapter<'static> for NumbersAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         match (type_name.as_ref(), coerce_to_type.as_ref()) {
             ("Number", "Prime") => {

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -3,10 +3,9 @@ use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
 use js_sys::try_iter;
 use trustfall_core::{
     interpreter::{
-        Adapter, ContextIterator, ContextOutcomeIterator, DataContext, InterpretedQuery,
-        VertexIterator,
+        Adapter, ContextIterator, ContextOutcomeIterator, DataContext, QueryInfo, VertexIterator,
     },
-    ir::{EdgeParameters as CoreEdgeParameters, Eid, FieldValue, Vid},
+    ir::{EdgeParameters as CoreEdgeParameters, FieldValue},
 };
 use wasm_bindgen::prelude::*;
 
@@ -262,8 +261,7 @@ impl Adapter<'static> for AdapterShim {
         &mut self,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<CoreEdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         let parameters: JsEdgeParameters = parameters.clone().into();
         let js_iter = self
@@ -277,8 +275,7 @@ impl Adapter<'static> for AdapterShim {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
         let ctx_iter = JsContextIterator::new(contexts);
         let registry = ctx_iter.registry.clone();
@@ -294,9 +291,7 @@ impl Adapter<'static> for AdapterShim {
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         parameters: &Option<Arc<CoreEdgeParameters>>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
-        edge_hint: Eid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let ctx_iter = JsContextIterator::new(contexts);
         let registry = ctx_iter.registry.clone();
@@ -320,8 +315,7 @@ impl Adapter<'static> for AdapterShim {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
-        query_hint: InterpretedQuery,
-        vertex_hint: Vid,
+        query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         let ctx_iter = JsContextIterator::new(contexts);
         let registry = ctx_iter.registry.clone();


### PR DESCRIPTION
This is "the big breaking change" of the `Adapter` API, to move it toward the new format that allows the advanced optimizations described in this blog post: https://predr.ag/blog/speeding-up-rust-semver-checking-by-over-2000x/