### PR TITLE
Make `EdgeParameters` in adapters more ergonomic to use.

### DIFF
--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -66,7 +66,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &str,
-        _parameters: Option<&EdgeParameters>,
+        _parameters: &EdgeParameters,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name {
             "Feed" => Box::new(self.data.iter().map(Token::Feed)),
@@ -160,7 +160,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
-        _parameters: Option<&EdgeParameters>,
+        _parameters: &EdgeParameters,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match type_name {
             "Feed" => match edge_name {

--- a/demo-hackernews/src/adapter.rs
+++ b/demo-hackernews/src/adapter.rs
@@ -106,31 +106,21 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &str,
-        parameters: Option<&EdgeParameters>,
+        parameters: &EdgeParameters,
     ) -> VertexIterator<'static, Self::Vertex> {
         match edge_name {
             "FrontPage" => self.front_page(),
             "Top" => {
-                // TODO: This is unergonomic, build a more convenient API here.
-                let max = parameters
-                    .unwrap()
-                    .0
-                    .get("max")
-                    .map(|v| v.as_u64().unwrap() as usize);
+                let max = parameters.get("max").map(|v| v.as_u64().unwrap() as usize);
                 self.top(max)
             }
             "LatestStory" => {
-                // TODO: This is unergonomic, build a more convenient API here.
-                let max = parameters
-                    .unwrap()
-                    .0
-                    .get("max")
-                    .map(|v| v.as_u64().unwrap() as usize);
+                let max = parameters.get("max").map(|v| v.as_u64().unwrap() as usize);
                 self.latest_stories(max)
             }
             "User" => {
-                let username_value = parameters.as_ref().unwrap().0.get("name").unwrap();
-                self.user(username_value.as_str().unwrap())
+                let username_value = parameters["name"].as_str().unwrap();
+                self.user(username_value)
             }
             _ => unreachable!(),
         }
@@ -199,7 +189,7 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
-        _parameters: Option<&EdgeParameters>,
+        _parameters: &EdgeParameters,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         match (type_name, edge_name) {
             ("Story", "byUser") => {

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -194,34 +194,22 @@ impl Adapter<'static> for DemoAdapter {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         match edge_name.as_ref() {
             "HackerNewsFrontPage" => self.front_page(),
             "HackerNewsTop" => {
-                // TODO: This is unergonomic, build a more convenient API here.
-                let max = parameters
-                    .as_deref()
-                    .unwrap()
-                    .0
-                    .get("max")
-                    .map(|v| v.as_u64().unwrap() as usize);
+                let max = parameters.get("max").map(|v| v.as_u64().unwrap() as usize);
                 self.top(max)
             }
             "HackerNewsLatestStories" => {
-                // TODO: This is unergonomic, build a more convenient API here.
-                let max = parameters
-                    .as_deref()
-                    .unwrap()
-                    .0
-                    .get("max")
-                    .map(|v| v.as_u64().unwrap() as usize);
+                let max = parameters.get("max").map(|v| v.as_u64().unwrap() as usize);
                 self.latest_stories(max)
             }
             "HackerNewsUser" => {
-                let username_value = parameters.as_ref().unwrap().0.get("name").unwrap();
-                self.user(username_value.as_str().unwrap())
+                let username_value = parameters["name"].as_str().unwrap();
+                self.user(username_value)
             }
             "MostDownloadedCrates" => self.most_downloaded_crates(),
             _ => unreachable!(),
@@ -371,7 +359,7 @@ impl Adapter<'static> for DemoAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        _parameters: &Option<Arc<EdgeParameters>>,
+        _parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -72,23 +72,13 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
             "MetarReport" => Box::new(self.data.iter().map(|x| x.into())),
             "LatestMetarReportForAirport" => {
-                let station_code = match parameters
-                    .as_ref()
-                    .unwrap()
-                    .0
-                    .get("airport_code")
-                    .unwrap()
-                    .clone()
-                {
-                    FieldValue::String(s) => s,
-                    _ => unreachable!(),
-                };
+                let station_code = parameters["airport_code"].as_str().unwrap().to_string();
                 let iter = self
                     .data
                     .iter()
@@ -166,12 +156,12 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("MetarReport", "cloudCover") => {
-                assert!(parameters.is_none());
+                assert!(parameters.is_empty());
 
                 Box::new(contexts.map(|ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match &ctx.current_token {

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -474,7 +474,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        _parameters: &Option<Arc<EdgeParameters>>,
+        _parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
@@ -578,7 +578,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match type_name.as_ref() {

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -239,14 +239,13 @@ impl BasicAdapter<'static> for AdapterShim {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &str,
-        parameters: Option<&EdgeParameters>,
+        parameters: &EdgeParameters,
     ) -> VertexIterator<'static, Self::Vertex> {
         Python::with_gil(|py| {
-            let parameter_data: Option<BTreeMap<String, Py<PyAny>>> = parameters.map(|x| {
-                x.0.iter()
-                    .map(|(k, v)| (k.to_string(), make_python_value(py, v.to_owned())))
-                    .collect()
-            });
+            let parameter_data: BTreeMap<String, Py<PyAny>> = parameters
+                .iter()
+                .map(|(k, v)| (k.to_string(), make_python_value(py, v.to_owned())))
+                .collect();
 
             let py_iterable = self
                 .adapter
@@ -290,15 +289,14 @@ impl BasicAdapter<'static> for AdapterShim {
         contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
-        parameters: Option<&EdgeParameters>,
+        parameters: &EdgeParameters,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let contexts = ContextIterator::new(contexts);
         Python::with_gil(|py| {
-            let parameter_data: Option<BTreeMap<String, Py<PyAny>>> = parameters.map(|x| {
-                x.0.iter()
-                    .map(|(k, v)| (k.to_string(), make_python_value(py, v.to_owned())))
-                    .collect()
-            });
+            let parameter_data: BTreeMap<String, Py<PyAny>> = parameters
+                .iter()
+                .map(|(k, v)| (k.to_string(), make_python_value(py, v.to_owned())))
+                .collect();
 
             let py_iterable = self
                 .adapter

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -261,11 +261,11 @@ impl Adapter<'static> for FilesystemInterpreter {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         assert!(edge_name.as_ref() == "OriginDirectory");
-        assert!(parameters.is_none());
+        assert!(parameters.is_empty());
         let token = DirectoryToken {
             name: "<origin>".to_owned(),
             path: "".to_owned(),
@@ -340,7 +340,7 @@ impl Adapter<'static> for FilesystemInterpreter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {

--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -147,7 +147,7 @@ fn get_vertex_field_definitions<'a>(
 fn make_edge_parameters(
     edge_definition: &FieldDefinition,
     specified_arguments: &BTreeMap<Arc<str>, FieldValue>,
-) -> Result<Option<Arc<EdgeParameters>>, Vec<FrontendError>> {
+) -> Result<EdgeParameters, Vec<FrontendError>> {
     let mut errors: Vec<FrontendError> = vec![];
 
     let mut edge_arguments: BTreeMap<Arc<str>, FieldValue> = BTreeMap::new();
@@ -222,10 +222,8 @@ fn make_edge_parameters(
 
     if !errors.is_empty() {
         Err(errors)
-    } else if edge_arguments.is_empty() {
-        Ok(None)
     } else {
-        Ok(Some(Arc::new(EdgeParameters(edge_arguments))))
+        Ok(EdgeParameters::new(Arc::new(edge_arguments)))
     }
 }
 
@@ -1262,7 +1260,7 @@ fn make_fold<'schema, 'query, V, E>(
     fold_group: &'query FoldGroup,
     fold_eid: Eid,
     edge_name: Arc<str>,
-    edge_parameters: Option<Arc<EdgeParameters>>,
+    edge_parameters: EdgeParameters,
     parent_vid: Vid,
     starting_vid: Vid,
     starting_pre_coercion_type: Arc<str>,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -28,7 +28,7 @@ pub trait BasicAdapter<'vertex> {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &str,
-        parameters: Option<&EdgeParameters>,
+        parameters: &EdgeParameters,
     ) -> VertexIterator<'vertex, Self::Vertex>;
 
     /// Resolve the value of a vertex property over an iterator of query contexts.
@@ -88,7 +88,7 @@ pub trait BasicAdapter<'vertex> {
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
-        parameters: Option<&EdgeParameters>,
+        parameters: &EdgeParameters,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>>;
 
     /// Attempt to coerce vertices to a subtype, over an iterator of query contexts.
@@ -142,14 +142,10 @@ where
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &std::sync::Arc<str>,
-        parameters: &Option<std::sync::Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> VertexIterator<'vertex, Self::Vertex> {
-        <Self as BasicAdapter>::resolve_starting_vertices(
-            self,
-            edge_name.as_ref(),
-            parameters.as_deref(),
-        )
+        <Self as BasicAdapter>::resolve_starting_vertices(self, edge_name.as_ref(), parameters)
     }
 
     fn resolve_property(
@@ -172,7 +168,7 @@ where
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &std::sync::Arc<str>,
         edge_name: &std::sync::Arc<str>,
-        parameters: &Option<std::sync::Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>> {
         <Self as BasicAdapter>::resolve_neighbors(
@@ -180,7 +176,7 @@ where
             contexts,
             type_name.as_ref(),
             edge_name.as_ref(),
-            parameters.as_deref(),
+            parameters,
         )
     }
 

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -1097,7 +1097,7 @@ fn expand_non_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
     _expanding_to: &IRVertex,
     edge_id: Eid,
     edge_name: &Arc<str>,
-    edge_parameters: &Option<Arc<EdgeParameters>>,
+    edge_parameters: &EdgeParameters,
     is_optional: bool,
     iterator: ContextIterator<'query, Vertex>,
 ) -> ContextIterator<'query, Vertex> {
@@ -1160,7 +1160,7 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
     expanding_to: &IRVertex,
     edge_id: Eid,
     edge_name: &Arc<str>,
-    edge_parameters: &Option<Arc<EdgeParameters>>,
+    edge_parameters: &EdgeParameters,
     recursive: &Recursive,
     iterator: ContextIterator<'query, Vertex>,
 ) -> ContextIterator<'query, Vertex> {
@@ -1245,7 +1245,7 @@ fn perform_one_recursive_edge_expansion<'query, Vertex: Clone + Debug + 'query>(
     _expanding_to: &IRVertex,
     edge_id: Eid,
     edge_name: &Arc<str>,
-    edge_parameters: &Option<Arc<EdgeParameters>>,
+    edge_parameters: &EdgeParameters,
     iterator: ContextIterator<'query, Vertex>,
 ) -> ContextIterator<'query, Vertex> {
     let query_info = QueryInfo::new(query.clone(), expanding_from.vid, Some(edge_id));

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -381,7 +381,7 @@ pub trait Adapter<'vertex> {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'vertex, Self::Vertex>;
 
@@ -399,7 +399,7 @@ pub trait Adapter<'vertex> {
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>>;
 

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -392,7 +392,7 @@ where
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'trace, Self::Vertex> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())
@@ -449,7 +449,7 @@ where
         contexts: ContextIterator<'trace, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'trace, Self::Vertex, VertexIterator<'trace, Self::Vertex>> {
         let (root_opid, trace_op) = advance_ref_iter(self.next_op.as_ref())

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -239,7 +239,7 @@ where
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'vertex, Self::Vertex> {
         let mut trace = self.tracer.borrow_mut();
@@ -347,7 +347,7 @@ where
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, VertexIterator<'vertex, Self::Vertex>> {
         let mut trace = self.tracer.borrow_mut();

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -20,7 +20,7 @@ impl Adapter<'static> for NullablesAdapter {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         unimplemented!()
@@ -41,7 +41,7 @@ impl Adapter<'static> for NullablesAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         unimplemented!()

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -178,7 +178,7 @@ impl Adapter<'static> for NumbersAdapter {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         let mut primes = btreeset![2, 3];
@@ -188,12 +188,8 @@ impl Adapter<'static> for NumbersAdapter {
             "Two" => Box::new(std::iter::once(make_number_token(&mut primes, 2))),
             "Four" => Box::new(std::iter::once(make_number_token(&mut primes, 4))),
             "Number" | "NumberImplicitNullDefault" => {
-                let parameters = &parameters.as_deref().unwrap().0;
-                let min_value = parameters
-                    .get("min")
-                    .and_then(FieldValue::as_i64)
-                    .unwrap_or(0);
-                let max_value = parameters.get("max").and_then(FieldValue::as_i64).unwrap();
+                let min_value = parameters["min"].as_i64().unwrap_or(0);
+                let max_value = parameters["max"].as_i64().unwrap();
 
                 if min_value > max_value {
                     Box::new(std::iter::empty())
@@ -241,7 +237,7 @@ impl Adapter<'static> for NumbersAdapter {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<EdgeParameters>>,
+        parameters: &EdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let mut primes = btreeset![2, 3];
@@ -279,8 +275,7 @@ impl Adapter<'static> for NumbersAdapter {
                             let value = vertex.0;
                             let mut local_primes = primes.clone();
 
-                            let max_multiple =
-                                parameters.as_ref().unwrap().0["max"].as_i64().unwrap();
+                            let max_multiple = parameters["max"].as_i64().unwrap();
 
                             // We're only outputting composite numbers only,
                             // and the initial number is prime.
@@ -295,8 +290,7 @@ impl Adapter<'static> for NumbersAdapter {
                             let value = vertex.0;
                             let mut local_primes = primes.clone();
 
-                            let max_multiple =
-                                parameters.as_ref().unwrap().0["max"].as_i64().unwrap();
+                            let max_multiple = parameters["max"].as_i64().unwrap();
                             Box::new((1..=max_multiple).map(move |mult| {
                                 let next_value = value * mult;
                                 make_number_token(&mut local_primes, next_value)

--- a/trustfall_core/test_data/tests/execution_errors/both_missing_and_unused.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/both_missing_and_unused.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/execution_errors/invalid_argument_types.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/invalid_argument_types.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/execution_errors/invalid_null_argument_values.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/invalid_null_argument_values.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/execution_errors/missing_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/missing_argument.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/execution_errors/missing_unused_and_invalid_arguments.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/missing_unused_and_invalid_arguments.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/execution_errors/unused_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/unused_argument.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/parse_errors/invalid_filter_argument_name.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/invalid_filter_argument_name.parse-error.ron
@@ -1,6 +1,4 @@
-Err(OtherError(
-    "Filter argument names must only contain ASCII alphanumerics or underscore characters: containsåäö",
-    Pos(
-        line: 4,
-        column: 58,
+Err(OtherError("Filter argument names must only contain ASCII alphanumerics or underscore characters: containsåäö", Pos(
+  line: 4,
+  column: 58,
 )))

--- a/trustfall_core/test_data/tests/parse_errors/invalid_filter_argument_name_start.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/invalid_filter_argument_name_start.parse-error.ron
@@ -1,7 +1,4 @@
-Err(OtherError(
-  "Filter argument names must start with an ASCII letter or underscore character: 1forexample",
-  Pos(
-    line: 4,
-    column: 58,
-  )
-))
+Err(OtherError("Filter argument names must start with an ASCII letter or underscore character: 1forexample", Pos(
+  line: 4,
+  column: 58,
+)))

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(20),
-      "min": Int64(10),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(20),
+        "min": Int64(10),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
@@ -1866,10 +1866,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(20),
-        "min": Int64(10),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(20),
+          "min": Int64(10),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
@@ -1318,10 +1318,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(10),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(10),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(6),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(6),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
@@ -1157,10 +1157,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(6),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(6),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(6),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(6),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
@@ -820,10 +820,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(6),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(6),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(4),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(4),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -2399,10 +2399,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(4),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(4),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(6),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(6),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -55,9 +57,11 @@ Ok(TestIRQuery(
           from_vid: Vid(4),
           to_vid: Vid(5),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
@@ -1916,10 +1916,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(6),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(6),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -1969,9 +1971,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(4),
             to_vid: Vid(5),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
@@ -502,10 +502,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(10),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(10),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -24,9 +26,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
@@ -577,10 +577,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -599,9 +601,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(10),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(10),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
@@ -149,9 +149,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(10),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(10),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.ir.ron
@@ -38,9 +38,11 @@ Ok(TestIRQuery(
           from_vid: Vid(2),
           to_vid: Vid(3),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(3),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
@@ -513,9 +513,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(2),
             to_vid: Vid(3),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(3),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -386,9 +386,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(2),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(2),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {
@@ -33,9 +35,11 @@ Ok(TestIRQuery(
                 from_vid: Vid(2),
                 to_vid: Vid(3),
                 edge_name: "multiple",
-                parameters: Some(EdgeParameters({
-                  "max": Int64(2),
-                })),
+                parameters: EdgeParameters(
+                  contents: {
+                    "max": Int64(2),
+                  },
+                ),
                 component: IRQueryComponent(
                   root: Vid(3),
                   vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -618,9 +618,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(2),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(2),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {
@@ -635,9 +637,11 @@ TestInterpreterOutputTrace(
                   from_vid: Vid(2),
                   to_vid: Vid(3),
                   edge_name: "multiple",
-                  parameters: Some(EdgeParameters({
-                    "max": Int64(2),
-                  })),
+                  parameters: EdgeParameters(
+                    contents: {
+                      "max": Int64(2),
+                    },
+                  ),
                   component: IRQueryComponent(
                     root: Vid(3),
                     vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(11),
-      "min": Int64(8),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(11),
+        "min": Int64(8),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
@@ -384,10 +384,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(11),
-        "min": Int64(8),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(11),
+          "min": Int64(8),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(8),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(8),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -33,9 +35,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(4),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(4),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
@@ -1341,10 +1341,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(10),
-        "min": Int64(8),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(10),
+          "min": Int64(8),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -1372,9 +1374,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(4),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(4),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(8),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(8),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -33,9 +35,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(4),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(4),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
@@ -1243,10 +1243,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(10),
-        "min": Int64(8),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(10),
+          "min": Int64(8),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -1274,9 +1276,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(4),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(4),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(14),
-      "min": Int64(4),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(14),
+        "min": Int64(4),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
@@ -479,10 +479,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(14),
-        "min": Int64(4),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(14),
+          "min": Int64(4),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(13),
-      "min": Int64(10),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(13),
+        "min": Int64(10),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
@@ -253,10 +253,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(13),
-        "min": Int64(10),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(13),
+          "min": Int64(10),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(20),
-      "min": Int64(12),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(20),
+        "min": Int64(12),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
@@ -608,10 +608,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(20),
-        "min": Int64(12),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(20),
+          "min": Int64(12),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(9),
-      "min": Int64(8),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(9),
+        "min": Int64(8),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
@@ -159,10 +159,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(9),
-        "min": Int64(8),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(9),
+          "min": Int64(8),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(9),
-      "min": Int64(8),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(9),
+        "min": Int64(8),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
@@ -159,10 +159,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(9),
-        "min": Int64(8),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(9),
+          "min": Int64(8),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(9),
-      "min": Int64(8),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(9),
+        "min": Int64(8),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
@@ -159,10 +159,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(9),
-        "min": Int64(8),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(9),
+          "min": Int64(8),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(16),
-      "min": Int64(12),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(16),
+        "min": Int64(12),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
@@ -306,10 +306,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(16),
-        "min": Int64(12),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(16),
+          "min": Int64(12),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(16),
-      "min": Int64(12),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(16),
+        "min": Int64(12),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
@@ -306,10 +306,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(16),
-        "min": Int64(12),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(16),
+          "min": Int64(12),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(22),
-      "min": Int64(5),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(22),
+        "min": Int64(5),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
@@ -1882,10 +1882,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(22),
-        "min": Int64(5),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(22),
+          "min": Int64(5),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(4),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(4),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
@@ -303,9 +303,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(4),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(4),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(6),
-      "min": Int64(4),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(6),
+        "min": Int64(4),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
@@ -425,10 +425,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(6),
-        "min": Int64(4),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(6),
+          "min": Int64(4),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(32),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(32),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -383,10 +383,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(32),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(32),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(32),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(32),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -383,10 +383,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(32),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(32),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(32),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(32),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -383,10 +383,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(32),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(32),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(32),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(32),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -383,10 +383,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(32),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(32),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(30),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(30),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -426,10 +426,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(30),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(30),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
@@ -199,9 +199,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(30),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(30),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
@@ -266,10 +266,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(30),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(30),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(30),
-      "min": Int64(30),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(30),
+        "min": Int64(30),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
@@ -266,10 +266,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(30),
-        "min": Int64(30),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(30),
+          "min": Int64(30),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(2),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(2),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {
@@ -33,9 +35,11 @@ Ok(TestIRQuery(
                 from_vid: Vid(2),
                 to_vid: Vid(3),
                 edge_name: "multiple",
-                parameters: Some(EdgeParameters({
-                  "max": Int64(2),
-                })),
+                parameters: EdgeParameters(
+                  contents: {
+                    "max": Int64(2),
+                  },
+                ),
                 component: IRQueryComponent(
                   root: Vid(3),
                   vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -514,9 +514,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(2),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(2),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {
@@ -531,9 +533,11 @@ TestInterpreterOutputTrace(
                   from_vid: Vid(2),
                   to_vid: Vid(3),
                   edge_name: "multiple",
-                  parameters: Some(EdgeParameters({
-                    "max": Int64(2),
-                  })),
+                  parameters: EdgeParameters(
+                    contents: {
+                      "max": Int64(2),
+                    },
+                  ),
                   component: IRQueryComponent(
                     root: Vid(3),
                     vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(12),
-      "min": Int64(10),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(12),
+        "min": Int64(10),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
@@ -2469,10 +2469,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(12),
-        "min": Int64(10),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(12),
+          "min": Int64(10),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "NumberImplicitNullDefault",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(1),
-      "min": Null,
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(1),
+        "min": Null,
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
@@ -109,10 +109,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "NumberImplicitNullDefault",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(1),
-        "min": Null,
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(1),
+          "min": Null,
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.ir.ron
@@ -29,9 +29,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
@@ -258,9 +258,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(6),
-      "min": Int64(6),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(6),
+        "min": Int64(6),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -46,9 +48,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(3),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(3),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -684,10 +684,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(6),
-        "min": Int64(6),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(6),
+          "min": Int64(6),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -728,9 +730,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(3),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(3),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(6),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(6),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
@@ -566,9 +566,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(6),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(6),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.ir.ron
@@ -16,9 +16,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(2),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(2),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
@@ -556,9 +556,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(2),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(2),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(7),
-      "min": Int64(5),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(7),
+        "min": Int64(5),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -20,9 +22,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
           component: IRQueryComponent(
             root: Vid(2),
             vertices: {
@@ -37,9 +41,11 @@ Ok(TestIRQuery(
                 from_vid: Vid(2),
                 to_vid: Vid(3),
                 edge_name: "multiple",
-                parameters: Some(EdgeParameters({
-                  "max": Int64(3),
-                })),
+                parameters: EdgeParameters(
+                  contents: {
+                    "max": Int64(3),
+                  },
+                ),
                 component: IRQueryComponent(
                   root: Vid(3),
                   vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
@@ -3831,10 +3831,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(7),
-        "min": Int64(5),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(7),
+          "min": Int64(5),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -3849,9 +3851,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
             component: IRQueryComponent(
               root: Vid(2),
               vertices: {
@@ -3866,9 +3870,11 @@ TestInterpreterOutputTrace(
                   from_vid: Vid(2),
                   to_vid: Vid(3),
                   edge_name: "multiple",
-                  parameters: Some(EdgeParameters({
-                    "max": Int64(3),
-                  })),
+                  parameters: EdgeParameters(
+                    contents: {
+                      "max": Int64(3),
+                    },
+                  ),
                   component: IRQueryComponent(
                     root: Vid(3),
                     vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(6),
-      "min": Int64(6),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(6),
+        "min": Int64(6),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -35,9 +37,11 @@ Ok(TestIRQuery(
                 from_vid: Vid(2),
                 to_vid: Vid(3),
                 edge_name: "multiple",
-                parameters: Some(EdgeParameters({
-                  "max": Int64(3),
-                })),
+                parameters: EdgeParameters(
+                  contents: {
+                    "max": Int64(3),
+                  },
+                ),
                 component: IRQueryComponent(
                   root: Vid(3),
                   vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
@@ -923,10 +923,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(6),
-        "min": Int64(6),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(6),
+          "min": Int64(6),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -956,9 +958,11 @@ TestInterpreterOutputTrace(
                   from_vid: Vid(2),
                   to_vid: Vid(3),
                   edge_name: "multiple",
-                  parameters: Some(EdgeParameters({
-                    "max": Int64(3),
-                  })),
+                  parameters: EdgeParameters(
+                    contents: {
+                      "max": Int64(3),
+                    },
+                  ),
                   component: IRQueryComponent(
                     root: Vid(3),
                     vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(64),
-      "min": Int64(64),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(64),
+        "min": Int64(64),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
@@ -975,10 +975,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(64),
-        "min": Int64(64),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(64),
+          "min": Int64(64),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
@@ -521,10 +521,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(4),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(4),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -24,9 +26,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
           optional: true,
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
@@ -1062,10 +1062,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(4),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(4),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -1084,9 +1086,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
             optional: true,
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(32),
-      "min": Int64(28),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(32),
+        "min": Int64(28),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
@@ -883,10 +883,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(32),
-        "min": Int64(28),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(32),
+          "min": Int64(28),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(5),
-      "min": Int64(4),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(5),
+        "min": Int64(4),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -37,9 +39,11 @@ Ok(TestIRQuery(
           from_vid: Vid(2),
           to_vid: Vid(3),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
@@ -4087,10 +4087,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(5),
-        "min": Int64(4),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(5),
+          "min": Int64(4),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -4122,9 +4124,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(2),
             to_vid: Vid(3),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
@@ -1982,10 +1982,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.ir.ron
@@ -20,9 +20,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(2),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(2),
+            },
+          ),
           recursive: Some(Recursive(
             depth: 3,
           )),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -1294,9 +1294,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(2),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(2),
+              },
+            ),
             recursive: Some(Recursive(
               depth: 3,
             )),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(5),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(5),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -2052,10 +2052,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(5),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(5),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(5),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(5),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -1952,10 +1952,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(5),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(5),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(10),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(10),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
@@ -505,10 +505,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(10),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(10),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
@@ -191,10 +191,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(0),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(0),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
@@ -183,10 +183,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(0),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(0),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(4),
-      "min": Int64(2),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(4),
+        "min": Int64(2),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -48,9 +50,11 @@ Ok(TestIRQuery(
           from_vid: Vid(2),
           to_vid: Vid(3),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
         Eid(3): IREdge(
           eid: Eid(3),

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -1057,10 +1057,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(4),
-        "min": Int64(2),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(4),
+          "min": Int64(2),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -1103,9 +1105,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(2),
             to_vid: Vid(3),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
           Eid(3): IREdge(
             eid: Eid(3),

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(2),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(2),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -38,18 +40,22 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
         Eid(2): IREdge(
           eid: Eid(2),
           from_vid: Vid(1),
           to_vid: Vid(3),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
       },
       outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -1579,10 +1579,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(2),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(2),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -1615,18 +1617,22 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
           Eid(2): IREdge(
             eid: Eid(2),
             from_vid: Vid(1),
             to_vid: Vid(3),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
         },
         outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(3),
-      "min": Int64(1),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(1),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {
@@ -63,9 +65,11 @@ Ok(TestIRQuery(
           from_vid: Vid(1),
           to_vid: Vid(2),
           edge_name: "multiple",
-          parameters: Some(EdgeParameters({
-            "max": Int64(3),
-          })),
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
         ),
         Eid(2): IREdge(
           eid: Eid(2),

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -2105,10 +2105,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(3),
-        "min": Int64(1),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(1),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {
@@ -2166,9 +2168,11 @@ TestInterpreterOutputTrace(
             from_vid: Vid(1),
             to_vid: Vid(2),
             edge_name: "multiple",
-            parameters: Some(EdgeParameters({
-              "max": Int64(3),
-            })),
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
           ),
           Eid(2): IREdge(
             eid: Eid(2),

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(2),
-      "min": Int64(1),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(2),
+        "min": Int64(1),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
@@ -139,10 +139,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(2),
-        "min": Int64(1),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(2),
+          "min": Int64(1),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.ir.ron
@@ -2,10 +2,12 @@ Ok(TestIRQuery(
   schema_name: "numbers",
   ir_query: IRQuery(
     root_name: "Number",
-    root_parameters: Some(EdgeParameters({
-      "max": Int64(2),
-      "min": Int64(1),
-    })),
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(2),
+        "min": Int64(1),
+      },
+    ),
     root_component: IRQueryComponent(
       root: Vid(1),
       vertices: {

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -333,10 +333,12 @@ TestInterpreterOutputTrace(
     },
     ir_query: IRQuery(
       root_name: "Number",
-      root_parameters: Some(EdgeParameters({
-        "max": Int64(2),
-        "min": Int64(1),
-      })),
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(2),
+          "min": Int64(1),
+        },
+      ),
       root_component: IRQueryComponent(
         root: Vid(1),
         vertices: {

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -260,7 +260,7 @@ impl Adapter<'static> for AdapterShim {
     fn resolve_starting_vertices(
         &mut self,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<CoreEdgeParameters>>,
+        parameters: &CoreEdgeParameters,
         query_info: &QueryInfo,
     ) -> VertexIterator<'static, Self::Vertex> {
         let parameters: JsEdgeParameters = parameters.clone().into();
@@ -290,7 +290,7 @@ impl Adapter<'static> for AdapterShim {
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
-        parameters: &Option<Arc<CoreEdgeParameters>>,
+        parameters: &CoreEdgeParameters,
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
         let ctx_iter = JsContextIterator::new(contexts);

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -73,21 +73,9 @@ impl JsEdgeParameters {
     }
 }
 
-impl From<Option<trustfall_core::ir::EdgeParameters>> for JsEdgeParameters {
-    fn from(p: Option<trustfall_core::ir::EdgeParameters>) -> Self {
-        match p.as_ref() {
-            None => Default::default(),
-            Some(parameters) => parameters.into(),
-        }
-    }
-}
-
-impl From<Option<Arc<trustfall_core::ir::EdgeParameters>>> for JsEdgeParameters {
-    fn from(p: Option<Arc<trustfall_core::ir::EdgeParameters>>) -> Self {
-        match p.as_ref() {
-            None => Default::default(),
-            Some(parameters) => (&(**parameters)).into(),
-        }
+impl From<trustfall_core::ir::EdgeParameters> for JsEdgeParameters {
+    fn from(p: trustfall_core::ir::EdgeParameters) -> Self {
+        Self::from(&p)
     }
 }
 
@@ -95,7 +83,6 @@ impl From<&trustfall_core::ir::EdgeParameters> for JsEdgeParameters {
     fn from(p: &trustfall_core::ir::EdgeParameters) -> Self {
         Self {
             values: p
-                .0
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.clone().into()))
                 .collect(),


### PR DESCRIPTION
- Make `EdgeParameters` in adapters more ergonomic to use.
- Fix filetests serialization format.
