### PR TITLE
Initial work on trustfall_macros, including NamedType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,6 +3198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall_macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+ "trustfall_core",
+]
+
+[[package]]
 name = "trustfall_rustdoc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "trustfall_core",
     "trustfall_filetests_macros",
+    "trustfall_macros",
     "trustfall_wasm",
     "pytrustfall",
     "demo-hackernews",

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -23,6 +23,10 @@ pub mod macros;
 pub mod replay;
 pub mod trace;
 
+trait NamedType {
+    fn typename(&self) -> &'static str;
+}
+
 /// An iterator of vertices representing data points we are querying.
 pub type VertexIterator<'vertex, VertexT> = Box<dyn Iterator<Item = VertexT> + 'vertex>;
 

--- a/trustfall_macros/Cargo.toml
+++ b/trustfall_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "trustfall_macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
+
+[dependencies]
+trustfall_core = { path = "../trustfall_core" }
+quote = "1.0"
+syn = "1.0"

--- a/trustfall_macros/src/lib.rs
+++ b/trustfall_macros/src/lib.rs
@@ -1,0 +1,33 @@
+use core::panicking::panic;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{self, Data};
+
+#[proc_macro_derive(NamedType)]
+pub fn named_type_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    impl_named_type(&ast)
+}
+
+fn impl_named_type(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    todo!("Iterate over variants, adding the string form of their name for each");
+
+    let variants = match &ast.data {
+        Data::Enum(d) => d.variants,
+        _ => panic!("Only enums can become named types!"),
+    };
+
+    let gen = quote! {
+        impl NamedType for #name {
+            fn typename(&self) -> &'static str {
+                match self {
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+    gen.into()
+}


### PR DESCRIPTION
Relates to discussion #161, where "__typename" could be implemented as a procedural macro.

My thinking is that if we use a `NamedType` trait, we can possibly add that as a trait bound (or not, if it is considered breaking). Alternatively, the trait can be skipped.

Very much WIP