### PR TITLE
Update names to new vertex-centric terminology.

### DIFF
--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -21,7 +21,7 @@ impl<'a> FeedAdapter<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum Token<'a> {
+pub(crate) enum Vertex<'a> {
     Feed(&'a Feed),
     FeedText(&'a Text),
     ChannelImage(&'a Image),
@@ -41,7 +41,7 @@ macro_rules! impl_downcast {
     };
 }
 
-impl<'a> Token<'a> {
+impl<'a> Vertex<'a> {
     impl_downcast!(as_feed, Feed, Self::Feed);
     impl_downcast!(as_feed_text, Text, Self::FeedText);
     impl_downcast!(as_channel_image, Image, Self::ChannelImage);
@@ -61,7 +61,7 @@ macro_rules! iterable {
 }
 
 impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
-    type Vertex = Token<'a>;
+    type Vertex = Vertex<'a>;
 
     fn resolve_starting_vertices(
         &mut self,
@@ -69,7 +69,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
         _parameters: &EdgeParameters,
     ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name {
-            "Feed" => Box::new(self.data.iter().map(Token::Feed)),
+            "Feed" => Box::new(self.data.iter().map(Vertex::Feed)),
             "FeedAtUrl" => {
                 todo!()
             }
@@ -164,35 +164,35 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match type_name {
             "Feed" => match edge_name {
-                "title" => neighbors(contexts, iterable!(as_feed, title, Token::FeedText)),
+                "title" => neighbors(contexts, iterable!(as_feed, title, Vertex::FeedText)),
                 "description" => {
-                    neighbors(contexts, iterable!(as_feed, description, Token::FeedText))
+                    neighbors(contexts, iterable!(as_feed, description, Vertex::FeedText))
                 }
-                "rights" => neighbors(contexts, iterable!(as_feed, rights, Token::FeedText)),
-                "icon" => neighbors(contexts, iterable!(as_feed, icon, Token::ChannelImage)),
-                "links" => neighbors(contexts, iterable!(as_feed, links, Token::FeedLink)),
-                "entries" => neighbors(contexts, iterable!(as_feed, entries, Token::FeedEntry)),
+                "rights" => neighbors(contexts, iterable!(as_feed, rights, Vertex::FeedText)),
+                "icon" => neighbors(contexts, iterable!(as_feed, icon, Vertex::ChannelImage)),
+                "links" => neighbors(contexts, iterable!(as_feed, links, Vertex::FeedLink)),
+                "entries" => neighbors(contexts, iterable!(as_feed, entries, Vertex::FeedEntry)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             "FeedEntry" => match edge_name {
-                "title" => neighbors(contexts, iterable!(as_feed_entry, title, Token::FeedText)),
+                "title" => neighbors(contexts, iterable!(as_feed_entry, title, Vertex::FeedText)),
                 "content" => neighbors(
                     contexts,
-                    iterable!(as_feed_entry, content, Token::FeedContent),
+                    iterable!(as_feed_entry, content, Vertex::FeedContent),
                 ),
-                "links" => neighbors(contexts, iterable!(as_feed_entry, links, Token::FeedLink)),
+                "links" => neighbors(contexts, iterable!(as_feed_entry, links, Vertex::FeedLink)),
                 "summary" => {
-                    neighbors(contexts, iterable!(as_feed_entry, summary, Token::FeedText))
+                    neighbors(contexts, iterable!(as_feed_entry, summary, Vertex::FeedText))
                 }
-                "rights" => neighbors(contexts, iterable!(as_feed_entry, rights, Token::FeedText)),
+                "rights" => neighbors(contexts, iterable!(as_feed_entry, rights, Vertex::FeedText)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             "FeedContent" => match edge_name {
-                "src" => neighbors(contexts, iterable!(as_feed_content, src, Token::FeedLink)),
+                "src" => neighbors(contexts, iterable!(as_feed_content, src, Vertex::FeedLink)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             "ChannelImage" => match edge_name {
-                "link" => neighbors(contexts, iterable!(as_channel_image, link, Token::FeedLink)),
+                "link" => neighbors(contexts, iterable!(as_channel_image, link, Vertex::FeedLink)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             _ => unreachable!("type {type_name} not found"),

--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -181,9 +181,10 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
                     iterable!(as_feed_entry, content, Vertex::FeedContent),
                 ),
                 "links" => neighbors(contexts, iterable!(as_feed_entry, links, Vertex::FeedLink)),
-                "summary" => {
-                    neighbors(contexts, iterable!(as_feed_entry, summary, Vertex::FeedText))
-                }
+                "summary" => neighbors(
+                    contexts,
+                    iterable!(as_feed_entry, summary, Vertex::FeedText),
+                ),
                 "rights" => neighbors(contexts, iterable!(as_feed_entry, rights, Vertex::FeedText)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
@@ -192,7 +193,10 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             "ChannelImage" => match edge_name {
-                "link" => neighbors(contexts, iterable!(as_channel_image, link, Vertex::FeedLink)),
+                "link" => neighbors(
+                    contexts,
+                    iterable!(as_channel_image, link, Vertex::FeedLink),
+                ),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             _ => unreachable!("type {type_name} not found"),

--- a/demo-hackernews/README.md
+++ b/demo-hackernews/README.md
@@ -44,20 +44,20 @@ already provided by the iterator-style execution model.
 ## Components
 
 The project consists of the following components:
-- `vertex.rs` defines the `Token` enum which `trustfall` uses to
+- `vertex.rs` defines the `Vertex` enum which `trustfall` uses to
   represent vertices in the query graph.
 - `adapter.rs` defines the `HackerNewsAdapter` struct, which implements
   the `trustfall_core::interpreter::Adapter` trait and connects the query engine
   to the HackerNews API.
-    - The `resolve_starting_vertices` method is what produces the initial iterator of `Token` vertices
+    - The `resolve_starting_vertices` method is what produces the initial iterator of `Vertex` vertices
       corresponding to the root edge at which querying starts (e.g. `FrontPage`).
-    - The `resolve_property` method is used to get property values for each `Token` in an iterator.
-    - The `resolve_neighbors` method is used to get the neighboring vertices (`Token`s)
-      across a particular edge, for each `Token` in an iterator.
+    - The `resolve_property` method is used to get property values for each `Vertex` in an iterator.
+    - The `resolve_neighbors` method is used to get the neighboring vertices (`Vertex`s)
+      across a particular edge, for each `Vertex` in an iterator.
     - The `resolve_coercion` method is kind of like the Python `isinstance()` function:
-      for each `Token` in an iterable, it checks whether that `Token`'s type can be narrowed
-      to a more derived type than it previously represented. For example, if the `Token` originally
-      represented `interface Animal`, `resolve_coercion` may be used to check whether the `Token`
+      for each `Vertex` in an iterable, it checks whether that `Vertex`'s type can be narrowed
+      to a more derived type than it previously represented. For example, if the `Vertex` originally
+      represented `interface Animal`, `resolve_coercion` may be used to check whether the `Vertex`
       is actually of `type Dog implements Animal`.
 - `main.rs` is a simple CLI app that can execute query files in `ron` format.
 

--- a/demo-hackernews/README.md
+++ b/demo-hackernews/README.md
@@ -44,7 +44,7 @@ already provided by the iterator-style execution model.
 ## Components
 
 The project consists of the following components:
-- `token.rs` defines the `Token` enum which `trustfall` uses to
+- `vertex.rs` defines the `Token` enum which `trustfall` uses to
   represent vertices in the query graph.
 - `adapter.rs` defines the `HackerNewsAdapter` struct, which implements
   the `trustfall_core::interpreter::Adapter` trait and connects the query engine

--- a/demo-hackernews/src/main.rs
+++ b/demo-hackernews/src/main.rs
@@ -16,7 +16,7 @@ use crate::adapter::HackerNewsAdapter;
 extern crate lazy_static;
 
 pub mod adapter;
-pub mod token;
+pub mod vertex;
 
 lazy_static! {
     static ref SCHEMA: Schema =

--- a/demo-hackernews/src/vertex.rs
+++ b/demo-hackernews/src/vertex.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use hn_api::types::{Comment, Item, Job, Story, User};
 
 #[derive(Debug, Clone)]
-pub enum Token {
+pub enum Vertex {
     Item(Rc<Item>),
     Story(Rc<Story>),
     Job(Rc<Job>),
@@ -11,21 +11,21 @@ pub enum Token {
     User(Rc<User>),
 }
 
-impl Token {
+impl Vertex {
     pub fn typename(&self) -> &'static str {
         match self {
-            Token::Item(..) => "Item",
-            Token::Story(..) => "Story",
-            Token::Job(..) => "Job",
-            Token::Comment(..) => "Comment",
-            Token::User(..) => "User",
+            Vertex::Item(..) => "Item",
+            Vertex::Story(..) => "Story",
+            Vertex::Job(..) => "Job",
+            Vertex::Comment(..) => "Comment",
+            Vertex::User(..) => "User",
         }
     }
 
     pub fn as_story(&self) -> Option<&Story> {
         match self {
-            Token::Story(s) => Some(s.as_ref()),
-            Token::Item(i) => match &**i {
+            Vertex::Story(s) => Some(s.as_ref()),
+            Vertex::Item(i) => match &**i {
                 Item::Story(s) => Some(s),
                 _ => None,
             },
@@ -35,8 +35,8 @@ impl Token {
 
     pub fn as_job(&self) -> Option<&Job> {
         match self {
-            Token::Job(s) => Some(s.as_ref()),
-            Token::Item(i) => match &**i {
+            Vertex::Job(s) => Some(s.as_ref()),
+            Vertex::Item(i) => match &**i {
                 Item::Job(s) => Some(s),
                 _ => None,
             },
@@ -46,8 +46,8 @@ impl Token {
 
     pub fn as_comment(&self) -> Option<&Comment> {
         match self {
-            Token::Comment(s) => Some(s.as_ref()),
-            Token::Item(i) => match &**i {
+            Vertex::Comment(s) => Some(s.as_ref()),
+            Vertex::Item(i) => match &**i {
                 Item::Comment(s) => Some(s),
                 _ => None,
             },
@@ -57,37 +57,37 @@ impl Token {
 
     pub fn as_user(&self) -> Option<&User> {
         match self {
-            Token::User(u) => Some(u.as_ref()),
+            Vertex::User(u) => Some(u.as_ref()),
             _ => None,
         }
     }
 }
 
-impl From<Item> for Token {
+impl From<Item> for Vertex {
     fn from(item: Item) -> Self {
         Self::Item(Rc::from(item))
     }
 }
 
-impl From<Story> for Token {
+impl From<Story> for Vertex {
     fn from(s: Story) -> Self {
         Self::Story(Rc::from(s))
     }
 }
 
-impl From<Job> for Token {
+impl From<Job> for Vertex {
     fn from(j: Job) -> Self {
         Self::Job(Rc::from(j))
     }
 }
 
-impl From<Comment> for Token {
+impl From<Comment> for Vertex {
     fn from(c: Comment) -> Self {
         Self::Comment(Rc::from(c))
     }
 }
 
-impl From<User> for Token {
+impl From<User> for Vertex {
     fn from(u: User) -> Self {
         Self::User(Rc::from(u))
     }

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -100,8 +100,8 @@ impl DemoAdapter {
         match HN_CLIENT.get_user(username) {
             Ok(Some(user)) => {
                 // Found a user by that name.
-                let token = Vertex::from(user);
-                Box::new(std::iter::once(token))
+                let vertex = Vertex::from(user);
+                Box::new(std::iter::once(vertex))
             }
             Ok(None) => {
                 // The request succeeded but did not find a user by that name.
@@ -126,8 +126,8 @@ impl DemoAdapter {
 macro_rules! impl_item_property {
     ($contexts:ident, $attr:ident) => {
         Box::new($contexts.map(|ctx| {
-            let token = ctx.active_vertex();
-            let value = match token {
+            let vertex = ctx.active_vertex();
+            let value = match vertex {
                 None => FieldValue::Null,
                 Some(t) => {
                     if let Some(s) = t.as_story() {
@@ -153,10 +153,10 @@ macro_rules! impl_item_property {
 macro_rules! impl_property {
     ($contexts:ident, $conversion:ident, $attr:ident) => {
         Box::new($contexts.map(|ctx| {
-            let token = ctx
+            let vertex = ctx
                 .active_vertex()
-                .map(|token| token.$conversion().unwrap());
-            let value = match token {
+                .map(|vertex| vertex.$conversion().unwrap());
+            let value = match vertex {
                 None => FieldValue::Null,
                 Some(t) => (&t.$attr).clone().into(),
 
@@ -170,10 +170,10 @@ macro_rules! impl_property {
 
     ($contexts:ident, $conversion:ident, $var:ident, $b:block) => {
         Box::new($contexts.map(|ctx| {
-            let token = ctx
+            let vertex = ctx
                 .active_vertex()
-                .map(|token| token.$conversion().unwrap());
-            let value = match token {
+                .map(|vertex| vertex.$conversion().unwrap());
+            let value = match vertex {
                 None => FieldValue::Null,
                 Some($var) => $b,
 
@@ -224,7 +224,7 @@ impl Adapter<'static> for DemoAdapter {
         match (type_name.as_ref(), property_name.as_ref()) {
             (_, "__typename") => Box::new(contexts.map(|ctx| {
                 let value = match ctx.active_vertex() {
-                    Some(token) => token.typename().into(),
+                    Some(vertex) => vertex.typename().into(),
                     None => FieldValue::Null,
                 };
 
@@ -478,11 +478,11 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("HackerNewsComment", "parent") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => {
-                        let comment = token.as_comment().unwrap();
+                    Some(vertex) => {
+                        let comment = vertex.as_comment().unwrap();
                         let comment_id = comment.id;
                         let parent_id = comment.parent;
 
@@ -502,11 +502,11 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("HackerNewsComment", "topmostAncestor") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => {
-                        let comment = token.as_comment().unwrap();
+                    Some(vertex) => {
+                        let comment = vertex.as_comment().unwrap();
                         let mut comment_id = comment.id;
                         let mut parent_id = comment.parent;
                         loop {
@@ -539,11 +539,11 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("HackerNewsComment", "reply") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => {
-                        let comment = token.as_comment().unwrap();
+                    Some(vertex) => {
+                        let comment = vertex.as_comment().unwrap();
                         let comment_id = comment.id;
                         let reply_ids = comment.kids.clone().unwrap_or_default();
 
@@ -571,11 +571,11 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("HackerNewsUser", "submitted") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => {
-                        let user = token.as_user().unwrap();
+                    Some(vertex) => {
+                        let user = vertex.as_user().unwrap();
                         let submitted_ids = user.submitted.clone();
 
                         Box::new(submitted_ids.into_iter().filter_map(move |submission_id| {
@@ -596,16 +596,16 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("Crate", "repository") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => {
-                        let cr = token.as_crate().unwrap();
+                    Some(vertex) => {
+                        let cr = vertex.as_crate().unwrap();
                         match cr.repository.as_ref() {
                             None => Box::new(std::iter::empty()),
                             Some(repo) => {
-                                let token = resolve_url(repo.as_str());
-                                Box::new(token.into_iter())
+                                let vertex = resolve_url(repo.as_str());
+                                Box::new(vertex.into_iter())
                             }
                         }
                     }
@@ -614,11 +614,11 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("GitHubRepository", "workflows") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => Box::new(
-                        WorkflowsPager::new(GITHUB_CLIENT.clone(), token, RUNTIME.deref())
+                    Some(vertex) => Box::new(
+                        WorkflowsPager::new(GITHUB_CLIENT.clone(), vertex, RUNTIME.deref())
                             .into_iter()
                             .map(|x| x.into()),
                     ),
@@ -627,11 +627,11 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("GitHubWorkflow", "jobs") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
-                    Some(token) => {
-                        let workflow = token.as_github_workflow().unwrap();
+                    Some(vertex) => {
+                        let workflow = vertex.as_github_workflow().unwrap();
                         let path = workflow.workflow.path.as_ref();
                         let repo = workflow.repo.as_ref();
                         let workflow_content = get_repo_file_content(repo, path);
@@ -648,8 +648,8 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("GitHubActionsJob", "step") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(Vertex::GitHubActionsJob(job)) => get_steps_in_job(job),
                     _ => unreachable!(),
@@ -658,8 +658,8 @@ impl Adapter<'static> for DemoAdapter {
                 (ctx, neighbors)
             })),
             ("GitHubActionsRunStep", "env") => Box::new(contexts.map(|ctx| {
-                let token = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match token {
+                let vertex = ctx.active_vertex().cloned();
+                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(Vertex::GitHubActionsRunStep(s)) => get_env_for_run_step(s),
                     _ => unreachable!(),
@@ -681,7 +681,7 @@ impl Adapter<'static> for DemoAdapter {
         let type_name = type_name.clone();
         let coerce_to_type = coerce_to_type.clone();
         let iterator = contexts.map(move |ctx| {
-            let token = match ctx.active_vertex() {
+            let vertex = match ctx.active_vertex() {
                 Some(t) => t,
                 None => return (ctx, false),
             };
@@ -691,17 +691,17 @@ impl Adapter<'static> for DemoAdapter {
             // at the cost of a bit of code repetition.
 
             let can_coerce = match (type_name.as_ref(), coerce_to_type.as_ref()) {
-                ("HackerNewsItem", "HackerNewsJob") => token.as_job().is_some(),
-                ("HackerNewsItem", "HackerNewsStory") => token.as_story().is_some(),
-                ("HackerNewsItem", "HackerNewsComment") => token.as_comment().is_some(),
-                ("Webpage", "Repository") => token.as_repository().is_some(),
-                ("Webpage", "GitHubRepository") => token.as_github_repository().is_some(),
-                ("Repository", "GitHubRepository") => token.as_github_repository().is_some(),
+                ("HackerNewsItem", "HackerNewsJob") => vertex.as_job().is_some(),
+                ("HackerNewsItem", "HackerNewsStory") => vertex.as_story().is_some(),
+                ("HackerNewsItem", "HackerNewsComment") => vertex.as_comment().is_some(),
+                ("Webpage", "Repository") => vertex.as_repository().is_some(),
+                ("Webpage", "GitHubRepository") => vertex.as_github_repository().is_some(),
+                ("Repository", "GitHubRepository") => vertex.as_github_repository().is_some(),
                 ("GitHubActionsStep", "GitHubActionsImportedStep") => {
-                    token.as_github_actions_imported_step().is_some()
+                    vertex.as_github_actions_imported_step().is_some()
                 }
                 ("GitHubActionsStep", "GitHubActionsRunStep") => {
-                    token.as_github_actions_run_step().is_some()
+                    vertex.as_github_actions_run_step().is_some()
                 }
                 unhandled => unreachable!("{:?}", unhandled),
             };

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -41,7 +41,7 @@ macro_rules! non_float_field {
         Box::new($iter.map(|ctx| {
             let value = match ctx.active_vertex() {
                 None => FieldValue::Null,
-                Some(token) => match token {
+                Some(vertex) => match vertex {
                     $variant(m) => m.$field.clone().into(),
                     _ => unreachable!(),
                 },
@@ -56,7 +56,7 @@ macro_rules! float_field {
         Box::new($iter.map(|ctx| {
             let value = match ctx.active_vertex() {
                 None => FieldValue::Null,
-                Some(token) => match token {
+                Some(vertex) => match vertex {
                     $variant(m) => m.$field.clone().try_into().unwrap(),
                     _ => unreachable!(),
                 },
@@ -165,7 +165,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
 
                 Box::new(contexts.map(|ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
-                        Some(token) => match token {
+                        Some(vertex) => match vertex {
                             &Token::MetarReport(metar) => {
                                 Box::new(metar.cloud_cover.iter().map(|c| c.into()))
                             }

--- a/demo-metar/src/adapter.rs
+++ b/demo-metar/src/adapter.rs
@@ -19,18 +19,18 @@ impl<'a> MetarAdapter<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum Token<'a> {
+pub(crate) enum Vertex<'a> {
     MetarReport(&'a MetarReport),
     CloudCover(&'a MetarCloudCover),
 }
 
-impl<'a> From<&'a MetarReport> for Token<'a> {
+impl<'a> From<&'a MetarReport> for Vertex<'a> {
     fn from(v: &'a MetarReport) -> Self {
         Self::MetarReport(v)
     }
 }
 
-impl<'a> From<&'a MetarCloudCover> for Token<'a> {
+impl<'a> From<&'a MetarCloudCover> for Vertex<'a> {
     fn from(v: &'a MetarCloudCover) -> Self {
         Self::CloudCover(v)
     }
@@ -67,7 +67,7 @@ macro_rules! float_field {
 }
 
 impl<'a> Adapter<'a> for MetarAdapter<'a> {
-    type Vertex = Token<'a>;
+    type Vertex = Vertex<'a>;
 
     fn resolve_starting_vertices(
         &mut self,
@@ -101,38 +101,38 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
             "MetarReport" => {
                 match property_name.as_ref() {
                     // TODO: implement __typename
-                    "stationId" => non_float_field!(contexts, Token::MetarReport, station_id),
-                    "rawReport" => non_float_field!(contexts, Token::MetarReport, raw_report),
+                    "stationId" => non_float_field!(contexts, Vertex::MetarReport, station_id),
+                    "rawReport" => non_float_field!(contexts, Vertex::MetarReport, raw_report),
                     "observationTime" => {
-                        non_float_field!(contexts, Token::MetarReport, observation_time)
+                        non_float_field!(contexts, Vertex::MetarReport, observation_time)
                     }
-                    "latitude" => float_field!(contexts, Token::MetarReport, latitude),
-                    "longitude" => float_field!(contexts, Token::MetarReport, longitude),
+                    "latitude" => float_field!(contexts, Vertex::MetarReport, latitude),
+                    "longitude" => float_field!(contexts, Vertex::MetarReport, longitude),
                     "windSpeedKts" => {
-                        non_float_field!(contexts, Token::MetarReport, wind_speed_kts)
+                        non_float_field!(contexts, Vertex::MetarReport, wind_speed_kts)
                     }
                     "windDirection" => {
-                        non_float_field!(contexts, Token::MetarReport, wind_direction)
+                        non_float_field!(contexts, Vertex::MetarReport, wind_direction)
                     }
                     "windGustsKts" => {
-                        non_float_field!(contexts, Token::MetarReport, wind_gusts_kts)
+                        non_float_field!(contexts, Vertex::MetarReport, wind_gusts_kts)
                     }
-                    "temperature" => float_field!(contexts, Token::MetarReport, temperature),
-                    "dewpoint" => float_field!(contexts, Token::MetarReport, dewpoint),
+                    "temperature" => float_field!(contexts, Vertex::MetarReport, temperature),
+                    "dewpoint" => float_field!(contexts, Vertex::MetarReport, dewpoint),
                     "visibilityUnlimited" => {
-                        non_float_field!(contexts, Token::MetarReport, visibility_unlimited)
+                        non_float_field!(contexts, Vertex::MetarReport, visibility_unlimited)
                     }
                     "visibilityMinimal" => {
-                        non_float_field!(contexts, Token::MetarReport, visibility_minimal)
+                        non_float_field!(contexts, Vertex::MetarReport, visibility_minimal)
                     }
                     "visibilityStatuteMi" => {
-                        float_field!(contexts, Token::MetarReport, visibility_statute_mi)
+                        float_field!(contexts, Vertex::MetarReport, visibility_statute_mi)
                     }
                     "altimeterInHg" => {
-                        float_field!(contexts, Token::MetarReport, altimeter_in_hg)
+                        float_field!(contexts, Vertex::MetarReport, altimeter_in_hg)
                     }
                     "seaLevelPressureMb" => {
-                        float_field!(contexts, Token::MetarReport, sea_level_pressure_mb)
+                        float_field!(contexts, Vertex::MetarReport, sea_level_pressure_mb)
                     }
                     unknown_field_name => unreachable!("{}", unknown_field_name),
                 }
@@ -140,9 +140,9 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
             "MetarCloudCover" => {
                 match property_name.as_ref() {
                     // TODO: implement __typename
-                    "skyCover" => non_float_field!(contexts, Token::CloudCover, sky_cover),
+                    "skyCover" => non_float_field!(contexts, Vertex::CloudCover, sky_cover),
                     "baseAltitude" => {
-                        non_float_field!(contexts, Token::CloudCover, base_altitude)
+                        non_float_field!(contexts, Vertex::CloudCover, base_altitude)
                     }
                     unknown_field_name => unreachable!("{}", unknown_field_name),
                 }
@@ -166,7 +166,7 @@ impl<'a> Adapter<'a> for MetarAdapter<'a> {
                 Box::new(contexts.map(|ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
                         Some(vertex) => match vertex {
-                            &Token::MetarReport(metar) => {
+                            &Vertex::MetarReport(metar) => {
                                 Box::new(metar.cloud_cover.iter().map(|c| c.into()))
                             }
                             _ => unreachable!(),

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -335,7 +335,9 @@ fn get_item_property(item_vertex: &Token, field_name: &str) -> FieldValue {
 }
 
 fn get_struct_property(item_vertex: &Token, field_name: &str) -> FieldValue {
-    let (_, struct_item) = item_vertex.as_struct_item().expect("vertex was not a Struct");
+    let (_, struct_item) = item_vertex
+        .as_struct_item()
+        .expect("vertex was not a Struct");
     match field_name {
         "struct_type" => match struct_item.struct_type {
             rustdoc_types::StructType::Plain => "plain",
@@ -716,29 +718,30 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let previous_crate = self.previous_crate;
 
                         Box::new(contexts.map(move |ctx| {
-                            let neighbors: VertexIterator<'a, Self::Vertex> =
-                                match ctx.active_vertex() {
-                                    None => Box::new(std::iter::empty()),
-                                    Some(vertex) => {
-                                        let origin = vertex.origin;
-                                        let item = vertex.as_item().expect("vertex was not an Item");
-                                        let item_id = &item.id;
+                            let neighbors: VertexIterator<'a, Self::Vertex> = match ctx
+                                .active_vertex()
+                            {
+                                None => Box::new(std::iter::empty()),
+                                Some(vertex) => {
+                                    let origin = vertex.origin;
+                                    let item = vertex.as_item().expect("vertex was not an Item");
+                                    let item_id = &item.id;
 
-                                        let parent_crate = match origin {
-                                            Origin::CurrentCrate => current_crate,
-                                            Origin::PreviousCrate => {
-                                                previous_crate.expect("no baseline provided")
-                                            }
-                                        };
+                                    let parent_crate = match origin {
+                                        Origin::CurrentCrate => current_crate,
+                                        Origin::PreviousCrate => {
+                                            previous_crate.expect("no baseline provided")
+                                        }
+                                    };
 
-                                        Box::new(
-                                            parent_crate
-                                                .publicly_importable_names(item_id)
-                                                .into_iter()
-                                                .map(move |x| origin.make_importable_path_vertex(x)),
-                                        )
-                                    }
-                                };
+                                    Box::new(
+                                        parent_crate
+                                            .publicly_importable_names(item_id)
+                                            .into_iter()
+                                            .map(move |x| origin.make_importable_path_vertex(x)),
+                                    )
+                                }
+                            };
 
                             (ctx, neighbors)
                         }))

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -44,49 +44,49 @@ pub enum Origin {
 }
 
 impl Origin {
-    fn make_item_token<'a>(&self, item: &'a Item) -> Token<'a> {
+    fn make_item_vertex<'a>(&self, item: &'a Item) -> Token<'a> {
         Token {
             origin: *self,
             kind: item.into(),
         }
     }
 
-    fn make_span_token<'a>(&self, span: &'a Span) -> Token<'a> {
+    fn make_span_vertex<'a>(&self, span: &'a Span) -> Token<'a> {
         Token {
             origin: *self,
             kind: span.into(),
         }
     }
 
-    fn make_path_token<'a>(&self, path: &'a [String]) -> Token<'a> {
+    fn make_path_vertex<'a>(&self, path: &'a [String]) -> Token<'a> {
         Token {
             origin: *self,
             kind: TokenKind::Path(path),
         }
     }
 
-    fn make_importable_path_token<'a>(&self, importable_path: Vec<&'a str>) -> Token<'a> {
+    fn make_importable_path_vertex<'a>(&self, importable_path: Vec<&'a str>) -> Token<'a> {
         Token {
             origin: *self,
             kind: TokenKind::ImportablePath(importable_path),
         }
     }
 
-    fn make_raw_type_token<'a>(&self, raw_type: &'a rustdoc_types::Type) -> Token<'a> {
+    fn make_raw_type_vertex<'a>(&self, raw_type: &'a rustdoc_types::Type) -> Token<'a> {
         Token {
             origin: *self,
             kind: TokenKind::RawType(raw_type),
         }
     }
 
-    fn make_attribute_token<'a>(&self, attr: &'a str) -> Token<'a> {
+    fn make_attribute_vertex<'a>(&self, attr: &'a str) -> Token<'a> {
         Token {
             origin: *self,
             kind: TokenKind::Attribute(attr),
         }
     }
 
-    fn make_implemented_trait_token<'a>(
+    fn make_implemented_trait_vertex<'a>(
         &self,
         path: &'a rustdoc_types::Path,
         trait_def: &'a Item,
@@ -128,7 +128,7 @@ impl<'a> Token<'a> {
         }
     }
 
-    /// The name of the actual runtime type of this token,
+    /// The name of the actual runtime type of this vertex,
     /// intended to fulfill resolution requests for the __typename property.
     #[inline]
     fn typename(&self) -> &'static str {
@@ -303,8 +303,8 @@ impl<'a> From<&'a Span> for TokenKind<'a> {
     }
 }
 
-fn get_crate_property(crate_token: &Token, field_name: &str) -> FieldValue {
-    let crate_item = crate_token.as_crate().expect("token was not a Crate");
+fn get_crate_property(crate_vertex: &Token, field_name: &str) -> FieldValue {
+    let crate_item = crate_vertex.as_crate().expect("vertex was not a Crate");
     match field_name {
         "root" => (&crate_item.root.0).into(),
         "crate_version" => (&crate_item.crate_version).into(),
@@ -314,8 +314,8 @@ fn get_crate_property(crate_token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
-fn get_item_property(item_token: &Token, field_name: &str) -> FieldValue {
-    let item = item_token.as_item().expect("token was not an Item");
+fn get_item_property(item_vertex: &Token, field_name: &str) -> FieldValue {
+    let item = item_vertex.as_item().expect("vertex was not an Item");
     match field_name {
         "id" => (&item.id.0).into(),
         "crate_id" => (&item.crate_id).into(),
@@ -334,8 +334,8 @@ fn get_item_property(item_token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
-fn get_struct_property(item_token: &Token, field_name: &str) -> FieldValue {
-    let (_, struct_item) = item_token.as_struct_item().expect("token was not a Struct");
+fn get_struct_property(item_vertex: &Token, field_name: &str) -> FieldValue {
+    let (_, struct_item) = item_vertex.as_struct_item().expect("vertex was not a Struct");
     match field_name {
         "struct_type" => match struct_item.struct_type {
             rustdoc_types::StructType::Plain => "plain",
@@ -348,8 +348,8 @@ fn get_struct_property(item_token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
-fn get_span_property(item_token: &Token, field_name: &str) -> FieldValue {
-    let span = item_token.as_span().expect("token was not a Span");
+fn get_span_property(item_vertex: &Token, field_name: &str) -> FieldValue {
+    let span = item_vertex.as_span().expect("vertex was not a Span");
     match field_name {
         "filename" => span
             .filename
@@ -364,28 +364,28 @@ fn get_span_property(item_token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
-fn get_enum_property(item_token: &Token, field_name: &str) -> FieldValue {
-    let enum_item = item_token.as_enum().expect("token was not an Enum");
+fn get_enum_property(item_vertex: &Token, field_name: &str) -> FieldValue {
+    let enum_item = item_vertex.as_enum().expect("vertex was not an Enum");
     match field_name {
         "variants_stripped" => enum_item.variants_stripped.into(),
         _ => unreachable!("Enum property {field_name}"),
     }
 }
 
-fn get_path_property(token: &Token, field_name: &str) -> FieldValue {
-    let path_token = token.as_path().expect("token was not a Path");
+fn get_path_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let path_vertex = vertex.as_path().expect("vertex was not a Path");
     match field_name {
-        "path" => path_token.into(),
+        "path" => path_vertex.into(),
         _ => unreachable!("Path property {field_name}"),
     }
 }
 
-fn get_importable_path_property(token: &Token, field_name: &str) -> FieldValue {
-    let path_token = token
+fn get_importable_path_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let path_vertex = vertex
         .as_importable_path()
-        .expect("token was not an ImportablePath");
+        .expect("vertex was not an ImportablePath");
     match field_name {
-        "path" => path_token
+        "path" => path_vertex
             .iter()
             .map(|x| x.to_string())
             .collect::<Vec<_>>()
@@ -395,15 +395,15 @@ fn get_importable_path_property(token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
-fn get_function_like_property(token: &Token, field_name: &str) -> FieldValue {
-    let maybe_function = token.as_function();
-    let maybe_method = token.as_method();
+fn get_function_like_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let maybe_function = vertex.as_function();
+    let maybe_method = vertex.as_method();
 
     let (header, _decl) = maybe_function
         .map(|func| (&func.header, &func.decl))
         .unwrap_or_else(|| {
             let method = maybe_method.unwrap_or_else(|| {
-                unreachable!("token was neither a function nor a method: {token:?}")
+                unreachable!("vertex was neither a function nor a method: {vertex:?}")
             });
             (&method.header, &method.decl)
         });
@@ -416,40 +416,40 @@ fn get_function_like_property(token: &Token, field_name: &str) -> FieldValue {
     }
 }
 
-fn get_impl_property(token: &Token, field_name: &str) -> FieldValue {
-    let impl_token = token.as_impl().expect("token was not an Impl");
+fn get_impl_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let impl_vertex = vertex.as_impl().expect("vertex was not an Impl");
     match field_name {
-        "unsafe" => impl_token.is_unsafe.into(),
-        "negative" => impl_token.negative.into(),
-        "synthetic" => impl_token.synthetic.into(),
+        "unsafe" => impl_vertex.is_unsafe.into(),
+        "negative" => impl_vertex.negative.into(),
+        "synthetic" => impl_vertex.synthetic.into(),
         _ => unreachable!("Impl property {field_name}"),
     }
 }
 
-fn get_attribute_property(token: &Token, field_name: &str) -> FieldValue {
-    let attribute_token = token.as_attribute().expect("token was not an Attribute");
+fn get_attribute_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let attribute_vertex = vertex.as_attribute().expect("vertex was not an Attribute");
     match field_name {
-        "value" => attribute_token.into(),
+        "value" => attribute_vertex.into(),
         _ => unreachable!("Attribute property {field_name}"),
     }
 }
 
-fn get_raw_type_property(token: &Token, field_name: &str) -> FieldValue {
-    let type_token = token.as_raw_type().expect("token was not a RawType");
+fn get_raw_type_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let type_vertex = vertex.as_raw_type().expect("vertex was not a RawType");
     match field_name {
-        "name" => match type_token {
+        "name" => match type_vertex {
             rustdoc_types::Type::ResolvedPath(path) => (&path.name).into(),
             rustdoc_types::Type::Primitive(name) => name.into(),
-            _ => unreachable!("unexpected RawType token content: {type_token:?}"),
+            _ => unreachable!("unexpected RawType vertex content: {type_vertex:?}"),
         },
         _ => unreachable!("RawType property {field_name}"),
     }
 }
 
-fn get_implemented_trait_property(token: &Token, field_name: &str) -> FieldValue {
-    let (path, _) = token
+fn get_implemented_trait_property(vertex: &Token, field_name: &str) -> FieldValue {
+    let (path, _) = vertex
         .as_implemented_trait()
-        .expect("token was not a ImplementedTrait");
+        .expect("vertex was not a ImplementedTrait");
     match field_name {
         "name" => (&path.name).into(),
         _ => unreachable!("ImplementedTrait property {field_name}"),
@@ -462,7 +462,7 @@ fn property_mapper<'a>(
     property_getter: fn(&Token<'a>, &str) -> FieldValue,
 ) -> (DataContext<Token<'a>>, FieldValue) {
     let value = match ctx.active_vertex() {
-        Some(token) => property_getter(token, field_name),
+        Some(vertex) => property_getter(vertex, field_name),
         None => FieldValue::Null,
     };
     (ctx, value)
@@ -502,8 +502,8 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         if property_name.as_ref() == "__typename" {
             Box::new(contexts.map(|ctx| match ctx.active_vertex() {
-                Some(token) => {
-                    let value = token.typename().into();
+                Some(vertex) => {
+                    let value = vertex.typename().into();
                     (ctx, value)
                 }
                 None => (ctx, FieldValue::Null),
@@ -586,9 +586,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "current" => Box::new(contexts.map(move |ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
                         None => Box::new(std::iter::empty()),
-                        Some(token) => {
+                        Some(vertex) => {
                             let crate_tuple =
-                                token.as_crate_diff().expect("token was not a CrateDiff");
+                                vertex.as_crate_diff().expect("vertex was not a CrateDiff");
                             let neighbor = Token::new_crate(Origin::CurrentCrate, crate_tuple.0);
                             Box::new(std::iter::once(neighbor))
                         }
@@ -599,9 +599,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "baseline" => Box::new(contexts.map(move |ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
                         None => Box::new(std::iter::empty()),
-                        Some(token) => {
+                        Some(vertex) => {
                             let crate_tuple =
-                                token.as_crate_diff().expect("token was not a CrateDiff");
+                                vertex.as_crate_diff().expect("vertex was not a CrateDiff");
                             let neighbor = Token::new_crate(Origin::PreviousCrate, crate_tuple.1);
                             Box::new(std::iter::once(neighbor))
                         }
@@ -619,16 +619,16 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
-                                let crate_token =
-                                    token.as_indexed_crate().expect("token was not a Crate");
+                            Some(vertex) => {
+                                let origin = vertex.origin;
+                                let crate_vertex =
+                                    vertex.as_indexed_crate().expect("vertex was not a Crate");
 
-                                // let iter = crate_token
+                                // let iter = crate_vertex
                                 //     .public_items
                                 //     .iter()
                                 //     .copied()
-                                //     .filter_map(|id| crate_token.inner.index.get(id))
+                                //     .filter_map(|id| crate_vertex.inner.index.get(id))
                                 //     .filter(|item| {
                                 //         matches!(
                                 //             item.inner,
@@ -641,11 +641,11 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                 //                 | rustdoc_types::ItemEnum::Impl(..)
                                 //         )
                                 //     })
-                                //     .map(move |value| origin.make_item_token(value));
+                                //     .map(move |value| origin.make_item_vertex(value));
                                 // Box::new(iter)
                                 // TODO: temporarily only return public items for testing
                                 //
-                                let iter = crate_token
+                                let iter = crate_vertex
                                     .inner
                                     .index
                                     .values()
@@ -662,7 +662,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                                 | rustdoc_types::ItemEnum::Impl(..)
                                         )
                                     })
-                                    .map(move |value| origin.make_item_token(value));
+                                    .map(move |value| origin.make_item_vertex(value));
                                 Box::new(iter)
                             }
                         };
@@ -685,9 +685,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                 .active_vertex()
                             {
                                 None => Box::new(std::iter::empty()),
-                                Some(token) => {
-                                    let origin = token.origin;
-                                    let item = token.as_item().expect("token was not an Item");
+                                Some(vertex) => {
+                                    let origin = vertex.origin;
+                                    let item = vertex.as_item().expect("vertex was not an Item");
                                     let item_id = &item.id;
 
                                     if let Some(path) = match origin {
@@ -701,7 +701,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                             .get(item_id)
                                             .map(|x| &x.path),
                                     } {
-                                        Box::new(std::iter::once(origin.make_path_token(path)))
+                                        Box::new(std::iter::once(origin.make_path_vertex(path)))
                                     } else {
                                         Box::new(std::iter::empty())
                                     }
@@ -719,9 +719,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                             let neighbors: VertexIterator<'a, Self::Vertex> =
                                 match ctx.active_vertex() {
                                     None => Box::new(std::iter::empty()),
-                                    Some(token) => {
-                                        let origin = token.origin;
-                                        let item = token.as_item().expect("token was not an Item");
+                                    Some(vertex) => {
+                                        let origin = vertex.origin;
+                                        let item = vertex.as_item().expect("vertex was not an Item");
                                         let item_id = &item.id;
 
                                         let parent_crate = match origin {
@@ -735,7 +735,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                             parent_crate
                                                 .publicly_importable_names(item_id)
                                                 .into_iter()
-                                                .map(move |x| origin.make_importable_path_token(x)),
+                                                .map(move |x| origin.make_importable_path_vertex(x)),
                                         )
                                     }
                                 };
@@ -756,11 +756,11 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
-                                let item = token.as_item().expect("token was not an Item");
+                            Some(vertex) => {
+                                let origin = vertex.origin;
+                                let item = vertex.as_item().expect("vertex was not an Item");
                                 if let Some(span) = &item.span {
-                                    Box::new(std::iter::once(origin.make_span_token(span)))
+                                    Box::new(std::iter::once(origin.make_span_vertex(span)))
                                 } else {
                                     Box::new(std::iter::empty())
                                 }
@@ -773,13 +773,13 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
-                                let item = token.as_item().expect("token was not an Item");
+                            Some(vertex) => {
+                                let origin = vertex.origin;
+                                let item = vertex.as_item().expect("vertex was not an Item");
                                 Box::new(
                                     item.attrs
                                         .iter()
-                                        .map(move |attr| origin.make_attribute_token(attr)),
+                                        .map(move |attr| origin.make_attribute_vertex(attr)),
                                 )
                             }
                         };
@@ -798,8 +798,8 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 Box::new(contexts.map(move |ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
                         None => Box::new(std::iter::empty()),
-                        Some(token) => {
-                            let origin = token.origin;
+                        Some(vertex) => {
+                            let origin = vertex.origin;
                             let item_index = match origin {
                                 Origin::CurrentCrate => &current_crate.inner.index,
                                 Origin::PreviousCrate => {
@@ -812,19 +812,19 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
 
                             // Get the IDs of all the impl blocks.
                             // Relies on the fact that only structs and enums can have impls,
-                            // so we know that the token must represent either a struct or an enum.
-                            let impl_ids = token
+                            // so we know that the vertex must represent either a struct or an enum.
+                            let impl_ids = vertex
                                 .as_struct_item()
                                 .map(|(_, s)| &s.impls)
-                                .or_else(|| token.as_enum().map(|e| &e.impls))
-                                .expect("token was neither a struct nor an enum");
+                                .or_else(|| vertex.as_enum().map(|e| &e.impls))
+                                .expect("vertex was neither a struct nor an enum");
 
                             Box::new(impl_ids.iter().filter_map(move |item_id| {
                                 let next_item = item_index.get(item_id);
                                 next_item.and_then(|next_item| match &next_item.inner {
                                     rustdoc_types::ItemEnum::Impl(imp) => {
                                         if !inherent_impls_only || imp.trait_.is_none() {
-                                            Some(origin.make_item_token(next_item))
+                                            Some(origin.make_item_vertex(next_item))
                                         } else {
                                             None
                                         }
@@ -846,10 +846,10 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
+                            Some(vertex) => {
+                                let origin = vertex.origin;
                                 let (_, struct_item) =
-                                    token.as_struct_item().expect("token was not a Struct");
+                                    vertex.as_struct_item().expect("vertex was not a Struct");
 
                                 let item_index = match origin {
                                     Origin::CurrentCrate => &current_crate.inner.index,
@@ -862,7 +862,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                 };
                                 Box::new(struct_item.fields.clone().into_iter().map(
                                     move |field_id| {
-                                        origin.make_item_token(
+                                        origin.make_item_vertex(
                                             item_index.get(&field_id).expect("missing item"),
                                         )
                                     },
@@ -885,9 +885,9 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
-                                let enum_item = token.as_enum().expect("token was not a Enum");
+                            Some(vertex) => {
+                                let origin = vertex.origin;
+                                let enum_item = vertex.as_enum().expect("vertex was not a Enum");
 
                                 let item_index = match origin {
                                     Origin::CurrentCrate => &current_crate.inner.index,
@@ -899,7 +899,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     }
                                 };
                                 Box::new(enum_item.variants.iter().map(move |field_id| {
-                                    origin.make_item_token(
+                                    origin.make_item_vertex(
                                         item_index.get(field_id).expect("missing item"),
                                     )
                                 }))
@@ -917,12 +917,12 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "raw_type" => Box::new(contexts.map(move |ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
                         None => Box::new(std::iter::empty()),
-                        Some(token) => {
-                            let origin = token.origin;
-                            let (_, field_type) = token
+                        Some(vertex) => {
+                            let origin = vertex.origin;
+                            let (_, field_type) = vertex
                                 .as_struct_field_item()
-                                .expect("not a StructField token");
-                            Box::new(std::iter::once(origin.make_raw_type_token(field_type)))
+                                .expect("not a StructField vertex");
+                            Box::new(std::iter::once(origin.make_raw_type_vertex(field_type)))
                         }
                     };
 
@@ -940,8 +940,8 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
+                            Some(vertex) => {
+                                let origin = vertex.origin;
                                 let item_index = match origin {
                                     Origin::CurrentCrate => &current_crate.inner.index,
                                     Origin::PreviousCrate => {
@@ -952,20 +952,20 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     }
                                 };
 
-                                let impl_token = token.as_impl().expect("not an Impl token");
-                                let provided_methods: VertexIterator<'a, &Id> = if impl_token
+                                let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
+                                let provided_methods: VertexIterator<'a, &Id> = if impl_vertex
                                     .provided_trait_methods
                                     .is_empty()
                                 {
                                     Box::new(std::iter::empty())
                                 } else {
-                                    let method_names: BTreeSet<&str> = impl_token
+                                    let method_names: BTreeSet<&str> = impl_vertex
                                         .provided_trait_methods
                                         .iter()
                                         .map(|x| x.as_str())
                                         .collect();
 
-                                    let trait_path = impl_token.trait_.as_ref().expect(
+                                    let trait_path = impl_vertex.trait_.as_ref().expect(
                                         "no trait but provided_trait_methods was non-empty",
                                     );
                                     let trait_item = item_index.get(&trait_path.id);
@@ -992,13 +992,13 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     }
                                 };
                                 Box::new(
-                                    provided_methods.chain(impl_token.items.iter()).filter_map(
+                                    provided_methods.chain(impl_vertex.items.iter()).filter_map(
                                         move |item_id| {
                                             let next_item = &item_index.get(item_id);
                                             if let Some(next_item) = next_item {
                                                 match &next_item.inner {
                                                     rustdoc_types::ItemEnum::Method(..) => {
-                                                        Some(origin.make_item_token(next_item))
+                                                        Some(origin.make_item_vertex(next_item))
                                                     }
                                                     _ => None,
                                                 }
@@ -1021,8 +1021,8 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                         let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex()
                         {
                             None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
+                            Some(vertex) => {
+                                let origin = vertex.origin;
                                 let item_index = match origin {
                                     Origin::CurrentCrate => &current_crate.inner.index,
                                     Origin::PreviousCrate => {
@@ -1033,12 +1033,12 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     }
                                 };
 
-                                let impl_token = token.as_impl().expect("not an Impl token");
+                                let impl_vertex = vertex.as_impl().expect("not an Impl vertex");
 
-                                if let Some(path) = &impl_token.trait_ {
+                                if let Some(path) = &impl_vertex.trait_ {
                                     if let Some(item) = item_index.get(&path.id) {
                                         Box::new(std::iter::once(
-                                            origin.make_implemented_trait_token(path, item),
+                                            origin.make_implemented_trait_vertex(path, item),
                                         ))
                                     } else {
                                         Box::new(std::iter::empty())
@@ -1060,13 +1060,13 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 "trait" => Box::new(contexts.map(move |ctx| {
                     let neighbors: VertexIterator<'a, Self::Vertex> = match ctx.active_vertex() {
                         None => Box::new(std::iter::empty()),
-                        Some(token) => {
-                            let origin = token.origin;
+                        Some(vertex) => {
+                            let origin = vertex.origin;
 
-                            let (_, trait_item) = token
+                            let (_, trait_item) = vertex
                                 .as_implemented_trait()
-                                .expect("token was not an ImplementedTrait");
-                            Box::new(std::iter::once(origin.make_item_token(trait_item)))
+                                .expect("vertex was not an ImplementedTrait");
+                            Box::new(std::iter::once(origin.make_item_vertex(trait_item)))
                         }
                     };
 
@@ -1094,8 +1094,8 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 Box::new(contexts.map(move |ctx| {
                     let can_coerce = match ctx.active_vertex() {
                         None => false,
-                        Some(token) => {
-                            let actual_type_name = token.typename();
+                        Some(vertex) => {
+                            let actual_type_name = vertex.typename();
 
                             match coerce_to_type.as_ref() {
                                 "Variant" => matches!(

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -280,7 +280,7 @@ impl BasicAdapter<'static> for AdapterShim {
                 .unwrap();
 
             let iter = make_iterator(py, py_iterable).unwrap();
-            Box::new(PythonProjectPropertyIterator::new(iter))
+            Box::new(PythonResolvePropertyIterator::new(iter))
         })
     }
 
@@ -309,7 +309,7 @@ impl BasicAdapter<'static> for AdapterShim {
                 .unwrap();
 
             let iter = make_iterator(py, py_iterable).unwrap();
-            Box::new(PythonProjectNeighborsIterator::new(iter))
+            Box::new(PythonResolveNeighborsIterator::new(iter))
         })
     }
 
@@ -332,7 +332,7 @@ impl BasicAdapter<'static> for AdapterShim {
                 .unwrap();
 
             let iter = make_iterator(py, py_iterable).unwrap();
-            Box::new(PythonCanCoerceToTypeIterator::new(iter))
+            Box::new(PythonResolveCoercionIterator::new(iter))
         })
     }
 }
@@ -368,17 +368,17 @@ impl Iterator for PythonTokenIterator {
     }
 }
 
-struct PythonProjectPropertyIterator {
+struct PythonResolvePropertyIterator {
     underlying: Py<PyAny>,
 }
 
-impl PythonProjectPropertyIterator {
+impl PythonResolvePropertyIterator {
     fn new(underlying: Py<PyAny>) -> Self {
         Self { underlying }
     }
 }
 
-impl Iterator for PythonProjectPropertyIterator {
+impl Iterator for PythonResolvePropertyIterator {
     type Item = (DataContext<Arc<Py<PyAny>>>, FieldValue);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -418,17 +418,17 @@ impl Iterator for PythonProjectPropertyIterator {
     }
 }
 
-struct PythonProjectNeighborsIterator {
+struct PythonResolveNeighborsIterator {
     underlying: Py<PyAny>,
 }
 
-impl PythonProjectNeighborsIterator {
+impl PythonResolveNeighborsIterator {
     fn new(underlying: Py<PyAny>) -> Self {
         Self { underlying }
     }
 }
 
-impl Iterator for PythonProjectNeighborsIterator {
+impl Iterator for PythonResolveNeighborsIterator {
     type Item = (
         DataContext<Arc<Py<PyAny>>>,
         VertexIterator<'static, Arc<Py<PyAny>>>,
@@ -470,17 +470,17 @@ impl Iterator for PythonProjectNeighborsIterator {
     }
 }
 
-struct PythonCanCoerceToTypeIterator {
+struct PythonResolveCoercionIterator {
     underlying: Py<PyAny>,
 }
 
-impl PythonCanCoerceToTypeIterator {
+impl PythonResolveCoercionIterator {
     fn new(underlying: Py<PyAny>) -> Self {
         Self { underlying }
     }
 }
 
-impl Iterator for PythonCanCoerceToTypeIterator {
+impl Iterator for PythonResolveCoercionIterator {
     type Item = (DataContext<Arc<Py<PyAny>>>, bool);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -257,7 +257,7 @@ impl BasicAdapter<'static> for AdapterShim {
                 )
                 .unwrap();
             let iter = make_iterator(py, py_iterable).unwrap();
-            Box::new(PythonTokenIterator::new(iter))
+            Box::new(PythonVertexIterator::new(iter))
         })
     }
 
@@ -337,17 +337,17 @@ impl BasicAdapter<'static> for AdapterShim {
     }
 }
 
-struct PythonTokenIterator {
+struct PythonVertexIterator {
     underlying: Py<PyAny>,
 }
 
-impl PythonTokenIterator {
+impl PythonVertexIterator {
     fn new(underlying: Py<PyAny>) -> Self {
         Self { underlying }
     }
 }
 
-impl Iterator for PythonTokenIterator {
+impl Iterator for PythonVertexIterator {
     type Item = Arc<Py<PyAny>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -453,7 +453,7 @@ impl Iterator for PythonResolveNeighborsIterator {
                     let neighbors_iter = make_iterator(py, neighbors_iterable).unwrap();
 
                     let neighbors: VertexIterator<'static, Arc<Py<PyAny>>> =
-                        Box::new(PythonTokenIterator::new(neighbors_iter));
+                        Box::new(PythonVertexIterator::new(neighbors_iter));
                     Some((context.0, neighbors))
                 }
                 Err(e) => {

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -200,9 +200,9 @@ impl Iterator for EdgeResolverIterator {
 
     fn next(&mut self) -> Option<ContextAndIterableOfEdges> {
         if let Some(context) = self.contexts.next() {
-            if let Some(token) = context.active_vertex() {
-                let edge_tokens = (self.edge_resolver)(self.origin.clone(), token);
-                Some((context, edge_tokens))
+            if let Some(vertex) = context.active_vertex() {
+                let neighbors = (self.edge_resolver)(self.origin.clone(), vertex);
+                Some((context, neighbors))
             } else {
                 let empty_iterator: iter::Empty<FilesystemToken> = iter::empty();
                 Some((context, Box::new(empty_iterator)))

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -27,12 +27,12 @@ impl FilesystemInterpreter {
 
 #[derive(Debug)]
 struct OriginIterator {
-    origin_vertex: DirectoryToken,
+    origin_vertex: DirectoryVertex,
     produced: bool,
 }
 
 impl OriginIterator {
-    pub fn new(vertex: DirectoryToken) -> OriginIterator {
+    pub fn new(vertex: DirectoryVertex) -> OriginIterator {
         OriginIterator {
             origin_vertex: vertex,
             produced: false,
@@ -41,14 +41,14 @@ impl OriginIterator {
 }
 
 impl Iterator for OriginIterator {
-    type Item = FilesystemToken;
+    type Item = FilesystemVertex;
 
-    fn next(&mut self) -> Option<FilesystemToken> {
+    fn next(&mut self) -> Option<FilesystemVertex> {
         if self.produced {
             None
         } else {
             self.produced = true;
-            Some(FilesystemToken::Directory(self.origin_vertex.clone()))
+            Some(FilesystemVertex::Directory(self.origin_vertex.clone()))
         }
     }
 }
@@ -56,12 +56,12 @@ impl Iterator for OriginIterator {
 #[derive(Debug)]
 struct DirectoryContainsFileIterator {
     origin: Rc<String>,
-    directory: DirectoryToken,
+    directory: DirectoryVertex,
     file_iter: ReadDir,
 }
 
 impl DirectoryContainsFileIterator {
-    pub fn new(origin: Rc<String>, directory: &DirectoryToken) -> DirectoryContainsFileIterator {
+    pub fn new(origin: Rc<String>, directory: &DirectoryVertex) -> DirectoryContainsFileIterator {
         let mut buf = PathBuf::new();
         buf.extend([&*origin, &directory.path]);
         DirectoryContainsFileIterator {
@@ -73,9 +73,9 @@ impl DirectoryContainsFileIterator {
 }
 
 impl Iterator for DirectoryContainsFileIterator {
-    type Item = FilesystemToken;
+    type Item = FilesystemVertex;
 
-    fn next(&mut self) -> Option<FilesystemToken> {
+    fn next(&mut self) -> Option<FilesystemVertex> {
         loop {
             if let Some(outcome) = self.file_iter.next() {
                 match outcome {
@@ -91,12 +91,12 @@ impl Iterator for DirectoryContainsFileIterator {
                             let extension = Path::new(&name)
                                 .extension()
                                 .map(|x| x.to_str().unwrap().to_owned());
-                            let result = FileToken {
+                            let result = FileVertex {
                                 name,
                                 extension,
                                 path: buf.to_str().unwrap().to_owned(),
                             };
-                            return Some(FilesystemToken::File(result));
+                            return Some(FilesystemVertex::File(result));
                         }
                     }
                     _ => continue,
@@ -111,12 +111,12 @@ impl Iterator for DirectoryContainsFileIterator {
 #[derive(Debug)]
 struct SubdirectoryIterator {
     origin: Rc<String>,
-    directory: DirectoryToken,
+    directory: DirectoryVertex,
     dir_iter: ReadDir,
 }
 
 impl SubdirectoryIterator {
-    pub fn new(origin: Rc<String>, directory: &DirectoryToken) -> Self {
+    pub fn new(origin: Rc<String>, directory: &DirectoryVertex) -> Self {
         let mut buf = PathBuf::new();
         buf.extend([&*origin, &directory.path]);
         Self {
@@ -128,9 +128,9 @@ impl SubdirectoryIterator {
 }
 
 impl Iterator for SubdirectoryIterator {
-    type Item = FilesystemToken;
+    type Item = FilesystemVertex;
 
-    fn next(&mut self) -> Option<FilesystemToken> {
+    fn next(&mut self) -> Option<FilesystemVertex> {
         loop {
             if let Some(outcome) = self.dir_iter.next() {
                 match outcome {
@@ -147,11 +147,11 @@ impl Iterator for SubdirectoryIterator {
 
                             let mut buf = PathBuf::new();
                             buf.extend([&self.directory.path, &name]);
-                            let result = DirectoryToken {
+                            let result = DirectoryVertex {
                                 name,
                                 path: buf.to_str().unwrap().to_owned(),
                             };
-                            return Some(FilesystemToken::Directory(result));
+                            return Some(FilesystemVertex::Directory(result));
                         }
                     }
                     _ => continue,
@@ -163,25 +163,25 @@ impl Iterator for SubdirectoryIterator {
     }
 }
 
-pub type ContextAndValue = (DataContext<FilesystemToken>, FieldValue);
+pub type ContextAndValue = (DataContext<FilesystemVertex>, FieldValue);
 
 type IndividualEdgeResolver =
-    fn(Rc<String>, &FilesystemToken) -> VertexIterator<'static, FilesystemToken>;
+    fn(Rc<String>, &FilesystemVertex) -> VertexIterator<'static, FilesystemVertex>;
 type ContextAndIterableOfEdges = (
-    DataContext<FilesystemToken>,
-    VertexIterator<'static, FilesystemToken>,
+    DataContext<FilesystemVertex>,
+    VertexIterator<'static, FilesystemVertex>,
 );
 
 struct EdgeResolverIterator {
     origin: Rc<String>,
-    contexts: VertexIterator<'static, DataContext<FilesystemToken>>,
+    contexts: VertexIterator<'static, DataContext<FilesystemVertex>>,
     edge_resolver: IndividualEdgeResolver,
 }
 
 impl EdgeResolverIterator {
     pub fn new(
         origin: Rc<String>,
-        contexts: VertexIterator<'static, DataContext<FilesystemToken>>,
+        contexts: VertexIterator<'static, DataContext<FilesystemVertex>>,
         edge_resolver: IndividualEdgeResolver,
     ) -> Self {
         Self {
@@ -194,8 +194,8 @@ impl EdgeResolverIterator {
 
 impl Iterator for EdgeResolverIterator {
     type Item = (
-        DataContext<FilesystemToken>,
-        VertexIterator<'static, FilesystemToken>,
+        DataContext<FilesystemVertex>,
+        VertexIterator<'static, FilesystemVertex>,
     );
 
     fn next(&mut self) -> Option<ContextAndIterableOfEdges> {
@@ -204,7 +204,7 @@ impl Iterator for EdgeResolverIterator {
                 let neighbors = (self.edge_resolver)(self.origin.clone(), vertex);
                 Some((context, neighbors))
             } else {
-                let empty_iterator: iter::Empty<FilesystemToken> = iter::empty();
+                let empty_iterator: iter::Empty<FilesystemVertex> = iter::empty();
                 Some((context, Box::new(empty_iterator)))
             }
         } else {
@@ -214,19 +214,19 @@ impl Iterator for EdgeResolverIterator {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FilesystemToken {
-    Directory(DirectoryToken),
-    File(FileToken),
+pub enum FilesystemVertex {
+    Directory(DirectoryVertex),
+    File(FileVertex),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DirectoryToken {
+pub struct DirectoryVertex {
     pub name: String,
     pub path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FileToken {
+pub struct FileVertex {
     pub name: String,
     pub extension: Option<String>,
     pub path: String,
@@ -234,10 +234,10 @@ pub struct FileToken {
 
 fn directory_contains_file_handler(
     origin: Rc<String>,
-    vertex: &FilesystemToken,
-) -> VertexIterator<'static, FilesystemToken> {
+    vertex: &FilesystemVertex,
+) -> VertexIterator<'static, FilesystemVertex> {
     let directory_vertex = match vertex {
-        FilesystemToken::Directory(dir) => dir,
+        FilesystemVertex::Directory(dir) => dir,
         _ => unreachable!(),
     };
     Box::from(DirectoryContainsFileIterator::new(origin, directory_vertex))
@@ -245,10 +245,10 @@ fn directory_contains_file_handler(
 
 fn directory_subdirectory_handler(
     origin: Rc<String>,
-    vertex: &FilesystemToken,
-) -> VertexIterator<'static, FilesystemToken> {
+    vertex: &FilesystemVertex,
+) -> VertexIterator<'static, FilesystemVertex> {
     let directory_vertex = match vertex {
-        FilesystemToken::Directory(dir) => dir,
+        FilesystemVertex::Directory(dir) => dir,
         _ => unreachable!(),
     };
     Box::from(SubdirectoryIterator::new(origin, directory_vertex))
@@ -256,7 +256,7 @@ fn directory_subdirectory_handler(
 
 #[allow(unused_variables)]
 impl Adapter<'static> for FilesystemInterpreter {
-    type Vertex = FilesystemToken;
+    type Vertex = FilesystemVertex;
 
     fn resolve_starting_vertices(
         &mut self,
@@ -266,7 +266,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     ) -> VertexIterator<'static, Self::Vertex> {
         assert!(edge_name.as_ref() == "OriginDirectory");
         assert!(parameters.is_empty());
-        let vertex = DirectoryToken {
+        let vertex = DirectoryVertex {
             name: "<origin>".to_owned(),
             path: "".to_owned(),
         };
@@ -284,7 +284,7 @@ impl Adapter<'static> for FilesystemInterpreter {
             "Directory" => match property_name.as_ref() {
                 "name" => Box::new(contexts.map(|context| match context.active_vertex() {
                     None => (context, FieldValue::Null),
-                    Some(FilesystemToken::Directory(ref x)) => {
+                    Some(FilesystemVertex::Directory(ref x)) => {
                         let value = FieldValue::String(x.name.clone());
                         (context, value)
                     }
@@ -292,18 +292,22 @@ impl Adapter<'static> for FilesystemInterpreter {
                 })),
                 "path" => Box::new(contexts.map(|context| match context.active_vertex() {
                     None => (context, FieldValue::Null),
-                    Some(FilesystemToken::Directory(ref x)) => {
+                    Some(FilesystemVertex::Directory(ref x)) => {
                         let value = FieldValue::String(x.path.clone());
                         (context, value)
                     }
                     _ => unreachable!(),
+                })),
+                "__typename" => Box::new(contexts.map(|context| match context.active_vertex() {
+                    None => (context, FieldValue::Null),
+                    Some(_) => (context, "Directory".into()),
                 })),
                 _ => todo!(),
             },
             "File" => match property_name.as_ref() {
                 "name" => Box::new(contexts.map(|context| match context.active_vertex() {
                     None => (context, FieldValue::Null),
-                    Some(FilesystemToken::File(ref x)) => {
+                    Some(FilesystemVertex::File(ref x)) => {
                         let value = FieldValue::String(x.name.clone());
                         (context, value)
                     }
@@ -311,7 +315,7 @@ impl Adapter<'static> for FilesystemInterpreter {
                 })),
                 "path" => Box::new(contexts.map(|context| match context.active_vertex() {
                     None => (context, FieldValue::Null),
-                    Some(FilesystemToken::File(ref x)) => {
+                    Some(FilesystemVertex::File(ref x)) => {
                         let value = FieldValue::String(x.path.clone());
                         (context, value)
                     }
@@ -319,7 +323,7 @@ impl Adapter<'static> for FilesystemInterpreter {
                 })),
                 "extension" => Box::new(contexts.map(|context| match context.active_vertex() {
                     None => (context, FieldValue::Null),
-                    Some(FilesystemToken::File(ref x)) => {
+                    Some(FilesystemVertex::File(ref x)) => {
                         let value = x
                             .extension
                             .clone()
@@ -328,6 +332,10 @@ impl Adapter<'static> for FilesystemInterpreter {
                         (context, value)
                     }
                     _ => unreachable!(),
+                })),
+                "__typename" => Box::new(contexts.map(|context| match context.active_vertex() {
+                    None => (context, FieldValue::Null),
+                    Some(_) => (context, "File".into()),
                 })),
                 _ => todo!(),
             },

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -27,14 +27,14 @@ impl FilesystemInterpreter {
 
 #[derive(Debug)]
 struct OriginIterator {
-    origin_token: DirectoryToken,
+    origin_vertex: DirectoryToken,
     produced: bool,
 }
 
 impl OriginIterator {
-    pub fn new(token: DirectoryToken) -> OriginIterator {
+    pub fn new(vertex: DirectoryToken) -> OriginIterator {
         OriginIterator {
-            origin_token: token,
+            origin_vertex: vertex,
             produced: false,
         }
     }
@@ -48,7 +48,7 @@ impl Iterator for OriginIterator {
             None
         } else {
             self.produced = true;
-            Some(FilesystemToken::Directory(self.origin_token.clone()))
+            Some(FilesystemToken::Directory(self.origin_vertex.clone()))
         }
     }
 }
@@ -234,24 +234,24 @@ pub struct FileToken {
 
 fn directory_contains_file_handler(
     origin: Rc<String>,
-    token: &FilesystemToken,
+    vertex: &FilesystemToken,
 ) -> VertexIterator<'static, FilesystemToken> {
-    let directory_token = match token {
+    let directory_vertex = match vertex {
         FilesystemToken::Directory(dir) => dir,
         _ => unreachable!(),
     };
-    Box::from(DirectoryContainsFileIterator::new(origin, directory_token))
+    Box::from(DirectoryContainsFileIterator::new(origin, directory_vertex))
 }
 
 fn directory_subdirectory_handler(
     origin: Rc<String>,
-    token: &FilesystemToken,
+    vertex: &FilesystemToken,
 ) -> VertexIterator<'static, FilesystemToken> {
-    let directory_token = match token {
+    let directory_vertex = match vertex {
         FilesystemToken::Directory(dir) => dir,
         _ => unreachable!(),
     };
-    Box::from(SubdirectoryIterator::new(origin, directory_token))
+    Box::from(SubdirectoryIterator::new(origin, directory_vertex))
 }
 
 #[allow(unused_variables)]
@@ -266,11 +266,11 @@ impl Adapter<'static> for FilesystemInterpreter {
     ) -> VertexIterator<'static, Self::Vertex> {
         assert!(edge_name.as_ref() == "OriginDirectory");
         assert!(parameters.is_empty());
-        let token = DirectoryToken {
+        let vertex = DirectoryToken {
             name: "<origin>".to_owned(),
             path: "".to_owned(),
         };
-        Box::new(OriginIterator::new(token))
+        Box::new(OriginIterator::new(vertex))
     }
 
     fn resolve_property(

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -135,7 +135,7 @@ where
     }
 
     iterator = Box::new(iterator.map(move |mut context| {
-        context.record_token(component_root_vid);
+        context.record_vertex(component_root_vid);
         context
     }));
 
@@ -212,8 +212,8 @@ fn construct_outputs<'query, Vertex: Clone + Debug + 'query>(
         let context_field = &ir_query.root_component.outputs[output_name];
         let vertex_id = context_field.vertex_id;
         let moved_iterator = Box::new(output_iterator.map(move |context| {
-            let new_token = context.vertices[&vertex_id].clone();
-            context.move_to_token(new_token)
+            let new_vertex = context.vertices[&vertex_id].clone();
+            context.move_to_vertex(new_vertex)
         }));
 
         let type_name = &ir_query.root_component.vertices[&vertex_id].type_name;
@@ -354,7 +354,7 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
             FieldRef::ContextField(field) => {
                 let vertex_id = field.vertex_id;
                 let activated_vertex_iterator: ContextIterator<'query, Vertex> =
-                    Box::new(iterator.map(move |x| x.activate_token(&vertex_id)));
+                    Box::new(iterator.map(move |x| x.activate_vertex(&vertex_id)));
 
                 let field_vertex = &parent_component.vertices[&field.vertex_id];
                 let type_name = &field_vertex.type_name;
@@ -397,7 +397,7 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
     // Get the initial vertices inside the folded scope.
     let expanding_from_vid = expanding_from.vid;
     let activated_vertex_iterator: ContextIterator<'query, Vertex> =
-        Box::new(iterator.map(move |x| x.activate_token(&expanding_from_vid)));
+        Box::new(iterator.map(move |x| x.activate_vertex(&expanding_from_vid)));
     let type_name = &expanding_from.type_name;
     let query_info = QueryInfo::new(query.clone(), expanding_from_vid, Some(fold.eid));
     let edge_iterator = adapter_ref.resolve_neighbors(
@@ -534,8 +534,8 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
                 let context_field = &fold.component.outputs[output_name.as_ref()];
                 let vertex_id = context_field.vertex_id;
                 let moved_iterator = Box::new(output_iterator.map(move |context| {
-                    let new_token = context.vertices[&vertex_id].clone();
-                    context.move_to_token(new_token)
+                    let new_vertex = context.vertices[&vertex_id].clone();
+                    context.move_to_vertex(new_vertex)
                 }));
 
                 let mut adapter_ref = cloned_adapter.borrow_mut();
@@ -603,7 +603,7 @@ fn compute_fold<'query, Vertex: Clone + Debug + 'query>(
 /// a scope that is optional and missing, and therefore the filter should pass.
 ///
 /// A small subtlety is important here: it's possible that the tagged value is *local* to
-/// the scope being filtered. In that case, the context *will not* yet have a token associated
+/// the scope being filtered. In that case, the context *will not* yet have a vertex associated
 /// with the [Vid] of the tag's ContextField. However, in such cases, the tagged value
 /// is *never* optional relative to the current scope, so we can safely return `false`.
 #[inline(always)]
@@ -619,7 +619,7 @@ fn is_tag_optional_and_missing<'query, Vertex: Clone + Debug + 'query>(
 
     // Some(None) means "there's a value associated with that Vid, and it's None".
     // None would mean that the tagged value is local, i.e. nothing is associated with that Vid yet.
-    // Some(Some(token)) would mean that a vertex was found and associated with that Vid.
+    // Some(Some(vertex)) would mean that a vertex was found and associated with that Vid.
     matches!(context.vertices.get(&vid), Some(None))
 }
 
@@ -902,9 +902,9 @@ fn compute_context_field<'query, Vertex: Clone + Debug + 'query>(
     if let Some(vertex) = component.vertices.get(&vertex_id) {
         let moved_iterator = iterator.map(move |mut context| {
             let active_vertex = context.active_vertex.clone();
-            let new_token = context.vertices[&vertex_id].clone();
+            let new_vertex = context.vertices[&vertex_id].clone();
             context.suspended_vertices.push(active_vertex);
-            context.move_to_token(new_token)
+            context.move_to_vertex(new_vertex)
         });
 
         let type_name = &vertex.type_name;
@@ -921,10 +921,10 @@ fn compute_context_field<'query, Vertex: Clone + Debug + 'query>(
         Box::new(context_and_value_iterator.map(|(mut context, value)| {
             context.values.push(value);
 
-            // Make sure that the context has the same "current" token
+            // Make sure that the context has the same "current" vertex
             // as before evaluating the context field.
             let old_active_vertex = context.suspended_vertices.pop().unwrap();
-            context.move_to_token(old_active_vertex)
+            context.move_to_vertex(old_active_vertex)
         }))
     } else {
         // This context field represents an imported tag value from an outer component.
@@ -1012,7 +1012,7 @@ impl<'query, Vertex: Clone + Debug + 'query> Iterator for EdgeExpander<'query, V
             let neighbor = self.neighbors.next();
             if neighbor.is_some() {
                 self.has_neighbors = true;
-                return Some(self.context.split_and_move_to_token(neighbor));
+                return Some(self.context.split_and_move_to_vertex(neighbor));
             } else {
                 self.neighbors_ended = true;
             }
@@ -1021,21 +1021,21 @@ impl<'query, Vertex: Clone + Debug + 'query> Iterator for EdgeExpander<'query, V
         assert!(self.neighbors_ended);
         self.ended = true;
 
-        // If there's no current token, there couldn't possibly be neighbors.
+        // If there's no current vertex, there couldn't possibly be neighbors.
         // If this assertion trips, the adapter's resolve_neighbors() implementation illegally
         // returned neighbors for a non-existent vertex.
         if self.context.active_vertex.is_none() {
             assert!(!self.has_neighbors);
         }
 
-        // If the current token is None, that means that a prior edge was optional and missing.
+        // If the current vertex is None, that means that a prior edge was optional and missing.
         // In that case, we couldn't possibly have found any neighbors here, but the optional-ness
-        // of that prior edge means we have to return a context with no active token.
+        // of that prior edge means we have to return a context with no active vertex.
         //
-        // The other case where we have to return a context with no active token is when
-        // we have a current token, but the edge we're traversing is optional and does not exist.
+        // The other case where we have to return a context with no active vertex is when
+        // we have a current vertex, but the edge we're traversing is optional and does not exist.
         if self.context.active_vertex.is_none() || (!self.has_neighbors && self.is_optional_edge) {
-            Some(self.context.split_and_move_to_token(None))
+            Some(self.context.split_and_move_to_vertex(None))
         } else {
             None
         }
@@ -1103,7 +1103,7 @@ fn expand_non_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
 ) -> ContextIterator<'query, Vertex> {
     let expanding_from_vid = expanding_from.vid;
     let expanding_vertex_iterator: ContextIterator<'query, Vertex> =
-        Box::new(iterator.map(move |x| x.activate_token(&expanding_from_vid)));
+        Box::new(iterator.map(move |x| x.activate_vertex(&expanding_from_vid)));
 
     let type_name = &expanding_from.type_name;
     let query_info = QueryInfo::new(query.clone(), expanding_from_vid, Some(edge_id));
@@ -1125,7 +1125,7 @@ fn expand_non_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
 /// Apply all the operations needed at entry into a new vertex:
 /// - coerce the type, if needed
 /// - apply all local filters
-/// - record the token at this Vid in the context
+/// - record the vertex at this Vid in the context
 fn perform_entry_into_new_vertex<'query, Vertex: Clone + Debug + 'query>(
     adapter: Rc<RefCell<impl Adapter<'query, Vertex = Vertex> + 'query>>,
     query: &InterpretedQuery,
@@ -1146,7 +1146,7 @@ fn perform_entry_into_new_vertex<'query, Vertex: Clone + Debug + 'query>(
         );
     }
     Box::new(iterator.map(move |mut x| {
-        x.record_token(vertex_id);
+        x.record_vertex(vertex_id);
         x
     }))
 }
@@ -1168,11 +1168,11 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
     let mut recursion_iterator: ContextIterator<'query, Vertex> =
         Box::new(iterator.map(move |mut context| {
             if context.active_vertex.is_none() {
-                // Mark that this token starts off with a None active_vertex value,
+                // Mark that this vertex starts off with a None active_vertex value,
                 // so the later unsuspend() call should restore it to such a state later.
                 context.suspended_vertices.push(None);
             }
-            context.activate_token(&expanding_from_vid)
+            context.activate_vertex(&expanding_from_vid)
         }));
 
     let max_depth = usize::from(recursive.depth);
@@ -1297,33 +1297,33 @@ impl<'query, Vertex: Clone + Debug + 'query> Iterator for RecursiveEdgeExpander<
         if !self.neighbors_ended {
             let neighbor = self.neighbors.next();
 
-            if let Some(token) = neighbor {
+            if let Some(vertex) = neighbor {
                 if let Some(context) = self.context.take() {
                     // Prep a neighbor base context for future use, since we're moving
                     // the "self" context out.
-                    self.neighbor_base = Some(context.split_and_move_to_token(None));
+                    self.neighbor_base = Some(context.split_and_move_to_vertex(None));
 
                     // Attach the "self" context as a piggyback rider on the neighbor.
-                    let mut neighbor_context = context.split_and_move_to_token(Some(token));
+                    let mut neighbor_context = context.split_and_move_to_vertex(Some(vertex));
                     neighbor_context
                         .piggyback
                         .get_or_insert_with(Default::default)
                         .push(context.ensure_suspended());
                     return Some(neighbor_context);
                 } else {
-                    // The "self" token has already been moved out, so use the neighbor base context
+                    // The "self" vertex has already been moved out, so use the neighbor base context
                     // as the starting point for constructing a new context.
                     return Some(
                         self.neighbor_base
                             .as_ref()
                             .unwrap()
-                            .split_and_move_to_token(Some(token)),
+                            .split_and_move_to_vertex(Some(vertex)),
                     );
                 }
             } else {
                 self.neighbors_ended = true;
 
-                // If there's no current token, there couldn't possibly be neighbors.
+                // If there's no current vertex, there couldn't possibly be neighbors.
                 // If this assertion trips, the adapter's resolve_neighbors() implementation
                 // illegally returned neighbors for a non-existent vertex.
                 if let Some(context) = &self.context {

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -903,7 +903,7 @@ fn compute_context_field<'query, Vertex: Clone + Debug + 'query>(
         let moved_iterator = iterator.map(move |mut context| {
             let active_vertex = context.active_vertex.clone();
             let new_token = context.tokens[&vertex_id].clone();
-            context.suspended_tokens.push(active_vertex);
+            context.suspended_vertices.push(active_vertex);
             context.move_to_token(new_token)
         });
 
@@ -923,7 +923,7 @@ fn compute_context_field<'query, Vertex: Clone + Debug + 'query>(
 
             // Make sure that the context has the same "current" token
             // as before evaluating the context field.
-            let old_active_vertex = context.suspended_tokens.pop().unwrap();
+            let old_active_vertex = context.suspended_vertices.pop().unwrap();
             context.move_to_token(old_active_vertex)
         }))
     } else {
@@ -1170,7 +1170,7 @@ fn expand_recursive_edge<'query, Vertex: Clone + Debug + 'query>(
             if context.active_vertex.is_none() {
                 // Mark that this token starts off with a None active_vertex value,
                 // so the later unsuspend() call should restore it to such a state later.
-                context.suspended_tokens.push(None);
+                context.suspended_vertices.push(None);
             }
             context.activate_token(&expanding_from_vid)
         }));

--- a/trustfall_core/src/interpreter/helpers.rs
+++ b/trustfall_core/src/interpreter/helpers.rs
@@ -17,7 +17,7 @@ pub fn resolve_property_with<'vertex, Vertex: Debug + Clone + 'vertex>(
     contexts: ContextIterator<'vertex, Vertex>,
     mut resolver: impl FnMut(&Vertex) -> FieldValue + 'static,
 ) -> ContextOutcomeIterator<'vertex, Vertex, FieldValue> {
-    Box::new(contexts.map(move |ctx| match ctx.current_token.as_ref() {
+    Box::new(contexts.map(move |ctx| match ctx.active_vertex.as_ref() {
         None => (ctx, FieldValue::Null),
         Some(vertex) => {
             let value = resolver(vertex);
@@ -37,7 +37,7 @@ pub fn resolve_neighbors_with<'vertex, Vertex: Debug + Clone + 'vertex>(
     mut resolver: impl FnMut(&Vertex) -> VertexIterator<'vertex, Vertex> + 'static,
 ) -> ContextOutcomeIterator<'vertex, Vertex, VertexIterator<'vertex, Vertex>> {
     Box::new(contexts.map(move |ctx| {
-        match ctx.current_token.as_ref() {
+        match ctx.active_vertex.as_ref() {
             None => {
                 // rustc needs a bit of help with the type inference here,
                 // due to the Box<dyn Iterator> conversion.
@@ -62,7 +62,7 @@ pub fn resolve_coercion_with<'vertex, Vertex: Debug + Clone + 'vertex>(
     contexts: ContextIterator<'vertex, Vertex>,
     mut resolver: impl FnMut(&Vertex) -> bool + 'static,
 ) -> ContextOutcomeIterator<'vertex, Vertex, bool> {
-    Box::new(contexts.map(move |ctx| match ctx.current_token.as_ref() {
+    Box::new(contexts.map(move |ctx| match ctx.active_vertex.as_ref() {
         None => (ctx, false),
         Some(vertex) => {
             let can_coerce = resolver(vertex);

--- a/trustfall_core/src/interpreter/macros.rs
+++ b/trustfall_core/src/interpreter/macros.rs
@@ -2,7 +2,7 @@
 macro_rules! property_stub {
     ($ctxs:ident, $token_variant:path $(| $other_variant:path)*, $token:ident, $impl:block) => {
         Box::new($ctxs.map(move |ctx| {
-            let value = match &ctx.current_token {
+            let value = match &ctx.active_vertex {
                 Some($token_variant($token)) => $impl,
                 $( Some($other_variant($token)) => $impl, )*
                 None => FieldValue::Null,
@@ -122,7 +122,7 @@ macro_rules! neighbor_stub {
     ($ctxs:ident, $lt:lifetime, $token_variant:path $(| $other_variant:path)*, $token:ident, $impl:tt) => {
         Box::new($ctxs.map(move |ctx| {
             let neighbors: VertexIterator<$lt, <Self as Adapter>::Vertex>> =
-                match &ctx.current_token {
+                match &ctx.active_vertex {
                     Some($token_variant($token)) => $impl,
                     $( Some($other_variant($token)) => $impl, )*
                     None => Box::new(std::iter::empty()),

--- a/trustfall_core/src/interpreter/macros.rs
+++ b/trustfall_core/src/interpreter/macros.rs
@@ -1,19 +1,19 @@
 #[macro_export]
 macro_rules! property_stub {
-    ($ctxs:ident, $token_variant:path $(| $other_variant:path)*, $token:ident, $impl:block) => {
+    ($ctxs:ident, $vertex_variant:path $(| $other_variant:path)*, $vertex:ident, $impl:block) => {
         Box::new($ctxs.map(move |ctx| {
             let value = match &ctx.active_vertex {
-                Some($token_variant($token)) => $impl,
-                $( Some($other_variant($token)) => $impl, )*
+                Some($vertex_variant($vertex)) => $impl,
+                $( Some($other_variant($vertex)) => $impl, )*
                 None => FieldValue::Null,
 
-                // If there's only one token variant, the below pattern is unreachable.
+                // If there's only one vertex variant, the below pattern is unreachable.
                 // We don't want to cause a lint for the user of the macro, so we suppress it.
                 #[allow(unreachable_patterns)]
                 Some(x) => {
                     unreachable!(
-                        "Unexpected token variant encountered! Expecting {:?} but got {:?}",
-                        stringify!($token_variant $(| $other_variant)*),
+                        "Unexpected vertex variant encountered! Expecting {:?} but got {:?}",
+                        stringify!($vertex_variant $(| $other_variant)*),
                         x
                     );
                 }
@@ -26,66 +26,66 @@ macro_rules! property_stub {
 #[macro_export]
 macro_rules! property_group {
     // initial case
-    ($ctxs:ident, $field_name:ident, $token_variant:path $(| $other_variant:path)*,
+    ($ctxs:ident, $field_name:ident, $vertex_variant:path $(| $other_variant:path)*,
         [
             $($rest:tt),+ $(,)?
         ] $(,)?
     ) => {
-        $crate::property_group!( @( $ctxs; $field_name; $token_variant $(| $other_variant)*; $($rest)+ ), )
+        $crate::property_group!( @( $ctxs; $field_name; $vertex_variant $(| $other_variant)*; $($rest)+ ), )
     };
 
-    // property name in schema matches field name on token variant inner type
-    (@($ctxs:ident; $field_name:ident; $token_variant:path $(| $other_variant:path)*;
+    // property name in schema matches field name on vertex variant inner type
+    (@($ctxs:ident; $field_name:ident; $vertex_variant:path $(| $other_variant:path)*;
         $prop_and_field:ident $($rest:tt)*
     ), $($arms:tt)*) => {
         $crate::property_group!(
-            @($ctxs; $field_name; $token_variant $(| $other_variant)*; $($rest)*),
+            @($ctxs; $field_name; $vertex_variant $(| $other_variant)*; $($rest)*),
             $($arms)*
             stringify!($prop_and_field) => {
-                $crate::property_stub!($ctxs, $token_variant $(| $other_variant)*, token, {
-                    token.$prop_and_field.clone().into()
+                $crate::property_stub!($ctxs, $vertex_variant $(| $other_variant)*, vertex, {
+                    vertex.$prop_and_field.clone().into()
                 })
             }
         )
     };
 
-    // (property name, field name on token variant inner type)
-    (@($ctxs:ident; $field_name:ident; $token_variant:path $(| $other_variant:path)*;
+    // (property name, field name on vertex variant inner type)
+    (@($ctxs:ident; $field_name:ident; $vertex_variant:path $(| $other_variant:path)*;
         ($prop_name:ident, $field:ident $(,)? ) $($rest:tt)*
     ), $($arms:tt)*) => {
         $crate::property_group!(
-            @($ctxs; $field_name; $token_variant $(| $other_variant:path)*; $($rest)*),
+            @($ctxs; $field_name; $vertex_variant $(| $other_variant:path)*; $($rest)*),
             $($arms)*
             stringify!($prop_name) => {
-                $crate::property_stub!($ctxs, $token_variant $(| $other_variant)*, token, {
-                    token.$field.clone().into()
+                $crate::property_stub!($ctxs, $vertex_variant $(| $other_variant)*, vertex, {
+                    vertex.$field.clone().into()
                 })
             }
         )
     };
 
-    // (property name, destructured token variant, handler block)
-    (@($ctxs:ident; $field_name:ident; $token_variant:path $(| $other_variant:path)*;
-        ($prop_name:ident, $token:ident, $impl:block $(,)? ) $($rest:tt)*
+    // (property name, destructured vertex variant, handler block)
+    (@($ctxs:ident; $field_name:ident; $vertex_variant:path $(| $other_variant:path)*;
+        ($prop_name:ident, $vertex:ident, $impl:block $(,)? ) $($rest:tt)*
     ), $($arms:tt)*) => {
         $crate::property_group!(
-            @($ctxs; $field_name; $token_variant $(| $other_variant)*; $($rest)*),
+            @($ctxs; $field_name; $vertex_variant $(| $other_variant)*; $($rest)*),
             $($arms)*
             stringify!($prop_name) => {
-                $crate::property_stub!($ctxs, $token_variant $(| $other_variant)*, $token, $impl)
+                $crate::property_stub!($ctxs, $vertex_variant $(| $other_variant)*, $vertex, $impl)
             }
         )
     };
 
     // final case
-    (@($ctxs:ident; $field_name:ident; $token_variant:path $(| $other_variant:path)*; ),
+    (@($ctxs:ident; $field_name:ident; $vertex_variant:path $(| $other_variant:path)*; ),
         $($arms:tt)+
     ) => {
         match $field_name.as_ref() {
             $($arms)+
             _ => unreachable!(
-                "Unexpected property name {} for token variant {:?}",
-                $field_name.as_ref(), stringify!($token_variant $(| $other_variant:path)*)
+                "Unexpected property name {} for vertex variant {:?}",
+                $field_name.as_ref(), stringify!($vertex_variant $(| $other_variant:path)*)
             ),
         }
     }
@@ -98,7 +98,7 @@ macro_rules! resolve_property {
             $(
                 {
                     $type_option:ident $(| $other_type_option:ident)*,
-                    $token_variant:path $(| $other_variant:path)*,
+                    $vertex_variant:path $(| $other_variant:path)*,
                     [ $($rest:tt),+ $(,)? ] $(,)?
                 }
             ),+ $(,)?
@@ -107,7 +107,7 @@ macro_rules! resolve_property {
         match $type_name.as_ref() {
             $(
                 stringify!($type_option) $(| stringify!($other_type_option))* => {
-                    $crate::property_group!($ctxs, $field_name, $token_variant $(| $other_variant)*, [ $($rest),+ ])
+                    $crate::property_group!($ctxs, $field_name, $vertex_variant $(| $other_variant)*, [ $($rest),+ ])
                 }
             )+
             _ => unreachable!(
@@ -119,21 +119,21 @@ macro_rules! resolve_property {
 
 #[macro_export]
 macro_rules! neighbor_stub {
-    ($ctxs:ident, $lt:lifetime, $token_variant:path $(| $other_variant:path)*, $token:ident, $impl:tt) => {
+    ($ctxs:ident, $lt:lifetime, $vertex_variant:path $(| $other_variant:path)*, $vertex:ident, $impl:tt) => {
         Box::new($ctxs.map(move |ctx| {
             let neighbors: VertexIterator<$lt, <Self as Adapter>::Vertex>> =
                 match &ctx.active_vertex {
-                    Some($token_variant($token)) => $impl,
-                    $( Some($other_variant($token)) => $impl, )*
+                    Some($vertex_variant($vertex)) => $impl,
+                    $( Some($other_variant($vertex)) => $impl, )*
                     None => Box::new(std::iter::empty()),
 
-                    // If there's only one token variant, the below pattern is unreachable.
+                    // If there's only one vertex variant, the below pattern is unreachable.
                     // We don't want to cause a lint for the user of the macro, so we suppress it.
                     #[allow(unreachable_patterns)]
                     Some(x) => {
                         unreachable!(
-                            "Unexpected token variant encountered! Expecting {} but got {:?}",
-                            stringify!($token_variant $(| $other_variant)*),
+                            "Unexpected vertex variant encountered! Expecting {} but got {:?}",
+                            stringify!($vertex_variant $(| $other_variant)*),
                             x
                         );
                     }
@@ -146,35 +146,35 @@ macro_rules! neighbor_stub {
 #[macro_export]
 macro_rules! neighbor_group {
     // initial case
-    ($ctxs:ident, $lt:lifetime, $edge_name_var:ident, $token_variant:path $(| $other_variant:path)*,
+    ($ctxs:ident, $lt:lifetime, $edge_name_var:ident, $vertex_variant:path $(| $other_variant:path)*,
         [
             $($rest:tt),+ $(,)?
         ] $(,)?
     ) => {
-        $crate::neighbor_group!( @( $ctxs; $lt; $edge_name_var; $token_variant $(| $other_variant)*; $($rest)+ ), )
+        $crate::neighbor_group!( @( $ctxs; $lt; $edge_name_var; $vertex_variant $(| $other_variant)*; $($rest)+ ), )
     };
 
-    // edge name in schema matches field name on token variant inner type,
-    // so matching (edge_and_field, resulting token variant)
-    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $token_variant:path $(| $other_variant:path)*;
+    // edge name in schema matches field name on vertex variant inner type,
+    // so matching (edge_and_field, resulting vertex variant)
+    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $vertex_variant:path $(| $other_variant:path)*;
         (
             $edge_and_field:ident,
             $next_variant:path $(,)?
         ) $($rest:tt)*
     ), $($arms:tt)*) => {
         $crate::neighbor_group!(
-            @($ctxs; $lt; $edge_name_var; $token_variant $(| $other_variant)*; $($rest)*),
+            @($ctxs; $lt; $edge_name_var; $vertex_variant $(| $other_variant)*; $($rest)*),
             $($arms)*
             stringify!($edge_and_field) => {
-                $crate::neighbor_stub!($ctxs, $lt, $token_variant, token, {
-                    Box::new(token.$edge_and_field.iter().map($next_variant))
+                $crate::neighbor_stub!($ctxs, $lt, $vertex_variant, vertex, {
+                    Box::new(vertex.$edge_and_field.iter().map($next_variant))
                 })
             }
         )
     };
 
-    // (edge name, field name on token variant inner type, resulting token variant)
-    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $token_variant:path $(| $other_variant:path)*;
+    // (edge name, field name on vertex variant inner type, resulting vertex variant)
+    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $vertex_variant:path $(| $other_variant:path)*;
         (
             $edge_name:ident,
             $field:ident,
@@ -182,42 +182,42 @@ macro_rules! neighbor_group {
         ) $($rest:tt)*
     ), $($arms:tt)*) => {
         $crate::neighbor_group!(
-            @($ctxs; $lt; $edge_name_var; $token_variant $(| $other_variant)*; $($rest)*),
+            @($ctxs; $lt; $edge_name_var; $vertex_variant $(| $other_variant)*; $($rest)*),
             $($arms)*
             stringify!($edge_name) => {
-                $crate::neighbor_stub!($ctxs, $lt, $token_variant $(| $other_variant)*, token, {
-                    Box::new(token.$field.iter().map($next_variant))
+                $crate::neighbor_stub!($ctxs, $lt, $vertex_variant $(| $other_variant)*, vertex, {
+                    Box::new(vertex.$field.iter().map($next_variant))
                 })
             }
         )
     };
 
-    // (edge name, destructured token variant, handler block)
-    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $token_variant:path $(| $other_variant:path)*;
+    // (edge name, destructured vertex variant, handler block)
+    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $vertex_variant:path $(| $other_variant:path)*;
         (
             $edge_name:ident,
-            $token:ident,
+            $vertex:ident,
             $impl:block $(,)?
         ) $($rest:tt)*
     ), $($arms:tt)*) => {
         $crate::neighbor_group!(
-            @($ctxs; $lt; $edge_name_var; $token_variant $(| $other_variant)*; $($rest)*),
+            @($ctxs; $lt; $edge_name_var; $vertex_variant $(| $other_variant)*; $($rest)*),
             $($arms)*
             stringify!($edge_name) => {
-                $crate::neighbor_stub!($ctxs, $lt, $token_variant $(| $other_variant)*, $token, $impl)
+                $crate::neighbor_stub!($ctxs, $lt, $vertex_variant $(| $other_variant)*, $vertex, $impl)
             }
         )
     };
 
     // final case
-    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $token_variant:path $(| $other_variant:path)*; ),
+    (@($ctxs:ident; $lt:lifetime; $edge_name_var:ident; $vertex_variant:path $(| $other_variant:path)*; ),
         $($arms:tt)+
     ) => {
         match $edge_name_var.as_ref() {
             $($arms)+
             _ => unreachable!(
-                "Unexpected edge name {} for token variant {:?}",
-                $edge_name_var.as_ref(), stringify!($token_variant $(| $other_variant)*)
+                "Unexpected edge name {} for vertex variant {:?}",
+                $edge_name_var.as_ref(), stringify!($vertex_variant $(| $other_variant)*)
             ),
         }
     }
@@ -230,7 +230,7 @@ macro_rules! resolve_neighbors {
             $(
                 {
                     $type_option:ident $(| $other_type_option:ident)*,
-                    $token_variant:path $(| $other_variant:path)*,
+                    $vertex_variant:path $(| $other_variant:path)*,
                     [ $($rest:tt),+ $(,)? ] $(,)?
                 }
             ),+ $(,)?
@@ -239,7 +239,7 @@ macro_rules! resolve_neighbors {
         match $type_name_var.as_ref() {
             $(
                 stringify!($type_option) $(| stringify!($other_type_option))* => {
-                    $crate::neighbor_group!($ctxs, $lt, $edge_name_var, $token_variant $(| $other_variant)*, [ $($rest),+ ])
+                    $crate::neighbor_group!($ctxs, $lt, $edge_name_var, $vertex_variant $(| $other_variant)*, [ $($rest),+ ])
                 }
             )+
             _ => unreachable!(
@@ -251,27 +251,27 @@ macro_rules! resolve_neighbors {
 
 #[macro_export]
 macro_rules! resolve_neighbors2_match_arm {
-    // token field is same as edge name, so this is just reading the next variant
-    ($ctxs:ident, $lt:lifetime, $edge_name:ident, $token_variant:path $(| $other_variant:path)*, $next_variant:path $(,)?) => {
+    // vertex field is same as edge name, so this is just reading the next variant
+    ($ctxs:ident, $lt:lifetime, $edge_name:ident, $vertex_variant:path $(| $other_variant:path)*, $next_variant:path $(,)?) => {
         $crate::neighbor_stub!(
-            $ctxs, $lt, $token_variant $(| $other_variant)*, token, {
-                Box::new(token.$edge_name.iter().map($next_variant))
+            $ctxs, $lt, $vertex_variant $(| $other_variant)*, vertex, {
+                Box::new(vertex.$edge_name.iter().map($next_variant))
             }
         )
     };
 
-    // (token field, next variant)
-    ($ctxs:ident, $lt:lifetime, $edge_name:ident, $token_variant:path $(| $other_variant:path)*, ($field:ident, $next_variant:path $(,)?) $(,)?) => {
+    // (vertex field, next variant)
+    ($ctxs:ident, $lt:lifetime, $edge_name:ident, $vertex_variant:path $(| $other_variant:path)*, ($field:ident, $next_variant:path $(,)?) $(,)?) => {
         $crate::neighbor_stub!(
-            $ctxs, $lt, $token_variant $(| $other_variant)*, token, {
-                Box::new(token.$field.iter().map($next_variant))
+            $ctxs, $lt, $vertex_variant $(| $other_variant)*, vertex, {
+                Box::new(vertex.$field.iter().map($next_variant))
             }
         )
     };
 
-    // (destuctured token var, impl block)
-    ($ctxs:ident, $lt:lifetime, $edge_name:ident, $token_variant:path $(| $other_variant:path)*, ($token:ident, $impl:block $(,)?) $(,)?) => {
-        $crate::neighbor_stub!($ctxs, $lt, $token_variant $(| $other_variant)*, $token, $impl)
+    // (destuctured vertex var, impl block)
+    ($ctxs:ident, $lt:lifetime, $edge_name:ident, $vertex_variant:path $(| $other_variant:path)*, ($vertex:ident, $impl:block $(,)?) $(,)?) => {
+        $crate::neighbor_stub!($ctxs, $lt, $vertex_variant $(| $other_variant)*, $vertex, $impl)
     };
 }
 
@@ -284,7 +284,7 @@ macro_rules! resolve_neighbors2 {
                 {
                     $type_option:ident $(| $other_type_option:ident)*,
                     $edge_name:ident,
-                    $token_variant:path $(| $other_variant:path)*,
+                    $vertex_variant:path $(| $other_variant:path)*,
                     $rest:tt $(,)?
                 }
             ),+ $(,)?
@@ -293,7 +293,7 @@ macro_rules! resolve_neighbors2 {
         match ($edge_name_var.as_ref(), $type_name_var.as_ref()) {
             $(
                 (stringify!($edge_name), stringify!($type_option)) $(| (stringify!($edge_name), stringify!($other_type_option)))* => {
-                    $crate::resolve_neighbors2_match_arm!($ctxs, $lt, $edge_name, $token_variant $(| $other_variant)*, $rest )
+                    $crate::resolve_neighbors2_match_arm!($ctxs, $lt, $edge_name, $vertex_variant $(| $other_variant)*, $rest )
                 }
             )+
             _ => unreachable!(

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -54,7 +54,7 @@ pub type ContextOutcomeIterator<'vertex, VertexT, OutcomeT> =
 #[derive(Debug, Clone)]
 pub struct DataContext<Vertex: Clone + Debug> {
     active_vertex: Option<Vertex>,
-    tokens: BTreeMap<Vid, Option<Vertex>>,
+    vertices: BTreeMap<Vid, Option<Vertex>>,
     values: Vec<FieldValue>,
     suspended_vertices: Vec<Option<Vertex>>,
     folded_contexts: BTreeMap<Eid, Vec<DataContext<Vertex>>>,
@@ -112,7 +112,7 @@ where
     for<'d> Vertex: Deserialize<'d>,
 {
     active_vertex: Option<Vertex>,
-    tokens: BTreeMap<Vid, Option<Vertex>>,
+    vertices: BTreeMap<Vid, Option<Vertex>>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     values: Vec<FieldValue>,
@@ -142,7 +142,7 @@ where
     fn from(context: SerializableContext<Vertex>) -> Self {
         Self {
             active_vertex: context.active_vertex,
-            tokens: context.tokens,
+            vertices: context.vertices,
             values: context.values,
             suspended_vertices: context.suspended_vertices,
             folded_contexts: context.folded_contexts,
@@ -161,7 +161,7 @@ where
     fn from(context: DataContext<Vertex>) -> Self {
         Self {
             active_vertex: context.active_vertex,
-            tokens: context.tokens,
+            vertices: context.vertices,
             values: context.values,
             suspended_vertices: context.suspended_vertices,
             folded_contexts: context.folded_contexts,
@@ -177,7 +177,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
         DataContext {
             active_vertex: token,
             piggyback: None,
-            tokens: Default::default(),
+            vertices: Default::default(),
             values: Default::default(),
             suspended_vertices: Default::default(),
             folded_contexts: Default::default(),
@@ -187,15 +187,15 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     }
 
     fn record_token(&mut self, vid: Vid) {
-        self.tokens
+        self.vertices
             .insert_or_error(vid, self.active_vertex.clone())
             .unwrap();
     }
 
     fn activate_token(self, vid: &Vid) -> DataContext<Vertex> {
         DataContext {
-            active_vertex: self.tokens[vid].clone(),
-            tokens: self.tokens,
+            active_vertex: self.vertices[vid].clone(),
+            vertices: self.vertices,
             values: self.values,
             suspended_vertices: self.suspended_vertices,
             folded_contexts: self.folded_contexts,
@@ -208,7 +208,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     fn split_and_move_to_token(&self, new_token: Option<Vertex>) -> DataContext<Vertex> {
         DataContext {
             active_vertex: new_token,
-            tokens: self.tokens.clone(),
+            vertices: self.vertices.clone(),
             values: self.values.clone(),
             suspended_vertices: self.suspended_vertices.clone(),
             folded_contexts: self.folded_contexts.clone(),
@@ -221,7 +221,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     fn move_to_token(self, new_token: Option<Vertex>) -> DataContext<Vertex> {
         DataContext {
             active_vertex: new_token,
-            tokens: self.tokens,
+            vertices: self.vertices,
             values: self.values,
             suspended_vertices: self.suspended_vertices,
             folded_contexts: self.folded_contexts,
@@ -236,7 +236,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
             self.suspended_vertices.push(Some(token));
             DataContext {
                 active_vertex: None,
-                tokens: self.tokens,
+                vertices: self.vertices,
                 values: self.values,
                 suspended_vertices: self.suspended_vertices,
                 folded_contexts: self.folded_contexts,
@@ -255,7 +255,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
                 let active_vertex = self.suspended_vertices.pop().unwrap();
                 DataContext {
                     active_vertex,
-                    tokens: self.tokens,
+                    vertices: self.vertices,
                     values: self.values,
                     suspended_vertices: self.suspended_vertices,
                     folded_contexts: self.folded_contexts,
@@ -272,7 +272,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
 impl<Vertex: Debug + Clone + PartialEq> PartialEq for DataContext<Vertex> {
     fn eq(&self, other: &Self) -> bool {
         self.active_vertex == other.active_vertex
-            && self.tokens == other.tokens
+            && self.vertices == other.vertices
             && self.values == other.values
             && self.suspended_vertices == other.suspended_vertices
             && self.folded_contexts == other.folded_contexts

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -56,7 +56,7 @@ pub struct DataContext<Vertex: Clone + Debug> {
     active_vertex: Option<Vertex>,
     tokens: BTreeMap<Vid, Option<Vertex>>,
     values: Vec<FieldValue>,
-    suspended_tokens: Vec<Option<Vertex>>,
+    suspended_vertices: Vec<Option<Vertex>>,
     folded_contexts: BTreeMap<Eid, Vec<DataContext<Vertex>>>,
     folded_values: BTreeMap<(Eid, Arc<str>), Option<ValueOrVec>>,
     piggyback: Option<Vec<DataContext<Vertex>>>,
@@ -118,7 +118,7 @@ where
     values: Vec<FieldValue>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    suspended_tokens: Vec<Option<Vertex>>,
+    suspended_vertices: Vec<Option<Vertex>>,
 
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     folded_contexts: BTreeMap<Eid, Vec<DataContext<Vertex>>>,
@@ -144,7 +144,7 @@ where
             active_vertex: context.active_vertex,
             tokens: context.tokens,
             values: context.values,
-            suspended_tokens: context.suspended_tokens,
+            suspended_vertices: context.suspended_vertices,
             folded_contexts: context.folded_contexts,
             folded_values: context.folded_values,
             piggyback: context.piggyback,
@@ -163,7 +163,7 @@ where
             active_vertex: context.active_vertex,
             tokens: context.tokens,
             values: context.values,
-            suspended_tokens: context.suspended_tokens,
+            suspended_vertices: context.suspended_vertices,
             folded_contexts: context.folded_contexts,
             folded_values: context.folded_values,
             piggyback: context.piggyback,
@@ -179,7 +179,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
             piggyback: None,
             tokens: Default::default(),
             values: Default::default(),
-            suspended_tokens: Default::default(),
+            suspended_vertices: Default::default(),
             folded_contexts: Default::default(),
             folded_values: Default::default(),
             imported_tags: Default::default(),
@@ -197,7 +197,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
             active_vertex: self.tokens[vid].clone(),
             tokens: self.tokens,
             values: self.values,
-            suspended_tokens: self.suspended_tokens,
+            suspended_vertices: self.suspended_vertices,
             folded_contexts: self.folded_contexts,
             folded_values: self.folded_values,
             piggyback: self.piggyback,
@@ -210,7 +210,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
             active_vertex: new_token,
             tokens: self.tokens.clone(),
             values: self.values.clone(),
-            suspended_tokens: self.suspended_tokens.clone(),
+            suspended_vertices: self.suspended_vertices.clone(),
             folded_contexts: self.folded_contexts.clone(),
             folded_values: self.folded_values.clone(),
             piggyback: None,
@@ -223,7 +223,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
             active_vertex: new_token,
             tokens: self.tokens,
             values: self.values,
-            suspended_tokens: self.suspended_tokens,
+            suspended_vertices: self.suspended_vertices,
             folded_contexts: self.folded_contexts,
             folded_values: self.folded_values,
             piggyback: self.piggyback,
@@ -233,12 +233,12 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
 
     fn ensure_suspended(mut self) -> DataContext<Vertex> {
         if let Some(token) = self.active_vertex {
-            self.suspended_tokens.push(Some(token));
+            self.suspended_vertices.push(Some(token));
             DataContext {
                 active_vertex: None,
                 tokens: self.tokens,
                 values: self.values,
-                suspended_tokens: self.suspended_tokens,
+                suspended_vertices: self.suspended_vertices,
                 folded_contexts: self.folded_contexts,
                 folded_values: self.folded_values,
                 piggyback: self.piggyback,
@@ -252,12 +252,12 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     fn ensure_unsuspended(mut self) -> DataContext<Vertex> {
         match self.active_vertex {
             None => {
-                let active_vertex = self.suspended_tokens.pop().unwrap();
+                let active_vertex = self.suspended_vertices.pop().unwrap();
                 DataContext {
                     active_vertex,
                     tokens: self.tokens,
                     values: self.values,
-                    suspended_tokens: self.suspended_tokens,
+                    suspended_vertices: self.suspended_vertices,
                     folded_contexts: self.folded_contexts,
                     folded_values: self.folded_values,
                     piggyback: self.piggyback,
@@ -274,7 +274,7 @@ impl<Vertex: Debug + Clone + PartialEq> PartialEq for DataContext<Vertex> {
         self.active_vertex == other.active_vertex
             && self.tokens == other.tokens
             && self.values == other.values
-            && self.suspended_tokens == other.suspended_tokens
+            && self.suspended_vertices == other.suspended_vertices
             && self.folded_contexts == other.folded_contexts
             && self.piggyback == other.piggyback
             && self.imported_tags == other.imported_tags

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -173,9 +173,9 @@ where
 }
 
 impl<Vertex: Clone + Debug> DataContext<Vertex> {
-    pub fn new(token: Option<Vertex>) -> DataContext<Vertex> {
+    pub fn new(vertex: Option<Vertex>) -> DataContext<Vertex> {
         DataContext {
-            active_vertex: token,
+            active_vertex: vertex,
             piggyback: None,
             vertices: Default::default(),
             values: Default::default(),
@@ -186,13 +186,13 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
         }
     }
 
-    fn record_token(&mut self, vid: Vid) {
+    fn record_vertex(&mut self, vid: Vid) {
         self.vertices
             .insert_or_error(vid, self.active_vertex.clone())
             .unwrap();
     }
 
-    fn activate_token(self, vid: &Vid) -> DataContext<Vertex> {
+    fn activate_vertex(self, vid: &Vid) -> DataContext<Vertex> {
         DataContext {
             active_vertex: self.vertices[vid].clone(),
             vertices: self.vertices,
@@ -205,9 +205,9 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
         }
     }
 
-    fn split_and_move_to_token(&self, new_token: Option<Vertex>) -> DataContext<Vertex> {
+    fn split_and_move_to_vertex(&self, new_vertex: Option<Vertex>) -> DataContext<Vertex> {
         DataContext {
-            active_vertex: new_token,
+            active_vertex: new_vertex,
             vertices: self.vertices.clone(),
             values: self.values.clone(),
             suspended_vertices: self.suspended_vertices.clone(),
@@ -218,9 +218,9 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
         }
     }
 
-    fn move_to_token(self, new_token: Option<Vertex>) -> DataContext<Vertex> {
+    fn move_to_vertex(self, new_vertex: Option<Vertex>) -> DataContext<Vertex> {
         DataContext {
-            active_vertex: new_token,
+            active_vertex: new_vertex,
             vertices: self.vertices,
             values: self.values,
             suspended_vertices: self.suspended_vertices,
@@ -232,8 +232,8 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     }
 
     fn ensure_suspended(mut self) -> DataContext<Vertex> {
-        if let Some(token) = self.active_vertex {
-            self.suspended_vertices.push(Some(token));
+        if let Some(vertex) = self.active_vertex {
+            self.suspended_vertices.push(Some(vertex));
             DataContext {
                 active_vertex: None,
                 vertices: self.vertices,

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -578,7 +578,7 @@ mod tests {
     use trustfall_filetests_macros::parameterize;
 
     use crate::{
-        filesystem_interpreter::FilesystemToken,
+        filesystem_interpreter::FilesystemVertex,
         interpreter::replay::assert_interpreted_results,
         numbers_interpreter::NumbersToken,
         util::{TestIRQuery, TestIRQueryResult, TestInterpreterOutputTrace},
@@ -597,7 +597,7 @@ mod tests {
     }
 
     fn check_filesystem_trace(expected_ir: TestIRQuery, input_data: &str) {
-        match ron::from_str::<TestInterpreterOutputTrace<FilesystemToken>>(input_data) {
+        match ron::from_str::<TestInterpreterOutputTrace<FilesystemVertex>>(input_data) {
             Ok(test_data) => {
                 assert_eq!(expected_ir.schema_name, "filesystem");
                 assert_eq!(test_data.schema_name, "filesystem");

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -72,7 +72,7 @@ where
                 self.exhausted = true;
                 None
             }
-            TraceOpContent::YieldFrom(YieldValue::GetStartingTokens(token)) => Some(token.clone()),
+            TraceOpContent::YieldFrom(YieldValue::GetStartingTokens(vertex)) => Some(vertex.clone()),
             _ => unreachable!(),
         }
     }
@@ -371,10 +371,10 @@ where
                 self.exhausted = true;
                 None
             }
-            TraceOpContent::YieldFrom(YieldValue::ProjectNeighborsInner(index, token)) => {
+            TraceOpContent::YieldFrom(YieldValue::ProjectNeighborsInner(index, vertex)) => {
                 assert_eq!(self.next_index, *index);
                 self.next_index += 1;
-                Some(token.clone())
+                Some(vertex.clone())
             }
             _ => unreachable!(),
         }

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -580,7 +580,7 @@ mod tests {
     use crate::{
         filesystem_interpreter::FilesystemVertex,
         interpreter::replay::assert_interpreted_results,
-        numbers_interpreter::NumbersToken,
+        numbers_interpreter::NumbersVertex,
         util::{TestIRQuery, TestIRQueryResult, TestInterpreterOutputTrace},
     };
 
@@ -610,7 +610,7 @@ mod tests {
     }
 
     fn check_numbers_trace(expected_ir: TestIRQuery, input_data: &str) {
-        match ron::from_str::<TestInterpreterOutputTrace<NumbersToken>>(input_data) {
+        match ron::from_str::<TestInterpreterOutputTrace<NumbersVertex>>(input_data) {
             Ok(test_data) => {
                 assert_eq!(expected_ir.schema_name, "numbers");
                 assert_eq!(test_data.schema_name, "numbers");

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -34,7 +34,7 @@ fn advance_ref_iter<T, Iter: Iterator<Item = T>>(iter: &RefCell<Iter>) -> Option
 }
 
 #[derive(Debug)]
-struct TraceReaderStartingTokensIter<'trace, Vertex>
+struct TraceReaderStartingVerticesIter<'trace, Vertex>
 where
     Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
     for<'de2> Vertex: Deserialize<'de2>,
@@ -45,7 +45,7 @@ where
 }
 
 #[allow(unused_variables)]
-impl<'trace, Vertex> Iterator for TraceReaderStartingTokensIter<'trace, Vertex>
+impl<'trace, Vertex> Iterator for TraceReaderStartingVerticesIter<'trace, Vertex>
 where
     Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
     for<'de2> Vertex: Deserialize<'de2>,
@@ -78,7 +78,7 @@ where
     }
 }
 
-struct TraceReaderProjectPropertiesIter<'trace, Vertex>
+struct TraceReaderResolvePropertiesIter<'trace, Vertex>
 where
     Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
     for<'de2> Vertex: Deserialize<'de2>,
@@ -91,7 +91,7 @@ where
 }
 
 #[allow(unused_variables)]
-impl<'trace, Vertex> Iterator for TraceReaderProjectPropertiesIter<'trace, Vertex>
+impl<'trace, Vertex> Iterator for TraceReaderResolvePropertiesIter<'trace, Vertex>
 where
     Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
     for<'de2> Vertex: Deserialize<'de2>,
@@ -158,7 +158,7 @@ where
     }
 }
 
-struct TraceReaderCanCoerceIter<'query, 'trace, Vertex>
+struct TraceReaderResolveCoercionIter<'query, 'trace, Vertex>
 where
     Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
     for<'de2> Vertex: Deserialize<'de2>,
@@ -172,7 +172,7 @@ where
 }
 
 #[allow(unused_variables)]
-impl<'query, 'trace, Vertex> Iterator for TraceReaderCanCoerceIter<'query, 'trace, Vertex>
+impl<'query, 'trace, Vertex> Iterator for TraceReaderResolveCoercionIter<'query, 'trace, Vertex>
 where
     Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
     for<'de2> Vertex: Deserialize<'de2>,
@@ -403,7 +403,7 @@ where
             assert_eq!(vid, query_info.origin_vid());
             assert!(query_info.origin_crossing_eid().is_none());
 
-            Box::new(TraceReaderStartingTokensIter {
+            Box::new(TraceReaderStartingVerticesIter {
                 exhausted: false,
                 parent_opid: *root_opid,
                 inner: self.next_op.clone(),
@@ -432,7 +432,7 @@ where
             assert_eq!(property, property_name);
             assert!(query_info.origin_crossing_eid().is_none());
 
-            Box::new(TraceReaderProjectPropertiesIter {
+            Box::new(TraceReaderResolvePropertiesIter {
                 exhausted: false,
                 parent_opid: *root_opid,
                 contexts,
@@ -494,7 +494,7 @@ where
             assert_eq!(to_type, coerce_to_type);
             assert!(query_info.origin_crossing_eid().is_none());
 
-            Box::new(TraceReaderCanCoerceIter {
+            Box::new(TraceReaderResolveCoercionIter {
                 exhausted: false,
                 parent_opid: *root_opid,
                 contexts,
@@ -584,10 +584,10 @@ mod tests {
         util::{TestIRQuery, TestIRQueryResult, TestInterpreterOutputTrace},
     };
 
-    fn check_trace<Token>(expected_ir: TestIRQuery, test_data: TestInterpreterOutputTrace<Token>)
+    fn check_trace<Vertex>(expected_ir: TestIRQuery, test_data: TestInterpreterOutputTrace<Vertex>)
     where
-        Token: Debug + Clone + PartialEq + Eq + Serialize,
-        for<'de> Token: Deserialize<'de>,
+        Vertex: Debug + Clone + PartialEq + Eq + Serialize,
+        for<'de> Vertex: Deserialize<'de>,
     {
         // Ensure that the trace file's IR hasn't drifted away from the IR file of the same name.
         assert_eq!(expected_ir.ir_query, test_data.trace.ir_query);

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -72,7 +72,9 @@ where
                 self.exhausted = true;
                 None
             }
-            TraceOpContent::YieldFrom(YieldValue::ResolveStartingVertices(vertex)) => Some(vertex.clone()),
+            TraceOpContent::YieldFrom(YieldValue::ResolveStartingVertices(vertex)) => {
+                Some(vertex.clone())
+            }
             _ => unreachable!(),
         }
     }

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -246,7 +246,9 @@ where
     ) -> VertexIterator<'vertex, Self::Vertex> {
         let mut trace = self.tracer.borrow_mut();
         let call_opid = trace.record(
-            TraceOpContent::Call(FunctionCall::ResolveStartingVertices(query_info.origin_vid())),
+            TraceOpContent::Call(FunctionCall::ResolveStartingVertices(
+                query_info.origin_vid(),
+            )),
             None,
         );
         drop(trace);

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -262,13 +262,13 @@ where
                     .borrow_mut()
                     .record(TraceOpContent::OutputIteratorExhausted, Some(call_opid));
             })
-            .map(move |token| {
+            .map(move |vertex| {
                 tracer_ref_2.borrow_mut().record(
-                    TraceOpContent::YieldFrom(YieldValue::GetStartingTokens(token.clone())),
+                    TraceOpContent::YieldFrom(YieldValue::GetStartingTokens(vertex.clone())),
                     Some(call_opid),
                 );
 
-                token
+                vertex
             }),
         )
     }
@@ -411,16 +411,16 @@ where
                 drop(trace);
 
                 let tracer_ref_6 = tracer_ref_5.clone();
-                let tapped_neighbor_iter = neighbor_iter.enumerate().map(move |(pos, token)| {
+                let tapped_neighbor_iter = neighbor_iter.enumerate().map(move |(pos, vertex)| {
                     tracer_ref_6.borrow_mut().record(
                         TraceOpContent::YieldFrom(YieldValue::ProjectNeighborsInner(
                             pos,
-                            token.clone(),
+                            vertex.clone(),
                         )),
                         Some(outer_iterator_opid),
                     );
 
-                    token
+                    vertex
                 });
 
                 let tracer_ref_7 = tracer_ref_5.clone();

--- a/trustfall_core/src/main.rs
+++ b/trustfall_core/src/main.rs
@@ -37,7 +37,7 @@ use crate::{
         Adapter,
     },
     nullables_interpreter::NullablesAdapter,
-    numbers_interpreter::{NumbersAdapter, NumbersToken},
+    numbers_interpreter::{NumbersAdapter, NumbersVertex},
     schema::Schema,
     util::{
         TestGraphQLQuery, TestIRQuery, TestIRQueryResult, TestInterpreterOutputTrace,
@@ -201,7 +201,7 @@ fn reserialize(path: &str) {
         }
         Some((_, "trace")) => {
             if let Ok(test_trace) =
-                ron::from_str::<TestInterpreterOutputTrace<NumbersToken>>(&input_data)
+                ron::from_str::<TestInterpreterOutputTrace<NumbersVertex>>(&input_data)
             {
                 serialize_to_ron(&test_trace)
             } else if let Ok(test_trace) =

--- a/trustfall_core/src/main.rs
+++ b/trustfall_core/src/main.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use trustfall_core::{interpreter::error::QueryArgumentsError, schema::error::InvalidSchemaError};
 
 use crate::{
-    filesystem_interpreter::{FilesystemInterpreter, FilesystemToken},
+    filesystem_interpreter::{FilesystemInterpreter, FilesystemVertex},
     graphql_query::error::ParseError,
     graphql_query::query::parse_document,
     interpreter::{
@@ -205,7 +205,7 @@ fn reserialize(path: &str) {
             {
                 serialize_to_ron(&test_trace)
             } else if let Ok(test_trace) =
-                ron::from_str::<TestInterpreterOutputTrace<FilesystemToken>>(&input_data)
+                ron::from_str::<TestInterpreterOutputTrace<FilesystemVertex>>(&input_data)
             {
                 serialize_to_ron(&test_trace)
             } else {

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -8,14 +8,14 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct NullablesToken;
+pub(crate) struct NullablesVertex;
 
 #[derive(Debug, Clone)]
 pub(crate) struct NullablesAdapter;
 
 #[allow(unused_variables)]
 impl Adapter<'static> for NullablesAdapter {
-    type Vertex = NullablesToken;
+    type Vertex = NullablesVertex;
 
     fn resolve_starting_vertices(
         &mut self,

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -156,7 +156,7 @@ fn get_factors(primes: &BTreeSet<i64>, num: i64) -> BTreeSet<i64> {
     }
 }
 
-fn make_number_token(primes: &mut BTreeSet<i64>, num: i64) -> NumbersToken {
+fn make_number_vertex(primes: &mut BTreeSet<i64>, num: i64) -> NumbersToken {
     if num >= 2 {
         generate_primes_up_to(primes, num);
     }
@@ -183,10 +183,10 @@ impl Adapter<'static> for NumbersAdapter {
     ) -> VertexIterator<'static, Self::Vertex> {
         let mut primes = btreeset![2, 3];
         match edge_name.as_ref() {
-            "Zero" => Box::new(std::iter::once(make_number_token(&mut primes, 0))),
-            "One" => Box::new(std::iter::once(make_number_token(&mut primes, 1))),
-            "Two" => Box::new(std::iter::once(make_number_token(&mut primes, 2))),
-            "Four" => Box::new(std::iter::once(make_number_token(&mut primes, 4))),
+            "Zero" => Box::new(std::iter::once(make_number_vertex(&mut primes, 0))),
+            "One" => Box::new(std::iter::once(make_number_vertex(&mut primes, 1))),
+            "Two" => Box::new(std::iter::once(make_number_vertex(&mut primes, 2))),
+            "Four" => Box::new(std::iter::once(make_number_vertex(&mut primes, 4))),
             "Number" | "NumberImplicitNullDefault" => {
                 let min_value = parameters["min"].as_i64().unwrap_or(0);
                 let max_value = parameters["max"].as_i64().unwrap();
@@ -196,7 +196,7 @@ impl Adapter<'static> for NumbersAdapter {
                 } else {
                     Box::new(
                         (min_value..=max_value)
-                            .map(move |n| make_number_token(&mut primes, n))
+                            .map(move |n| make_number_vertex(&mut primes, n))
                             .collect_vec()
                             .into_iter(),
                     )
@@ -251,7 +251,7 @@ impl Adapter<'static> for NumbersAdapter {
                         NumbersToken::Composite(inner) => inner.value(),
                     };
                     if value > 0 {
-                        Box::new(std::iter::once(make_number_token(&mut primes, value - 1)))
+                        Box::new(std::iter::once(make_number_vertex(&mut primes, value - 1)))
                     } else {
                         Box::new(std::iter::empty())
                     }
@@ -264,7 +264,7 @@ impl Adapter<'static> for NumbersAdapter {
                         NumbersToken::Prime(inner) => inner.value(),
                         NumbersToken::Composite(inner) => inner.value(),
                     };
-                    Box::new(std::iter::once(make_number_token(&mut primes, value + 1)))
+                    Box::new(std::iter::once(make_number_vertex(&mut primes, value + 1)))
                 })
             }
             ("Number" | "Prime" | "Composite", "multiple") => {
@@ -283,7 +283,7 @@ impl Adapter<'static> for NumbersAdapter {
 
                             Box::new((start_multiple..=max_multiple).map(move |mult| {
                                 let next_value = value * mult;
-                                make_number_token(&mut local_primes, next_value)
+                                make_number_vertex(&mut local_primes, next_value)
                             }))
                         }
                         NumbersToken::Composite(vertex) => {
@@ -293,7 +293,7 @@ impl Adapter<'static> for NumbersAdapter {
                             let max_multiple = parameters["max"].as_i64().unwrap();
                             Box::new((1..=max_multiple).map(move |mult| {
                                 let next_value = value * mult;
-                                make_number_token(&mut local_primes, next_value)
+                                make_number_vertex(&mut local_primes, next_value)
                             }))
                         }
                     }
@@ -306,7 +306,7 @@ impl Adapter<'static> for NumbersAdapter {
                         Box::new(
                             factors
                                 .iter()
-                                .map(|n| make_number_token(&mut primes, *n))
+                                .map(|n| make_number_vertex(&mut primes, *n))
                                 .collect_vec()
                                 .into_iter(),
                         )
@@ -325,7 +325,7 @@ impl Adapter<'static> for NumbersAdapter {
                                 (1..value)
                                     .filter_map(|maybe_divisor| {
                                         if value % maybe_divisor == 0 {
-                                            Some(make_number_token(&mut primes, maybe_divisor))
+                                            Some(make_number_vertex(&mut primes, maybe_divisor))
                                         } else {
                                             None
                                         }

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -355,9 +355,9 @@ impl Adapter<'static> for NumbersAdapter {
         query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
         match (type_name.as_ref(), coerce_to_type.as_ref()) {
-            ("Number", "Prime") => {
-                resolve_coercion_with(contexts, |vertex| matches!(vertex, NumbersVertex::Prime(..)))
-            }
+            ("Number", "Prime") => resolve_coercion_with(contexts, |vertex| {
+                matches!(vertex, NumbersVertex::Prime(..))
+            }),
             ("Number", "Composite") => resolve_coercion_with(contexts, |vertex| {
                 matches!(vertex, NumbersVertex::Composite(..))
             }),

--- a/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "name")),
+        content: Call(ResolveProperty(Vid(2), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(2),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         )),
@@ -134,7 +134,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(2),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         ), Int64(1))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
@@ -5,32 +5,32 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(2))),
@@ -112,7 +112,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           values: [
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           values: [
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
@@ -53,7 +53,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -64,7 +64,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -164,7 +164,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -202,13 +202,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -240,13 +240,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -296,7 +296,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(34): TraceOp(
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(35): TraceOp(
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(38): TraceOp(
@@ -339,7 +339,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(39): TraceOp(
@@ -350,7 +350,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -366,7 +366,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -404,7 +404,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(44)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -414,7 +414,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(44)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(44)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -439,7 +439,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(44)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -467,7 +467,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -477,13 +477,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -505,7 +505,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -515,13 +515,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -571,7 +571,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(62): TraceOp(
@@ -579,7 +579,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(63): TraceOp(
@@ -603,7 +603,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(66): TraceOp(
@@ -614,7 +614,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(67): TraceOp(
@@ -625,7 +625,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -641,7 +641,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -679,7 +679,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(72)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -689,7 +689,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(72)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -704,7 +704,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(72)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -714,7 +714,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(72)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
         ), Int64(7))),
@@ -742,7 +742,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -752,13 +752,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(7))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
               ),
@@ -780,7 +780,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -790,13 +790,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(7))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
               ),
@@ -852,7 +852,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(90): TraceOp(
@@ -863,7 +863,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(91): TraceOp(
@@ -874,7 +874,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -890,7 +890,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -928,7 +928,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(96)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -938,7 +938,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(96)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -953,7 +953,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(96)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -963,7 +963,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(96)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -991,7 +991,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -1001,13 +1001,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -1029,7 +1029,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -1039,13 +1039,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -1099,7 +1099,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(114): TraceOp(
@@ -1109,7 +1109,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(115): TraceOp(
@@ -1119,7 +1119,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1133,7 +1133,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1165,7 +1165,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(119)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1175,7 +1175,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(119)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -1202,7 +1202,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1211,7 +1211,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -1231,7 +1231,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1240,7 +1240,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -1288,7 +1288,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(134): TraceOp(
@@ -1296,7 +1296,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(135): TraceOp(
@@ -1320,7 +1320,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(138): TraceOp(
@@ -1331,7 +1331,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(139): TraceOp(
@@ -1342,7 +1342,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1358,7 +1358,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1396,7 +1396,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(144)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(144)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -1421,7 +1421,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(144)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1431,7 +1431,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(144)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -1459,7 +1459,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1469,13 +1469,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -1497,7 +1497,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1507,13 +1507,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -1563,7 +1563,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(162): TraceOp(
@@ -1571,7 +1571,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(163): TraceOp(
@@ -1595,7 +1595,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(166): TraceOp(
@@ -1606,7 +1606,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(167): TraceOp(
@@ -1617,7 +1617,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1633,7 +1633,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1671,7 +1671,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1681,7 +1681,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -1696,7 +1696,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1706,7 +1706,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -1734,7 +1734,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1744,13 +1744,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -1772,7 +1772,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1782,13 +1782,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -201,13 +201,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -239,13 +239,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         )),
       ),
@@ -303,7 +303,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         ), false)),
       ),
@@ -324,7 +324,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -335,7 +335,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -346,7 +346,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -403,7 +403,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(44)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -413,7 +413,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(44)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(44)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -438,7 +438,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(44)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -463,7 +463,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -476,13 +476,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -501,7 +501,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -514,13 +514,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -570,7 +570,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -578,7 +578,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), false)),
       ),
@@ -599,7 +599,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -610,7 +610,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -621,7 +621,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -637,7 +637,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -678,7 +678,7 @@ TestInterpreterOutputTrace(
         opid: Opid(74),
         parent_opid: Some(Opid(72)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -688,7 +688,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(72)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -703,7 +703,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(72)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
@@ -713,7 +713,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(72)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
@@ -738,7 +738,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -751,13 +751,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(7))),
+                active_vertex: Some(Prime(PrimeNumber(7))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
@@ -776,7 +776,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -789,13 +789,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(7))),
+                active_vertex: Some(Prime(PrimeNumber(7))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
@@ -848,7 +848,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -859,7 +859,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -870,7 +870,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -886,7 +886,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -927,7 +927,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(96)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -937,7 +937,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(96)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -952,7 +952,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(96)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -962,7 +962,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(96)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -987,7 +987,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1000,13 +1000,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -1025,7 +1025,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1038,13 +1038,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -1096,7 +1096,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -1106,7 +1106,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -1116,7 +1116,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1130,7 +1130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(116),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1164,7 +1164,7 @@ TestInterpreterOutputTrace(
         opid: Opid(121),
         parent_opid: Some(Opid(119)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1174,7 +1174,7 @@ TestInterpreterOutputTrace(
         opid: Opid(122),
         parent_opid: Some(Opid(119)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1199,7 +1199,7 @@ TestInterpreterOutputTrace(
         opid: Opid(126),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1210,7 +1210,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -1228,7 +1228,7 @@ TestInterpreterOutputTrace(
         opid: Opid(127),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1239,7 +1239,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -1287,7 +1287,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {},
         )),
       ),
@@ -1295,7 +1295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {},
         ), false)),
       ),
@@ -1316,7 +1316,7 @@ TestInterpreterOutputTrace(
         opid: Opid(137),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1327,7 +1327,7 @@ TestInterpreterOutputTrace(
         opid: Opid(138),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1338,7 +1338,7 @@ TestInterpreterOutputTrace(
         opid: Opid(139),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1354,7 +1354,7 @@ TestInterpreterOutputTrace(
         opid: Opid(140),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1395,7 +1395,7 @@ TestInterpreterOutputTrace(
         opid: Opid(146),
         parent_opid: Some(Opid(144)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1405,7 +1405,7 @@ TestInterpreterOutputTrace(
         opid: Opid(147),
         parent_opid: Some(Opid(144)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1420,7 +1420,7 @@ TestInterpreterOutputTrace(
         opid: Opid(149),
         parent_opid: Some(Opid(144)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1430,7 +1430,7 @@ TestInterpreterOutputTrace(
         opid: Opid(150),
         parent_opid: Some(Opid(144)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1455,7 +1455,7 @@ TestInterpreterOutputTrace(
         opid: Opid(154),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1468,13 +1468,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -1493,7 +1493,7 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1506,13 +1506,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -1562,7 +1562,7 @@ TestInterpreterOutputTrace(
         opid: Opid(161),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {},
         )),
       ),
@@ -1570,7 +1570,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {},
         ), false)),
       ),
@@ -1591,7 +1591,7 @@ TestInterpreterOutputTrace(
         opid: Opid(165),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1602,7 +1602,7 @@ TestInterpreterOutputTrace(
         opid: Opid(166),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1613,7 +1613,7 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1629,7 +1629,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1670,7 +1670,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1680,7 +1680,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1695,7 +1695,7 @@ TestInterpreterOutputTrace(
         opid: Opid(177),
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1705,7 +1705,7 @@ TestInterpreterOutputTrace(
         opid: Opid(178),
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1730,7 +1730,7 @@ TestInterpreterOutputTrace(
         opid: Opid(182),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1743,13 +1743,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -1768,7 +1768,7 @@ TestInterpreterOutputTrace(
         opid: Opid(183),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1781,13 +1781,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -59,7 +59,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -102,12 +102,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(5)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -225,7 +225,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(11)))),
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
@@ -302,7 +302,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {},
         ), false)),
@@ -315,7 +315,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -377,12 +377,12 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(43): TraceOp(
         opid: Opid(43),
@@ -392,7 +392,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(45): TraceOp(
         opid: Opid(45),
@@ -412,7 +412,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(44)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -437,7 +437,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(44)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -564,7 +564,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(61): TraceOp(
         opid: Opid(61),
@@ -577,7 +577,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), false)),
@@ -590,7 +590,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -609,7 +609,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -636,7 +636,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -652,12 +652,12 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(68)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(68)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(7)))),
       ),
       Opid(71): TraceOp(
         opid: Opid(71),
@@ -667,7 +667,7 @@ TestInterpreterOutputTrace(
       Opid(72): TraceOp(
         opid: Opid(72),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(73): TraceOp(
         opid: Opid(73),
@@ -687,7 +687,7 @@ TestInterpreterOutputTrace(
       Opid(75): TraceOp(
         opid: Opid(75),
         parent_opid: Some(Opid(72)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -712,7 +712,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(72)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -775,7 +775,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -839,7 +839,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -858,7 +858,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -885,7 +885,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -901,12 +901,12 @@ TestInterpreterOutputTrace(
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(92)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(94): TraceOp(
         opid: Opid(94),
         parent_opid: Some(Opid(92)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(5)))),
       ),
       Opid(95): TraceOp(
         opid: Opid(95),
@@ -916,7 +916,7 @@ TestInterpreterOutputTrace(
       Opid(96): TraceOp(
         opid: Opid(96),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
@@ -936,7 +936,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(96)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -961,7 +961,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(96)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1024,7 +1024,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -1088,7 +1088,7 @@ TestInterpreterOutputTrace(
       Opid(112): TraceOp(
         opid: Opid(112),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -1105,7 +1105,7 @@ TestInterpreterOutputTrace(
       Opid(114): TraceOp(
         opid: Opid(114),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1129,7 +1129,7 @@ TestInterpreterOutputTrace(
       Opid(116): TraceOp(
         opid: Opid(116),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1143,7 +1143,7 @@ TestInterpreterOutputTrace(
       Opid(117): TraceOp(
         opid: Opid(117),
         parent_opid: Some(Opid(116)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(118): TraceOp(
         opid: Opid(118),
@@ -1153,7 +1153,7 @@ TestInterpreterOutputTrace(
       Opid(119): TraceOp(
         opid: Opid(119),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(120): TraceOp(
         opid: Opid(120),
@@ -1173,7 +1173,7 @@ TestInterpreterOutputTrace(
       Opid(122): TraceOp(
         opid: Opid(122),
         parent_opid: Some(Opid(119)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1227,7 +1227,7 @@ TestInterpreterOutputTrace(
       Opid(127): TraceOp(
         opid: Opid(127),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1281,7 +1281,7 @@ TestInterpreterOutputTrace(
       Opid(132): TraceOp(
         opid: Opid(132),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(17)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(17)))),
       ),
       Opid(133): TraceOp(
         opid: Opid(133),
@@ -1294,7 +1294,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
           vertices: {},
         ), false)),
@@ -1307,7 +1307,7 @@ TestInterpreterOutputTrace(
       Opid(136): TraceOp(
         opid: Opid(136),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -1326,7 +1326,7 @@ TestInterpreterOutputTrace(
       Opid(138): TraceOp(
         opid: Opid(138),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1353,7 +1353,7 @@ TestInterpreterOutputTrace(
       Opid(140): TraceOp(
         opid: Opid(140),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1369,12 +1369,12 @@ TestInterpreterOutputTrace(
       Opid(141): TraceOp(
         opid: Opid(141),
         parent_opid: Some(Opid(140)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: Some(Opid(140)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(143): TraceOp(
         opid: Opid(143),
@@ -1384,7 +1384,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(145): TraceOp(
         opid: Opid(145),
@@ -1404,7 +1404,7 @@ TestInterpreterOutputTrace(
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(144)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1429,7 +1429,7 @@ TestInterpreterOutputTrace(
       Opid(150): TraceOp(
         opid: Opid(150),
         parent_opid: Some(Opid(144)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1492,7 +1492,7 @@ TestInterpreterOutputTrace(
       Opid(155): TraceOp(
         opid: Opid(155),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1556,7 +1556,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(19)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(19)))),
       ),
       Opid(161): TraceOp(
         opid: Opid(161),
@@ -1569,7 +1569,7 @@ TestInterpreterOutputTrace(
       Opid(162): TraceOp(
         opid: Opid(162),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
           vertices: {},
         ), false)),
@@ -1582,7 +1582,7 @@ TestInterpreterOutputTrace(
       Opid(164): TraceOp(
         opid: Opid(164),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(20, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(20, [
           2,
           5,
         ])))),
@@ -1601,7 +1601,7 @@ TestInterpreterOutputTrace(
       Opid(166): TraceOp(
         opid: Opid(166),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -1628,7 +1628,7 @@ TestInterpreterOutputTrace(
       Opid(168): TraceOp(
         opid: Opid(168),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -1644,12 +1644,12 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(168)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(170): TraceOp(
         opid: Opid(170),
         parent_opid: Some(Opid(168)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(5)))),
       ),
       Opid(171): TraceOp(
         opid: Opid(171),
@@ -1659,7 +1659,7 @@ TestInterpreterOutputTrace(
       Opid(172): TraceOp(
         opid: Opid(172),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(173): TraceOp(
         opid: Opid(173),
@@ -1679,7 +1679,7 @@ TestInterpreterOutputTrace(
       Opid(175): TraceOp(
         opid: Opid(175),
         parent_opid: Some(Opid(172)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1704,7 +1704,7 @@ TestInterpreterOutputTrace(
       Opid(178): TraceOp(
         opid: Opid(178),
         parent_opid: Some(Opid(172)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1767,7 +1767,7 @@ TestInterpreterOutputTrace(
       Opid(183): TraceOp(
         opid: Opid(183),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(21)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -248,7 +248,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(36): TraceOp(
         opid: Opid(36),
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(37)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(52): TraceOp(
         opid: Opid(52),
@@ -396,7 +396,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -406,7 +406,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(53)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -425,7 +425,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -452,7 +452,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -473,7 +473,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -487,7 +487,7 @@ TestInterpreterOutputTrace(
       Opid(63): TraceOp(
         opid: Opid(63),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(64): TraceOp(
         opid: Opid(64),
@@ -504,7 +504,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -529,7 +529,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -560,7 +560,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -611,7 +611,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(77): TraceOp(
         opid: Opid(77),
@@ -626,7 +626,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -636,7 +636,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(78)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -657,7 +657,7 @@ TestInterpreterOutputTrace(
       Opid(81): TraceOp(
         opid: Opid(81),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -685,7 +685,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -709,7 +709,7 @@ TestInterpreterOutputTrace(
       Opid(87): TraceOp(
         opid: Opid(87),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -725,7 +725,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(87)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(89): TraceOp(
         opid: Opid(89),
@@ -743,7 +743,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -770,7 +770,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
       Opid(94): TraceOp(
         opid: Opid(94),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -857,7 +857,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(7)))),
       ),
       Opid(102): TraceOp(
         opid: Opid(102),
@@ -872,7 +872,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
@@ -882,7 +882,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(103)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -901,7 +901,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -928,7 +928,7 @@ TestInterpreterOutputTrace(
       Opid(110): TraceOp(
         opid: Opid(110),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -949,7 +949,7 @@ TestInterpreterOutputTrace(
       Opid(112): TraceOp(
         opid: Opid(112),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -963,7 +963,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(112)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -984,7 +984,7 @@ TestInterpreterOutputTrace(
       Opid(115): TraceOp(
         opid: Opid(115),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1013,7 +1013,7 @@ TestInterpreterOutputTrace(
       Opid(119): TraceOp(
         opid: Opid(119),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -1034,7 +1034,7 @@ TestInterpreterOutputTrace(
       Opid(121): TraceOp(
         opid: Opid(121),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1048,7 +1048,7 @@ TestInterpreterOutputTrace(
       Opid(122): TraceOp(
         opid: Opid(122),
         parent_opid: Some(Opid(121)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -1071,7 +1071,7 @@ TestInterpreterOutputTrace(
       Opid(124): TraceOp(
         opid: Opid(124),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -1101,7 +1101,7 @@ TestInterpreterOutputTrace(
       Opid(128): TraceOp(
         opid: Opid(128),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -1125,7 +1125,7 @@ TestInterpreterOutputTrace(
       Opid(130): TraceOp(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -1141,7 +1141,7 @@ TestInterpreterOutputTrace(
       Opid(131): TraceOp(
         opid: Opid(131),
         parent_opid: Some(Opid(130)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(11)))),
       ),
       Opid(132): TraceOp(
         opid: Opid(132),
@@ -1159,7 +1159,7 @@ TestInterpreterOutputTrace(
       Opid(133): TraceOp(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -1186,7 +1186,7 @@ TestInterpreterOutputTrace(
       Opid(135): TraceOp(
         opid: Opid(135),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -1220,7 +1220,7 @@ TestInterpreterOutputTrace(
       Opid(137): TraceOp(
         opid: Opid(137),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), false)),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), true)),
@@ -167,7 +167,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -203,7 +203,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -255,7 +255,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -280,7 +280,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -290,7 +290,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), true)),
@@ -300,7 +300,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -311,7 +311,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -322,7 +322,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -336,7 +336,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -417,7 +417,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), false)),
@@ -463,7 +463,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -477,7 +477,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -494,7 +494,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -506,7 +506,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -518,7 +518,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -531,7 +531,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -564,7 +564,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -628,7 +628,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -649,7 +649,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -662,7 +662,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), false)),
@@ -698,7 +698,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -714,7 +714,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -732,7 +732,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -745,7 +745,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -758,7 +758,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -772,7 +772,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -789,7 +789,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -809,7 +809,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -864,7 +864,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -874,7 +874,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         ))),
@@ -893,7 +893,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -905,7 +905,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         ), false)),
@@ -939,7 +939,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -953,7 +953,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -974,7 +974,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -988,7 +988,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -1024,7 +1024,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1038,7 +1038,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1061,7 +1061,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1076,7 +1076,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1114,7 +1114,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1130,7 +1130,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1148,7 +1148,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1161,7 +1161,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1174,7 +1174,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1188,7 +1188,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1205,7 +1205,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1225,7 +1225,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -156,7 +156,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -254,7 +254,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -279,7 +279,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -310,7 +310,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -321,7 +321,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -335,7 +335,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -387,7 +387,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -397,7 +397,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -414,7 +414,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -426,7 +426,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -460,7 +460,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -474,7 +474,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -493,7 +493,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -505,7 +505,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -517,7 +517,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -530,7 +530,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -543,7 +543,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -561,7 +561,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -617,7 +617,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -627,7 +627,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -645,7 +645,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -658,7 +658,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -694,7 +694,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -710,7 +710,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -731,7 +731,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -744,7 +744,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -757,7 +757,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -771,7 +771,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -785,7 +785,7 @@ TestInterpreterOutputTrace(
         opid: Opid(93),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -805,7 +805,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -863,7 +863,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -873,7 +873,7 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -890,7 +890,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -902,7 +902,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -936,7 +936,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -950,7 +950,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -971,7 +971,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -985,7 +985,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1021,7 +1021,7 @@ TestInterpreterOutputTrace(
         opid: Opid(120),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1035,7 +1035,7 @@ TestInterpreterOutputTrace(
         opid: Opid(121),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1057,7 +1057,7 @@ TestInterpreterOutputTrace(
         opid: Opid(123),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1072,7 +1072,7 @@ TestInterpreterOutputTrace(
         opid: Opid(124),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1110,7 +1110,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1126,7 +1126,7 @@ TestInterpreterOutputTrace(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1147,7 +1147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -1160,7 +1160,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -1173,7 +1173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -1187,7 +1187,7 @@ TestInterpreterOutputTrace(
         opid: Opid(135),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -1201,7 +1201,7 @@ TestInterpreterOutputTrace(
         opid: Opid(136),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1221,7 +1221,7 @@ TestInterpreterOutputTrace(
         opid: Opid(137),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -98,7 +98,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(22)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(26): TraceOp(
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(22)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(27): TraceOp(
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           folded_contexts: {
@@ -224,7 +224,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           folded_contexts: {
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(39)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(43): TraceOp(
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(39)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(44): TraceOp(
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
@@ -350,7 +350,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
@@ -389,7 +389,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(56)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(60): TraceOp(
@@ -432,7 +432,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(56)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(61): TraceOp(
@@ -470,7 +470,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(65)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -480,7 +480,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(65)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -505,14 +505,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -530,14 +530,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -584,7 +584,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -598,7 +598,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -625,7 +625,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(80)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(84): TraceOp(
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(80)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(85): TraceOp(
@@ -671,7 +671,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(89)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -681,7 +681,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(89)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -708,7 +708,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -737,7 +737,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -746,7 +746,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -789,7 +789,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -799,7 +799,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -828,7 +828,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(108): TraceOp(
@@ -838,7 +838,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(109): TraceOp(
@@ -866,7 +866,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           folded_contexts: {
@@ -882,7 +882,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           folded_contexts: {
@@ -927,7 +927,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -943,7 +943,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -971,7 +971,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(121)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(125): TraceOp(
@@ -979,7 +979,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(121)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(126): TraceOp(
@@ -1017,7 +1017,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(130)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1027,7 +1027,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(130)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -1055,7 +1055,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1065,7 +1065,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -1086,7 +1086,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1096,7 +1096,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(22)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {},
         )),
       ),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(22)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {},
         ), false)),
       ),
@@ -207,7 +207,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -223,7 +223,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -272,7 +272,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(39)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         )),
       ),
@@ -305,7 +305,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(39)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         ), false)),
       ),
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -349,7 +349,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -423,7 +423,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(56)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         )),
       ),
@@ -431,7 +431,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(56)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         ), true)),
       ),
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(65)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -479,7 +479,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(65)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -504,14 +504,14 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -529,14 +529,14 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -581,7 +581,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -595,7 +595,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -624,7 +624,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(80)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         )),
       ),
@@ -632,7 +632,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(80)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         ), true)),
       ),
@@ -670,7 +670,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(89)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(89)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -705,7 +705,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -716,7 +716,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -734,7 +734,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -745,7 +745,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -788,7 +788,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -798,7 +798,7 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -825,7 +825,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(104)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -835,7 +835,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(104)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -865,7 +865,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -881,7 +881,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -923,7 +923,7 @@ TestInterpreterOutputTrace(
         opid: Opid(119),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -939,7 +939,7 @@ TestInterpreterOutputTrace(
         opid: Opid(120),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -970,7 +970,7 @@ TestInterpreterOutputTrace(
         opid: Opid(124),
         parent_opid: Some(Opid(121)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         )),
       ),
@@ -978,7 +978,7 @@ TestInterpreterOutputTrace(
         opid: Opid(125),
         parent_opid: Some(Opid(121)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         ), true)),
       ),
@@ -1016,7 +1016,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(130)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1026,7 +1026,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(130)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1051,7 +1051,7 @@ TestInterpreterOutputTrace(
         opid: Opid(137),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1064,7 +1064,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -1082,7 +1082,7 @@ TestInterpreterOutputTrace(
         opid: Opid(138),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1095,7 +1095,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(21)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(22)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {},
         ), false)),
@@ -222,7 +222,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -256,7 +256,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(37): TraceOp(
         opid: Opid(37),
@@ -271,7 +271,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(38)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
         ), false)),
@@ -348,7 +348,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -382,7 +382,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(54): TraceOp(
         opid: Opid(54),
@@ -397,7 +397,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -407,7 +407,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
@@ -417,7 +417,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(55)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(59): TraceOp(
         opid: Opid(59),
@@ -430,7 +430,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(56)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {},
         ), true)),
@@ -458,7 +458,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(66): TraceOp(
         opid: Opid(66),
@@ -478,7 +478,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(65)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -528,7 +528,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -573,7 +573,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -594,7 +594,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -608,7 +608,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(81): TraceOp(
         opid: Opid(81),
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(79)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(83): TraceOp(
         opid: Opid(83),
@@ -631,7 +631,7 @@ TestInterpreterOutputTrace(
       Opid(84): TraceOp(
         opid: Opid(84),
         parent_opid: Some(Opid(80)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {},
         ), true)),
@@ -659,7 +659,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
@@ -679,7 +679,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(89)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -733,7 +733,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -782,7 +782,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(102): TraceOp(
         opid: Opid(102),
@@ -797,7 +797,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -807,7 +807,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(105): TraceOp(
         opid: Opid(105),
@@ -817,7 +817,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(103)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -834,7 +834,7 @@ TestInterpreterOutputTrace(
       Opid(108): TraceOp(
         opid: Opid(108),
         parent_opid: Some(Opid(104)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -880,7 +880,7 @@ TestInterpreterOutputTrace(
       Opid(114): TraceOp(
         opid: Opid(114),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -914,7 +914,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -938,7 +938,7 @@ TestInterpreterOutputTrace(
       Opid(120): TraceOp(
         opid: Opid(120),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -954,7 +954,7 @@ TestInterpreterOutputTrace(
       Opid(121): TraceOp(
         opid: Opid(121),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(122): TraceOp(
         opid: Opid(122),
@@ -964,7 +964,7 @@ TestInterpreterOutputTrace(
       Opid(123): TraceOp(
         opid: Opid(123),
         parent_opid: Some(Opid(120)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(124): TraceOp(
         opid: Opid(124),
@@ -977,7 +977,7 @@ TestInterpreterOutputTrace(
       Opid(125): TraceOp(
         opid: Opid(125),
         parent_opid: Some(Opid(121)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {},
         ), true)),
@@ -1005,7 +1005,7 @@ TestInterpreterOutputTrace(
       Opid(130): TraceOp(
         opid: Opid(130),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(131): TraceOp(
         opid: Opid(131),
@@ -1025,7 +1025,7 @@ TestInterpreterOutputTrace(
       Opid(133): TraceOp(
         opid: Opid(133),
         parent_opid: Some(Opid(130)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1081,7 +1081,7 @@ TestInterpreterOutputTrace(
       Opid(138): TraceOp(
         opid: Opid(138),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -175,7 +175,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(28): TraceOp(
         opid: Opid(28),
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(37): TraceOp(
         opid: Opid(37),
@@ -255,7 +255,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(38)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
@@ -280,7 +280,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -301,7 +301,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -373,7 +373,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -394,7 +394,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -408,7 +408,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(54)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(56): TraceOp(
         opid: Opid(56),
@@ -425,7 +425,7 @@ TestInterpreterOutputTrace(
       Opid(57): TraceOp(
         opid: Opid(57),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -450,7 +450,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -481,7 +481,7 @@ TestInterpreterOutputTrace(
       Opid(61): TraceOp(
         opid: Opid(61),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -532,7 +532,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(69): TraceOp(
         opid: Opid(69),
@@ -547,7 +547,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -557,7 +557,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(70)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -576,7 +576,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -603,7 +603,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -627,7 +627,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -643,7 +643,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(79)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(81): TraceOp(
         opid: Opid(81),
@@ -661,7 +661,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -688,7 +688,7 @@ TestInterpreterOutputTrace(
       Opid(84): TraceOp(
         opid: Opid(84),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -722,7 +722,7 @@ TestInterpreterOutputTrace(
       Opid(86): TraceOp(
         opid: Opid(86),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -141,7 +141,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -151,7 +151,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -191,7 +191,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -206,7 +206,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -256,7 +256,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -271,7 +271,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -302,7 +302,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -313,7 +313,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -327,7 +327,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -395,7 +395,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -414,7 +414,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -426,7 +426,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -438,7 +438,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -451,7 +451,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -464,7 +464,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -482,7 +482,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -538,7 +538,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -548,7 +548,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -565,7 +565,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -577,7 +577,7 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -612,7 +612,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -628,7 +628,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -649,7 +649,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -662,7 +662,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -675,7 +675,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -689,7 +689,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -703,7 +703,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -723,7 +723,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), false)),
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), false)),
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -207,7 +207,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), false)),
@@ -247,7 +247,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -272,7 +272,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -282,7 +282,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), true)),
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -303,7 +303,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -314,7 +314,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -415,7 +415,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -427,7 +427,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -439,7 +439,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -452,7 +452,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -467,7 +467,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -485,7 +485,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -539,7 +539,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -549,7 +549,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -568,7 +568,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -580,7 +580,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), false)),
@@ -616,7 +616,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -632,7 +632,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -650,7 +650,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -663,7 +663,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -676,7 +676,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -690,7 +690,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -707,7 +707,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -727,7 +727,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -101,13 +101,13 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -122,13 +122,13 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -148,13 +148,13 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -180,13 +180,13 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -227,7 +227,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -252,7 +252,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -287,7 +287,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -360,7 +360,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -370,7 +370,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -380,7 +380,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -391,7 +391,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -402,7 +402,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -416,7 +416,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -488,7 +488,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -498,7 +498,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -513,13 +513,13 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -534,13 +534,13 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -560,13 +560,13 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -575,7 +575,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -592,13 +592,13 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -607,7 +607,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -631,7 +631,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -641,7 +641,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -656,7 +656,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -666,7 +666,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -676,7 +676,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -687,7 +687,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -698,7 +698,7 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -712,7 +712,7 @@ TestInterpreterOutputTrace(
         opid: Opid(74),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -749,7 +749,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -759,7 +759,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -769,7 +769,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -780,7 +780,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -791,7 +791,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -805,7 +805,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -842,7 +842,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -854,7 +854,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -906,7 +906,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -916,7 +916,7 @@ TestInterpreterOutputTrace(
         opid: Opid(100),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -931,13 +931,13 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -952,13 +952,13 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -980,7 +980,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -988,7 +988,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -997,7 +997,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -1014,7 +1014,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1022,7 +1022,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -1031,7 +1031,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -1053,7 +1053,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1063,7 +1063,7 @@ TestInterpreterOutputTrace(
         opid: Opid(109),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1073,7 +1073,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1084,7 +1084,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1095,7 +1095,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1109,7 +1109,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1146,7 +1146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(118),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1156,7 +1156,7 @@ TestInterpreterOutputTrace(
         opid: Opid(119),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1166,7 +1166,7 @@ TestInterpreterOutputTrace(
         opid: Opid(120),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1177,7 +1177,7 @@ TestInterpreterOutputTrace(
         opid: Opid(121),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1188,7 +1188,7 @@ TestInterpreterOutputTrace(
         opid: Opid(122),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1202,7 +1202,7 @@ TestInterpreterOutputTrace(
         opid: Opid(123),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1239,7 +1239,7 @@ TestInterpreterOutputTrace(
         opid: Opid(128),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1251,7 +1251,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1268,7 +1268,7 @@ TestInterpreterOutputTrace(
         opid: Opid(131),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1278,7 +1278,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1288,7 +1288,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1299,7 +1299,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1310,7 +1310,7 @@ TestInterpreterOutputTrace(
         opid: Opid(135),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1324,7 +1324,7 @@ TestInterpreterOutputTrace(
         opid: Opid(136),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1396,7 +1396,7 @@ TestInterpreterOutputTrace(
         opid: Opid(148),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
         opid: Opid(149),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1423,7 +1423,7 @@ TestInterpreterOutputTrace(
         opid: Opid(151),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1431,7 +1431,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1446,7 +1446,7 @@ TestInterpreterOutputTrace(
         opid: Opid(152),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1454,7 +1454,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1474,13 +1474,13 @@ TestInterpreterOutputTrace(
         opid: Opid(154),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1491,7 +1491,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1508,13 +1508,13 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1525,7 +1525,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1550,7 +1550,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1560,7 +1560,7 @@ TestInterpreterOutputTrace(
         opid: Opid(158),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1570,7 +1570,7 @@ TestInterpreterOutputTrace(
         opid: Opid(159),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1581,7 +1581,7 @@ TestInterpreterOutputTrace(
         opid: Opid(160),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1592,7 +1592,7 @@ TestInterpreterOutputTrace(
         opid: Opid(161),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1606,7 +1606,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1643,7 +1643,7 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1655,7 +1655,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1672,7 +1672,7 @@ TestInterpreterOutputTrace(
         opid: Opid(170),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1682,7 +1682,7 @@ TestInterpreterOutputTrace(
         opid: Opid(171),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1692,7 +1692,7 @@ TestInterpreterOutputTrace(
         opid: Opid(172),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1703,7 +1703,7 @@ TestInterpreterOutputTrace(
         opid: Opid(173),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1714,7 +1714,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1728,7 +1728,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1765,7 +1765,7 @@ TestInterpreterOutputTrace(
         opid: Opid(180),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1778,7 +1778,7 @@ TestInterpreterOutputTrace(
         opid: Opid(181),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1833,7 +1833,7 @@ TestInterpreterOutputTrace(
         opid: Opid(190),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1847,7 +1847,7 @@ TestInterpreterOutputTrace(
         opid: Opid(191),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1866,7 +1866,7 @@ TestInterpreterOutputTrace(
         opid: Opid(193),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1874,7 +1874,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1893,7 +1893,7 @@ TestInterpreterOutputTrace(
         opid: Opid(194),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1901,7 +1901,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1928,7 +1928,7 @@ TestInterpreterOutputTrace(
         opid: Opid(196),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1939,7 +1939,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1950,7 +1950,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -1971,7 +1971,7 @@ TestInterpreterOutputTrace(
         opid: Opid(197),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1982,7 +1982,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1993,7 +1993,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -2019,7 +2019,7 @@ TestInterpreterOutputTrace(
         opid: Opid(199),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -2033,7 +2033,7 @@ TestInterpreterOutputTrace(
         opid: Opid(200),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -2052,7 +2052,7 @@ TestInterpreterOutputTrace(
         opid: Opid(202),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2064,7 +2064,7 @@ TestInterpreterOutputTrace(
         opid: Opid(203),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2076,7 +2076,7 @@ TestInterpreterOutputTrace(
         opid: Opid(204),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2089,7 +2089,7 @@ TestInterpreterOutputTrace(
         opid: Opid(205),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2102,7 +2102,7 @@ TestInterpreterOutputTrace(
         opid: Opid(206),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -2120,7 +2120,7 @@ TestInterpreterOutputTrace(
         opid: Opid(207),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -2161,7 +2161,7 @@ TestInterpreterOutputTrace(
         opid: Opid(212),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2176,7 +2176,7 @@ TestInterpreterOutputTrace(
         opid: Opid(213),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2196,7 +2196,7 @@ TestInterpreterOutputTrace(
         opid: Opid(215),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2208,7 +2208,7 @@ TestInterpreterOutputTrace(
         opid: Opid(216),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2220,7 +2220,7 @@ TestInterpreterOutputTrace(
         opid: Opid(217),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2233,7 +2233,7 @@ TestInterpreterOutputTrace(
         opid: Opid(218),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2246,7 +2246,7 @@ TestInterpreterOutputTrace(
         opid: Opid(219),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -2264,7 +2264,7 @@ TestInterpreterOutputTrace(
         opid: Opid(220),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -5,37 +5,37 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Prime")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(19)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(21): TraceOp(
         opid: Opid(21),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(22)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(24): TraceOp(
         opid: Opid(24),
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -251,7 +251,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -276,7 +276,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -322,7 +322,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -369,7 +369,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -390,7 +390,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -415,7 +415,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -482,7 +482,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
@@ -497,7 +497,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -507,7 +507,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(58)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(60): TraceOp(
         opid: Opid(60),
@@ -533,7 +533,7 @@ TestInterpreterOutputTrace(
       Opid(61): TraceOp(
         opid: Opid(61),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -554,7 +554,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(61)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(63): TraceOp(
         opid: Opid(63),
@@ -591,7 +591,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -623,7 +623,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(64)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -640,7 +640,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -665,7 +665,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -686,7 +686,7 @@ TestInterpreterOutputTrace(
       Opid(72): TraceOp(
         opid: Opid(72),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -711,7 +711,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -758,7 +758,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -779,7 +779,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
       Opid(84): TraceOp(
         opid: Opid(84),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -853,7 +853,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -900,7 +900,7 @@ TestInterpreterOutputTrace(
       Opid(98): TraceOp(
         opid: Opid(98),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(99): TraceOp(
         opid: Opid(99),
@@ -915,7 +915,7 @@ TestInterpreterOutputTrace(
       Opid(100): TraceOp(
         opid: Opid(100),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -925,7 +925,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(100)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(102): TraceOp(
         opid: Opid(102),
@@ -951,7 +951,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -972,7 +972,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(103)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1013,7 +1013,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1047,7 +1047,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(106)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(108): TraceOp(
         opid: Opid(108),
@@ -1062,7 +1062,7 @@ TestInterpreterOutputTrace(
       Opid(109): TraceOp(
         opid: Opid(109),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1083,7 +1083,7 @@ TestInterpreterOutputTrace(
       Opid(111): TraceOp(
         opid: Opid(111),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1108,7 +1108,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1155,7 +1155,7 @@ TestInterpreterOutputTrace(
       Opid(119): TraceOp(
         opid: Opid(119),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1176,7 +1176,7 @@ TestInterpreterOutputTrace(
       Opid(121): TraceOp(
         opid: Opid(121),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1201,7 +1201,7 @@ TestInterpreterOutputTrace(
       Opid(123): TraceOp(
         opid: Opid(123),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1250,7 +1250,7 @@ TestInterpreterOutputTrace(
       Opid(129): TraceOp(
         opid: Opid(129),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1277,7 +1277,7 @@ TestInterpreterOutputTrace(
       Opid(132): TraceOp(
         opid: Opid(132),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1298,7 +1298,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1323,7 +1323,7 @@ TestInterpreterOutputTrace(
       Opid(136): TraceOp(
         opid: Opid(136),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1390,7 +1390,7 @@ TestInterpreterOutputTrace(
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(148): TraceOp(
         opid: Opid(148),
@@ -1405,7 +1405,7 @@ TestInterpreterOutputTrace(
       Opid(149): TraceOp(
         opid: Opid(149),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1415,7 +1415,7 @@ TestInterpreterOutputTrace(
       Opid(150): TraceOp(
         opid: Opid(150),
         parent_opid: Some(Opid(149)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1445,7 +1445,7 @@ TestInterpreterOutputTrace(
       Opid(152): TraceOp(
         opid: Opid(152),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1468,7 +1468,7 @@ TestInterpreterOutputTrace(
       Opid(153): TraceOp(
         opid: Opid(153),
         parent_opid: Some(Opid(152)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(154): TraceOp(
         opid: Opid(154),
@@ -1507,7 +1507,7 @@ TestInterpreterOutputTrace(
       Opid(155): TraceOp(
         opid: Opid(155),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1541,7 +1541,7 @@ TestInterpreterOutputTrace(
       Opid(156): TraceOp(
         opid: Opid(156),
         parent_opid: Some(Opid(155)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1559,7 +1559,7 @@ TestInterpreterOutputTrace(
       Opid(158): TraceOp(
         opid: Opid(158),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1580,7 +1580,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1605,7 +1605,7 @@ TestInterpreterOutputTrace(
       Opid(162): TraceOp(
         opid: Opid(162),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1654,7 +1654,7 @@ TestInterpreterOutputTrace(
       Opid(168): TraceOp(
         opid: Opid(168),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1681,7 +1681,7 @@ TestInterpreterOutputTrace(
       Opid(171): TraceOp(
         opid: Opid(171),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1702,7 +1702,7 @@ TestInterpreterOutputTrace(
       Opid(173): TraceOp(
         opid: Opid(173),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1727,7 +1727,7 @@ TestInterpreterOutputTrace(
       Opid(175): TraceOp(
         opid: Opid(175),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1777,7 +1777,7 @@ TestInterpreterOutputTrace(
       Opid(181): TraceOp(
         opid: Opid(181),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1825,7 +1825,7 @@ TestInterpreterOutputTrace(
       Opid(189): TraceOp(
         opid: Opid(189),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1846,7 +1846,7 @@ TestInterpreterOutputTrace(
       Opid(191): TraceOp(
         opid: Opid(191),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1860,7 +1860,7 @@ TestInterpreterOutputTrace(
       Opid(192): TraceOp(
         opid: Opid(192),
         parent_opid: Some(Opid(191)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(193): TraceOp(
         opid: Opid(193),
@@ -1892,7 +1892,7 @@ TestInterpreterOutputTrace(
       Opid(194): TraceOp(
         opid: Opid(194),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1919,7 +1919,7 @@ TestInterpreterOutputTrace(
       Opid(195): TraceOp(
         opid: Opid(195),
         parent_opid: Some(Opid(194)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1970,7 +1970,7 @@ TestInterpreterOutputTrace(
       Opid(197): TraceOp(
         opid: Opid(197),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2013,7 +2013,7 @@ TestInterpreterOutputTrace(
       Opid(198): TraceOp(
         opid: Opid(198),
         parent_opid: Some(Opid(197)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(199): TraceOp(
         opid: Opid(199),
@@ -2032,7 +2032,7 @@ TestInterpreterOutputTrace(
       Opid(200): TraceOp(
         opid: Opid(200),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -2063,7 +2063,7 @@ TestInterpreterOutputTrace(
       Opid(203): TraceOp(
         opid: Opid(203),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -2088,7 +2088,7 @@ TestInterpreterOutputTrace(
       Opid(205): TraceOp(
         opid: Opid(205),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -2119,7 +2119,7 @@ TestInterpreterOutputTrace(
       Opid(207): TraceOp(
         opid: Opid(207),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -2175,7 +2175,7 @@ TestInterpreterOutputTrace(
       Opid(213): TraceOp(
         opid: Opid(213),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2207,7 +2207,7 @@ TestInterpreterOutputTrace(
       Opid(216): TraceOp(
         opid: Opid(216),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -2232,7 +2232,7 @@ TestInterpreterOutputTrace(
       Opid(218): TraceOp(
         opid: Opid(218),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -2263,7 +2263,7 @@ TestInterpreterOutputTrace(
       Opid(220): TraceOp(
         opid: Opid(220),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -167,7 +167,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -199,7 +199,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -544,7 +544,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -570,7 +570,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -579,7 +579,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -602,7 +602,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -611,7 +611,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -941,7 +941,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -962,7 +962,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -992,7 +992,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -1001,7 +1001,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -1026,7 +1026,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -1035,7 +1035,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -1435,7 +1435,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -1458,7 +1458,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -1484,7 +1484,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1495,7 +1495,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1518,7 +1518,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1529,7 +1529,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1880,7 +1880,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1907,7 +1907,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1945,7 +1945,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -1956,7 +1956,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1988,7 +1988,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -1999,7 +1999,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -102,13 +102,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -123,13 +123,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -149,13 +149,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -164,7 +164,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -181,13 +181,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -228,7 +228,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), false)),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), false)),
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), true)),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -310,7 +310,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -324,7 +324,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), true)),
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -392,7 +392,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -403,7 +403,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -417,7 +417,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -489,7 +489,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -499,7 +499,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -514,13 +514,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -535,13 +535,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -561,13 +561,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -576,7 +576,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -593,13 +593,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -608,7 +608,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -632,7 +632,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -642,7 +642,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), false)),
@@ -657,7 +657,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -667,7 +667,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), true)),
@@ -677,7 +677,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -688,7 +688,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -699,7 +699,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -713,7 +713,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -750,7 +750,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -760,7 +760,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), true)),
@@ -770,7 +770,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -781,7 +781,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -792,7 +792,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -806,7 +806,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -845,7 +845,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -857,7 +857,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), false)),
@@ -907,7 +907,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -917,7 +917,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -932,13 +932,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -953,13 +953,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -983,13 +983,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -998,7 +998,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -1017,13 +1017,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -1032,7 +1032,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -1054,7 +1054,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1064,7 +1064,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), true)),
@@ -1074,7 +1074,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1085,7 +1085,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1096,7 +1096,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1110,7 +1110,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1147,7 +1147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1157,7 +1157,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), true)),
@@ -1167,7 +1167,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1178,7 +1178,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1189,7 +1189,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1203,7 +1203,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1242,7 +1242,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1254,7 +1254,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), false)),
@@ -1269,7 +1269,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -1279,7 +1279,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), true)),
@@ -1289,7 +1289,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1300,7 +1300,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1311,7 +1311,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1325,7 +1325,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1397,7 +1397,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1407,7 +1407,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -1426,13 +1426,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1449,13 +1449,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1475,13 +1475,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1492,7 +1492,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1509,13 +1509,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1526,7 +1526,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1551,7 +1551,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1561,7 +1561,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), true)),
@@ -1571,7 +1571,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1582,7 +1582,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1593,7 +1593,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1607,7 +1607,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1646,7 +1646,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1658,7 +1658,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), false)),
@@ -1673,7 +1673,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1683,7 +1683,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), true)),
@@ -1693,7 +1693,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1704,7 +1704,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1715,7 +1715,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1729,7 +1729,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1769,7 +1769,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1782,7 +1782,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), false)),
@@ -1836,7 +1836,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1850,7 +1850,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1867,7 +1867,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1875,7 +1875,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1894,7 +1894,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1902,7 +1902,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1932,7 +1932,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1940,7 +1940,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1951,7 +1951,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1975,7 +1975,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1983,7 +1983,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1994,7 +1994,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -2022,7 +2022,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2036,7 +2036,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2053,7 +2053,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2065,7 +2065,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2077,7 +2077,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2090,7 +2090,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2105,7 +2105,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2123,7 +2123,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2165,7 +2165,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2180,7 +2180,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2197,7 +2197,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2209,7 +2209,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2221,7 +2221,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2234,7 +2234,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2249,7 +2249,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2267,7 +2267,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -203,7 +203,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -274,7 +274,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -287,7 +287,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -305,7 +305,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -319,7 +319,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -350,7 +350,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -367,7 +367,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -385,7 +385,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -462,7 +462,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -472,7 +472,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -487,7 +487,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -498,7 +498,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -514,7 +514,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -526,7 +526,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -543,7 +543,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -556,7 +556,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -616,7 +616,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -630,7 +630,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -649,7 +649,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -662,7 +662,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -694,7 +694,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -713,7 +713,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -728,7 +728,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -788,7 +788,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -798,7 +798,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -815,7 +815,7 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -830,7 +830,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -850,7 +850,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -864,7 +864,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -883,7 +883,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -898,7 +898,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -920,7 +920,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -940,7 +940,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -960,7 +960,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -981,7 +981,7 @@ TestInterpreterOutputTrace(
         opid: Opid(116),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1002,7 +1002,7 @@ TestInterpreterOutputTrace(
         opid: Opid(117),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1024,7 +1024,7 @@ TestInterpreterOutputTrace(
         opid: Opid(118),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1078,7 +1078,7 @@ TestInterpreterOutputTrace(
         opid: Opid(124),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1100,7 +1100,7 @@ TestInterpreterOutputTrace(
         opid: Opid(125),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1122,7 +1122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(126),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1144,7 +1144,7 @@ TestInterpreterOutputTrace(
         opid: Opid(127),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1166,7 +1166,7 @@ TestInterpreterOutputTrace(
         opid: Opid(128),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1189,7 +1189,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1284,7 +1284,7 @@ TestInterpreterOutputTrace(
         opid: Opid(143),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1300,7 +1300,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1321,7 +1321,7 @@ TestInterpreterOutputTrace(
         opid: Opid(146),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1335,7 +1335,7 @@ TestInterpreterOutputTrace(
         opid: Opid(147),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1356,7 +1356,7 @@ TestInterpreterOutputTrace(
         opid: Opid(149),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1375,7 +1375,7 @@ TestInterpreterOutputTrace(
         opid: Opid(150),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1399,7 +1399,7 @@ TestInterpreterOutputTrace(
         opid: Opid(152),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1417,7 +1417,7 @@ TestInterpreterOutputTrace(
         opid: Opid(153),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1443,7 +1443,7 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1468,7 +1468,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1493,7 +1493,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1518,7 +1518,7 @@ TestInterpreterOutputTrace(
         opid: Opid(158),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1543,7 +1543,7 @@ TestInterpreterOutputTrace(
         opid: Opid(159),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1571,7 +1571,7 @@ TestInterpreterOutputTrace(
         opid: Opid(160),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1630,7 +1630,7 @@ TestInterpreterOutputTrace(
         opid: Opid(166),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1653,7 +1653,7 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1676,7 +1676,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1700,7 +1700,7 @@ TestInterpreterOutputTrace(
         opid: Opid(169),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
@@ -1724,7 +1724,7 @@ TestInterpreterOutputTrace(
         opid: Opid(170),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1751,7 +1751,7 @@ TestInterpreterOutputTrace(
         opid: Opid(171),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
@@ -5,42 +5,42 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(3), "Number", Eid(3))),
+        content: Call(ResolveNeighbors(Vid(3), "Number", Eid(3))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(4), "Number", Eid(4))),
+        content: Call(ResolveNeighbors(Vid(4), "Number", Eid(4))),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(5), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(5), "Composite", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(4), "Number", "value")),
+        content: Call(ResolveProperty(Vid(4), "Number", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(23)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
@@ -156,7 +156,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -187,7 +187,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(33)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
@@ -228,7 +228,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -239,7 +239,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(36)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(38): TraceOp(
         opid: Opid(38),
@@ -256,7 +256,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -286,7 +286,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -318,7 +318,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -349,7 +349,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -456,7 +456,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(61): TraceOp(
         opid: Opid(61),
@@ -471,7 +471,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -481,7 +481,7 @@ TestInterpreterOutputTrace(
       Opid(63): TraceOp(
         opid: Opid(63),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(64): TraceOp(
         opid: Opid(64),
@@ -497,7 +497,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -508,7 +508,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(65)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(67): TraceOp(
         opid: Opid(67),
@@ -525,7 +525,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -537,7 +537,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(68)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(70): TraceOp(
         opid: Opid(70),
@@ -555,7 +555,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -608,7 +608,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -629,7 +629,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -643,7 +643,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
@@ -661,7 +661,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -674,7 +674,7 @@ TestInterpreterOutputTrace(
       Opid(86): TraceOp(
         opid: Opid(86),
         parent_opid: Some(Opid(85)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
@@ -693,7 +693,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -707,7 +707,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: Some(Opid(88)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
@@ -727,7 +727,7 @@ TestInterpreterOutputTrace(
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -782,7 +782,7 @@ TestInterpreterOutputTrace(
       Opid(100): TraceOp(
         opid: Opid(100),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(101): TraceOp(
         opid: Opid(101),
@@ -797,7 +797,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -807,7 +807,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(102)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -829,7 +829,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -844,7 +844,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(105)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(107): TraceOp(
         opid: Opid(107),
@@ -863,7 +863,7 @@ TestInterpreterOutputTrace(
       Opid(108): TraceOp(
         opid: Opid(108),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -877,7 +877,7 @@ TestInterpreterOutputTrace(
       Opid(109): TraceOp(
         opid: Opid(109),
         parent_opid: Some(Opid(108)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(110): TraceOp(
         opid: Opid(110),
@@ -897,7 +897,7 @@ TestInterpreterOutputTrace(
       Opid(111): TraceOp(
         opid: Opid(111),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -912,7 +912,7 @@ TestInterpreterOutputTrace(
       Opid(112): TraceOp(
         opid: Opid(112),
         parent_opid: Some(Opid(111)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -939,7 +939,7 @@ TestInterpreterOutputTrace(
       Opid(114): TraceOp(
         opid: Opid(114),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -980,7 +980,7 @@ TestInterpreterOutputTrace(
       Opid(116): TraceOp(
         opid: Opid(116),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1023,7 +1023,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1069,7 +1069,7 @@ TestInterpreterOutputTrace(
       Opid(123): TraceOp(
         opid: Opid(123),
         parent_opid: Some(Opid(111)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1099,7 +1099,7 @@ TestInterpreterOutputTrace(
       Opid(125): TraceOp(
         opid: Opid(125),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1143,7 +1143,7 @@ TestInterpreterOutputTrace(
       Opid(127): TraceOp(
         opid: Opid(127),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1188,7 +1188,7 @@ TestInterpreterOutputTrace(
       Opid(129): TraceOp(
         opid: Opid(129),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1275,7 +1275,7 @@ TestInterpreterOutputTrace(
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1299,7 +1299,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1315,7 +1315,7 @@ TestInterpreterOutputTrace(
       Opid(145): TraceOp(
         opid: Opid(145),
         parent_opid: Some(Opid(144)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(146): TraceOp(
         opid: Opid(146),
@@ -1334,7 +1334,7 @@ TestInterpreterOutputTrace(
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -1348,7 +1348,7 @@ TestInterpreterOutputTrace(
       Opid(148): TraceOp(
         opid: Opid(148),
         parent_opid: Some(Opid(147)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1374,7 +1374,7 @@ TestInterpreterOutputTrace(
       Opid(150): TraceOp(
         opid: Opid(150),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1393,7 +1393,7 @@ TestInterpreterOutputTrace(
       Opid(151): TraceOp(
         opid: Opid(151),
         parent_opid: Some(Opid(150)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(152): TraceOp(
         opid: Opid(152),
@@ -1416,7 +1416,7 @@ TestInterpreterOutputTrace(
       Opid(153): TraceOp(
         opid: Opid(153),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -1434,7 +1434,7 @@ TestInterpreterOutputTrace(
       Opid(154): TraceOp(
         opid: Opid(154),
         parent_opid: Some(Opid(153)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1467,7 +1467,7 @@ TestInterpreterOutputTrace(
       Opid(156): TraceOp(
         opid: Opid(156),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1517,7 +1517,7 @@ TestInterpreterOutputTrace(
       Opid(158): TraceOp(
         opid: Opid(158),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -1570,7 +1570,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1622,7 +1622,7 @@ TestInterpreterOutputTrace(
       Opid(165): TraceOp(
         opid: Opid(165),
         parent_opid: Some(Opid(153)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -1652,7 +1652,7 @@ TestInterpreterOutputTrace(
       Opid(167): TraceOp(
         opid: Opid(167),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1699,7 +1699,7 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
@@ -1750,7 +1750,7 @@ TestInterpreterOutputTrace(
       Opid(171): TraceOp(
         opid: Opid(171),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -194,7 +194,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -204,7 +204,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -219,7 +219,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -258,7 +258,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -320,7 +320,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -351,7 +351,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -368,7 +368,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -386,7 +386,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(0))),
@@ -463,7 +463,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -473,7 +473,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -488,7 +488,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -499,7 +499,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -515,7 +515,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -527,7 +527,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -544,7 +544,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -557,7 +557,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -619,7 +619,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -650,7 +650,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -663,7 +663,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -681,7 +681,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -695,7 +695,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -714,7 +714,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -729,7 +729,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -789,7 +789,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -799,7 +799,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -818,7 +818,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -833,7 +833,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -851,7 +851,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -865,7 +865,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -884,7 +884,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -899,7 +899,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -923,7 +923,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -943,7 +943,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -961,7 +961,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -982,7 +982,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1003,7 +1003,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1025,7 +1025,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1082,7 +1082,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1104,7 +1104,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1123,7 +1123,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1145,7 +1145,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1167,7 +1167,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1190,7 +1190,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1288,7 +1288,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1304,7 +1304,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1322,7 +1322,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1336,7 +1336,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1359,7 +1359,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1378,7 +1378,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1400,7 +1400,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1418,7 +1418,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1447,7 +1447,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1472,7 +1472,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1494,7 +1494,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1519,7 +1519,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1546,7 +1546,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1574,7 +1574,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1633,7 +1633,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1656,7 +1656,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1677,7 +1677,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1701,7 +1701,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1727,7 +1727,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1754,7 +1754,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,

--- a/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
             Vid(3): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -120,7 +120,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -168,7 +168,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -252,7 +252,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -276,7 +276,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(7)))),
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
@@ -319,7 +319,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
@@ -341,7 +341,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -409,7 +409,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -435,7 +435,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -459,7 +459,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(0))),
@@ -64,7 +64,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(1))),
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -222,7 +222,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -311,7 +311,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -321,7 +321,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         ), Int64(7))),
@@ -352,7 +352,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -366,7 +366,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -413,7 +413,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -448,7 +448,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -464,7 +464,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -261,7 +261,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -310,7 +310,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -320,7 +320,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -349,7 +349,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -363,7 +363,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -396,7 +396,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -410,7 +410,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -444,7 +444,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -460,7 +460,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -235,7 +235,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -252,7 +252,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -283,7 +283,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -364,7 +364,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -395,7 +395,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -412,7 +412,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -456,7 +456,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -471,7 +471,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -484,7 +484,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -248,7 +248,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -282,7 +282,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -332,7 +332,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -360,7 +360,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -377,7 +377,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -394,7 +394,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -453,7 +453,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -468,7 +468,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -483,7 +483,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
@@ -499,7 +499,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -222,7 +222,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -247,7 +247,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
@@ -341,7 +341,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -351,7 +351,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(41)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -376,7 +376,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -410,7 +410,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -445,7 +445,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(41)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -467,7 +467,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -498,7 +498,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -214,7 +214,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -224,7 +224,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -235,7 +235,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -305,7 +305,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(4): Some(Prime(PrimeNumber(3))),
@@ -316,7 +316,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -327,7 +327,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -349,7 +349,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(4): Some(Prime(PrimeNumber(3))),
@@ -360,7 +360,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(3))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(3))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(4), "Number", "value")),
+        content: Call(ResolveProperty(Vid(4), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -102,14 +102,14 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(19)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(19)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -255,7 +255,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(30)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
@@ -347,7 +347,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(19)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(19)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(19)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(19)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -213,7 +213,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -256,7 +256,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -274,7 +274,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -313,7 +313,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -348,7 +348,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -357,7 +357,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -367,7 +367,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),

--- a/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "name")),
+        content: Call(ResolveProperty(Vid(2), "Number", "name")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -103,7 +103,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -124,7 +124,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(24)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(24)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(24)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -290,7 +290,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(24)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), String("two"))),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -223,7 +223,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -244,7 +244,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -271,7 +271,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Prime", "name")),
+        content: Call(ResolveProperty(Vid(1), "Prime", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "name")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "name")),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -99,7 +99,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Prime", "name")),
+        content: Call(ResolveProperty(Vid(1), "Prime", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -99,7 +99,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "name")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "name")),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -204,7 +204,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -228,7 +228,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
@@ -296,7 +296,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
@@ -474,7 +474,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(43)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -276,7 +276,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -344,7 +344,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -410,7 +410,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(43)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -421,7 +421,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -438,7 +438,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -475,7 +475,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(43)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -503,7 +503,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), String("two"))),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           imported_tags: {
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(1),
@@ -279,7 +279,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -300,7 +300,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -347,7 +347,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -413,7 +413,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -441,7 +441,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -478,7 +478,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -489,7 +489,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -506,7 +506,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -99,7 +99,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -206,7 +206,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -237,7 +237,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -302,7 +302,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -325,7 +325,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         )),
       ),
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         ), List([
           String("e"),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), List([
           String("e"),
           String("i"),
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(21): TraceOp(
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), List([
           String("i"),
           String("e"),
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -223,7 +223,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(32): TraceOp(
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), List([
           String("e"),
         ]))),
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(36): TraceOp(
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         ), List([
           String("e"),
           String("e"),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "vowelsInName")),
+        content: Call(ResolveProperty(Vid(1), "Number", "vowelsInName")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "vowelsInName")),
+        content: Call(ResolveProperty(Vid(1), "Number", "vowelsInName")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -84,7 +84,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -236,7 +236,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -282,7 +282,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -301,7 +301,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -319,7 +319,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(11)))),
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
@@ -332,7 +332,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {},
         ), List([

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -227,7 +227,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -317,7 +317,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -331,7 +331,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -379,7 +379,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -459,7 +459,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -473,7 +473,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -494,7 +494,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -508,7 +508,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -536,7 +536,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -551,7 +551,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -577,7 +577,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -591,7 +591,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -605,7 +605,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -622,7 +622,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -639,7 +639,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -659,7 +659,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -711,7 +711,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -726,7 +726,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -741,7 +741,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -760,7 +760,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -778,7 +778,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -799,7 +799,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -862,7 +862,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -878,7 +878,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -902,7 +902,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -918,7 +918,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -947,7 +947,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -963,7 +963,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -994,7 +994,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1011,7 +1011,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1028,7 +1028,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1050,7 +1050,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1071,7 +1071,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1095,7 +1095,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1150,7 +1150,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1166,7 +1166,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1182,7 +1182,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1202,7 +1202,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1222,7 +1222,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1245,7 +1245,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -204,7 +204,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -223,7 +223,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -314,7 +314,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -359,7 +359,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -376,7 +376,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -396,7 +396,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -456,7 +456,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -470,7 +470,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -491,7 +491,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -505,7 +505,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -532,7 +532,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -547,7 +547,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -574,7 +574,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -588,7 +588,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -602,7 +602,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -619,7 +619,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -636,7 +636,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -656,7 +656,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -707,7 +707,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -722,7 +722,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -737,7 +737,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -756,7 +756,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -775,7 +775,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -796,7 +796,7 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -858,7 +858,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -874,7 +874,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -898,7 +898,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -914,7 +914,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -943,7 +943,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -959,7 +959,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -989,7 +989,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -1006,7 +1006,7 @@ TestInterpreterOutputTrace(
         opid: Opid(93),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -1023,7 +1023,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -1045,7 +1045,7 @@ TestInterpreterOutputTrace(
         opid: Opid(95),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -1067,7 +1067,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1091,7 +1091,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1146,7 +1146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1162,7 +1162,7 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1178,7 +1178,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1198,7 +1198,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1218,7 +1218,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1241,7 +1241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(24, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(24, [
           2,
           3,
         ])))),
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
@@ -222,7 +222,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -327,7 +327,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -358,7 +358,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -395,7 +395,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -448,7 +448,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -483,7 +483,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(47)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -504,7 +504,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(47)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -566,7 +566,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(47)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(27, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(27, [
           3,
         ])))),
       ),
@@ -587,7 +587,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
@@ -655,7 +655,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -698,7 +698,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(47)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(36, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(36, [
           2,
           3,
         ])))),
@@ -721,7 +721,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
@@ -755,7 +755,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
@@ -795,7 +795,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -849,7 +849,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -873,7 +873,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -889,7 +889,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -913,7 +913,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -934,7 +934,7 @@ TestInterpreterOutputTrace(
       Opid(87): TraceOp(
         opid: Opid(87),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(20, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(20, [
           2,
           5,
         ])))),
@@ -958,7 +958,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -979,7 +979,7 @@ TestInterpreterOutputTrace(
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -1005,7 +1005,7 @@ TestInterpreterOutputTrace(
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -1044,7 +1044,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -1090,7 +1090,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -1137,7 +1137,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(40, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(40, [
           2,
           5,
         ])))),
@@ -1161,7 +1161,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
@@ -1197,7 +1197,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
@@ -1240,7 +1240,7 @@ TestInterpreterOutputTrace(
       Opid(108): TraceOp(
         opid: Opid(108),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -219,7 +219,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -247,7 +247,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -301,7 +301,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -396,7 +396,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -410,7 +410,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -438,7 +438,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -453,7 +453,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -479,7 +479,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -493,7 +493,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -507,7 +507,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -524,7 +524,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -541,7 +541,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -561,7 +561,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -613,7 +613,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -628,7 +628,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -643,7 +643,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -662,7 +662,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -701,7 +701,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -764,7 +764,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -780,7 +780,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -820,7 +820,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -849,7 +849,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -865,7 +865,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -896,7 +896,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -913,7 +913,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -930,7 +930,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -952,7 +952,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -973,7 +973,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -997,7 +997,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1052,7 +1052,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1068,7 +1068,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1084,7 +1084,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1104,7 +1104,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1124,7 +1124,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -1147,7 +1147,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(24, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(24, [
           2,
           3,
         ])))),
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -260,7 +260,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -350,7 +350,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -385,7 +385,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -406,7 +406,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -425,7 +425,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -448,7 +448,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -468,7 +468,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(27, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(27, [
           3,
         ])))),
       ),
@@ -489,7 +489,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
@@ -557,7 +557,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -600,7 +600,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(36, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(36, [
           2,
           3,
         ])))),
@@ -623,7 +623,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
@@ -657,7 +657,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
@@ -697,7 +697,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -751,7 +751,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -775,7 +775,7 @@ TestInterpreterOutputTrace(
       Opid(75): TraceOp(
         opid: Opid(75),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -791,7 +791,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(75)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -815,7 +815,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -836,7 +836,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(75)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(20, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(20, [
           2,
           5,
         ])))),
@@ -860,7 +860,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -881,7 +881,7 @@ TestInterpreterOutputTrace(
       Opid(84): TraceOp(
         opid: Opid(84),
         parent_opid: Some(Opid(75)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -907,7 +907,7 @@ TestInterpreterOutputTrace(
       Opid(86): TraceOp(
         opid: Opid(86),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -946,7 +946,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -992,7 +992,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -1039,7 +1039,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(75)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(40, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(40, [
           2,
           5,
         ])))),
@@ -1063,7 +1063,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
@@ -1099,7 +1099,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
@@ -1142,7 +1142,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -244,7 +244,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -261,7 +261,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -358,7 +358,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -372,7 +372,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -393,7 +393,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -407,7 +407,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -434,7 +434,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -449,7 +449,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -476,7 +476,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -490,7 +490,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -504,7 +504,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -521,7 +521,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(27, [
+          active_vertex: Some(Composite(CompositeNumber(27, [
             3,
           ]))),
           tokens: {
@@ -538,7 +538,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -558,7 +558,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -609,7 +609,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -624,7 +624,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -639,7 +639,7 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -658,7 +658,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -677,7 +677,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -698,7 +698,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -760,7 +760,7 @@ TestInterpreterOutputTrace(
         opid: Opid(74),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -776,7 +776,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -800,7 +800,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -816,7 +816,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -845,7 +845,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -861,7 +861,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -891,7 +891,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -908,7 +908,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -925,7 +925,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -947,7 +947,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -969,7 +969,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -993,7 +993,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1048,7 +1048,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1064,7 +1064,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1080,7 +1080,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1100,7 +1100,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(40, [
+          active_vertex: Some(Composite(CompositeNumber(40, [
             2,
             5,
           ]))),
@@ -1120,7 +1120,7 @@ TestInterpreterOutputTrace(
         opid: Opid(100),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -1143,7 +1143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
@@ -41,7 +41,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("four"))),
       ),
       Opid(9): TraceOp(
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         ), String("five"))),
       ),
       Opid(17): TraceOp(
@@ -141,7 +141,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(20): TraceOp(
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("six"))),
       ),
       Opid(21): TraceOp(
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(24): TraceOp(
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {},
+          vertices: {},
         ), String("seven"))),
       ),
       Opid(25): TraceOp(
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(28): TraceOp(
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("eight"))),
       ),
       Opid(29): TraceOp(
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(32): TraceOp(
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("nine"))),
       ),
       Opid(33): TraceOp(
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(36): TraceOp(
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("ten"))),
       ),
       Opid(37): TraceOp(
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(40): TraceOp(
@@ -303,7 +303,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         ), String("eleven"))),
       ),
       Opid(41): TraceOp(
@@ -327,7 +327,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(44): TraceOp(
@@ -338,7 +338,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twelve"))),
       ),
       Opid(45): TraceOp(
@@ -356,7 +356,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(48): TraceOp(
@@ -364,7 +364,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), String("thirteen"))),
       ),
       Opid(49): TraceOp(
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(52): TraceOp(
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fourteen"))),
       ),
       Opid(53): TraceOp(
@@ -410,7 +410,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -426,7 +426,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {},
         ), String("five"))),
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(7)))),
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {},
         ), String("seven"))),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -206,7 +206,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -238,7 +238,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -272,7 +272,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(11)))),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
@@ -301,7 +301,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {},
         ), String("eleven"))),
@@ -314,7 +314,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -349,7 +349,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), String("thirteen"))),
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -394,7 +394,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -421,7 +421,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
@@ -38,7 +38,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         )),
       ),
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         ), String("five"))),
       ),
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {},
         )),
       ),
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {},
         ), String("seven"))),
       ),
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -207,7 +207,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -239,7 +239,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         )),
       ),
@@ -302,7 +302,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         ), String("eleven"))),
       ),
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -355,7 +355,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -363,7 +363,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), String("thirteen"))),
       ),
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -395,7 +395,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -406,7 +406,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -422,7 +422,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
@@ -39,7 +39,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         )),
       ),
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         ), String("eleven"))),
       ),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), String("thirteen"))),
       ),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -54,7 +54,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("ten"))),
       ),
       Opid(9): TraceOp(
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         ), String("eleven"))),
       ),
       Opid(13): TraceOp(
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
         )),
@@ -98,7 +98,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
         ), String("eleven"))),
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(20): TraceOp(
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twelve"))),
       ),
       Opid(21): TraceOp(
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(28): TraceOp(
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), String("thirteen"))),
       ),
       Opid(29): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(11)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {},
         ), String("eleven"))),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), String("thirteen"))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -54,7 +54,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twelve"))),
       ),
       Opid(9): TraceOp(
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), String("thirteen"))),
       ),
       Opid(13): TraceOp(
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
         )),
@@ -98,7 +98,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
         ), String("thirteen"))),
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(20): TraceOp(
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fourteen"))),
       ),
       Opid(21): TraceOp(
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(28): TraceOp(
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fifteen"))),
       ),
       Opid(29): TraceOp(
@@ -237,7 +237,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(36): TraceOp(
@@ -302,7 +302,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("sixteen"))),
       ),
       Opid(37): TraceOp(
@@ -312,7 +312,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -360,7 +360,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(44): TraceOp(
@@ -368,7 +368,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {},
+          vertices: {},
         ), String("seventeen"))),
       ),
       Opid(45): TraceOp(
@@ -376,7 +376,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
         )),
@@ -386,7 +386,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
         ), String("seventeen"))),
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(52): TraceOp(
@@ -435,7 +435,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("eighteen"))),
       ),
       Opid(53): TraceOp(
@@ -446,7 +446,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -462,7 +462,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -497,7 +497,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(60): TraceOp(
@@ -505,7 +505,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {},
+          vertices: {},
         ), String("nineteen"))),
       ),
       Opid(61): TraceOp(
@@ -513,7 +513,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
         )),
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
         ), String("nineteen"))),
@@ -561,7 +561,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(68): TraceOp(
@@ -572,7 +572,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twenty"))),
       ),
       Opid(69): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), String("thirteen"))),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -248,7 +248,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -322,7 +322,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -353,7 +353,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(17)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(17)))),
       ),
       Opid(43): TraceOp(
         opid: Opid(43),
@@ -366,7 +366,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
           vertices: {},
         ), String("seventeen"))),
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -430,7 +430,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -457,7 +457,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -490,7 +490,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(19)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(19)))),
       ),
       Opid(59): TraceOp(
         opid: Opid(59),
@@ -503,7 +503,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
           vertices: {},
         ), String("nineteen"))),
@@ -521,7 +521,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
@@ -548,7 +548,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(20, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(20, [
           2,
           5,
         ])))),
@@ -567,7 +567,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
@@ -39,7 +39,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), String("thirteen"))),
       ),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -222,7 +222,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -359,7 +359,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {},
         )),
       ),
@@ -367,7 +367,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {},
         ), String("seventeen"))),
       ),
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
@@ -385,7 +385,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
@@ -420,7 +420,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -431,7 +431,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -442,7 +442,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -458,7 +458,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -496,7 +496,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {},
         )),
       ),
@@ -504,7 +504,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {},
         ), String("nineteen"))),
       ),
@@ -512,7 +512,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
@@ -522,7 +522,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
@@ -557,7 +557,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -568,7 +568,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
@@ -41,7 +41,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(8))),
       ),
       Opid(9): TraceOp(
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -113,7 +113,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(9))),
       ),
       Opid(17): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
@@ -38,7 +38,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -120,7 +120,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
@@ -41,7 +41,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(8))),
       ),
       Opid(9): TraceOp(
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -113,7 +113,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(9))),
       ),
       Opid(17): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
@@ -38,7 +38,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -120,7 +120,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
@@ -38,7 +38,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
@@ -41,7 +41,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(8))),
       ),
       Opid(9): TraceOp(
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(9))),
       ),
       Opid(13): TraceOp(
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -103,7 +103,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -54,7 +54,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twelve"))),
       ),
       Opid(9): TraceOp(
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), String("thirteen"))),
       ),
       Opid(13): TraceOp(
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fourteen"))),
       ),
       Opid(17): TraceOp(
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(24): TraceOp(
@@ -194,7 +194,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fifteen"))),
       ),
       Opid(25): TraceOp(
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -260,7 +260,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(32): TraceOp(
@@ -270,7 +270,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("sixteen"))),
       ),
       Opid(33): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
@@ -39,7 +39,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), String("thirteen"))),
       ),
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), String("thirteen"))),
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -54,7 +54,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twelve"))),
       ),
       Opid(9): TraceOp(
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), String("thirteen"))),
       ),
       Opid(13): TraceOp(
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fourteen"))),
       ),
       Opid(17): TraceOp(
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(24): TraceOp(
@@ -194,7 +194,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fifteen"))),
       ),
       Opid(25): TraceOp(
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -260,7 +260,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(32): TraceOp(
@@ -270,7 +270,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("sixteen"))),
       ),
       Opid(33): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
@@ -39,7 +39,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), String("thirteen"))),
       ),
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), String("thirteen"))),
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -53,7 +53,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {},
         ), String("five"))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -149,7 +149,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(7)))),
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {},
         ), String("seven"))),
@@ -284,7 +284,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -360,7 +360,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -415,7 +415,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -455,7 +455,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -472,7 +472,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -496,7 +496,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -527,7 +527,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -567,7 +567,7 @@ TestInterpreterOutputTrace(
       Opid(63): TraceOp(
         opid: Opid(63),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -586,7 +586,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -613,7 +613,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -648,7 +648,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -690,7 +690,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(11)))),
       ),
       Opid(75): TraceOp(
         opid: Opid(75),
@@ -703,7 +703,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {},
         ), String("eleven"))),
@@ -721,7 +721,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
@@ -744,7 +744,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
@@ -780,7 +780,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -799,7 +799,7 @@ TestInterpreterOutputTrace(
       Opid(87): TraceOp(
         opid: Opid(87),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -826,7 +826,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -861,7 +861,7 @@ TestInterpreterOutputTrace(
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -903,7 +903,7 @@ TestInterpreterOutputTrace(
       Opid(96): TraceOp(
         opid: Opid(96),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(13)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(13)))),
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
@@ -916,7 +916,7 @@ TestInterpreterOutputTrace(
       Opid(98): TraceOp(
         opid: Opid(98),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {},
         ), String("thirteen"))),
@@ -934,7 +934,7 @@ TestInterpreterOutputTrace(
       Opid(100): TraceOp(
         opid: Opid(100),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
@@ -957,7 +957,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
@@ -993,7 +993,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -1012,7 +1012,7 @@ TestInterpreterOutputTrace(
       Opid(109): TraceOp(
         opid: Opid(109),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -1039,7 +1039,7 @@ TestInterpreterOutputTrace(
       Opid(111): TraceOp(
         opid: Opid(111),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -1074,7 +1074,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -1116,7 +1116,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -1135,7 +1135,7 @@ TestInterpreterOutputTrace(
       Opid(120): TraceOp(
         opid: Opid(120),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -1162,7 +1162,7 @@ TestInterpreterOutputTrace(
       Opid(122): TraceOp(
         opid: Opid(122),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -1197,7 +1197,7 @@ TestInterpreterOutputTrace(
       Opid(124): TraceOp(
         opid: Opid(124),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -1239,7 +1239,7 @@ TestInterpreterOutputTrace(
       Opid(129): TraceOp(
         opid: Opid(129),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -1256,7 +1256,7 @@ TestInterpreterOutputTrace(
       Opid(131): TraceOp(
         opid: Opid(131),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1280,7 +1280,7 @@ TestInterpreterOutputTrace(
       Opid(133): TraceOp(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1311,7 +1311,7 @@ TestInterpreterOutputTrace(
       Opid(135): TraceOp(
         opid: Opid(135),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1351,7 +1351,7 @@ TestInterpreterOutputTrace(
       Opid(140): TraceOp(
         opid: Opid(140),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(17)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(17)))),
       ),
       Opid(141): TraceOp(
         opid: Opid(141),
@@ -1364,7 +1364,7 @@ TestInterpreterOutputTrace(
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
           vertices: {},
         ), String("seventeen"))),
@@ -1382,7 +1382,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
@@ -1405,7 +1405,7 @@ TestInterpreterOutputTrace(
       Opid(146): TraceOp(
         opid: Opid(146),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
@@ -1441,7 +1441,7 @@ TestInterpreterOutputTrace(
       Opid(151): TraceOp(
         opid: Opid(151),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -1460,7 +1460,7 @@ TestInterpreterOutputTrace(
       Opid(153): TraceOp(
         opid: Opid(153),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1487,7 +1487,7 @@ TestInterpreterOutputTrace(
       Opid(155): TraceOp(
         opid: Opid(155),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1522,7 +1522,7 @@ TestInterpreterOutputTrace(
       Opid(157): TraceOp(
         opid: Opid(157),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1564,7 +1564,7 @@ TestInterpreterOutputTrace(
       Opid(162): TraceOp(
         opid: Opid(162),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(19)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(19)))),
       ),
       Opid(163): TraceOp(
         opid: Opid(163),
@@ -1577,7 +1577,7 @@ TestInterpreterOutputTrace(
       Opid(164): TraceOp(
         opid: Opid(164),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
           vertices: {},
         ), String("nineteen"))),
@@ -1595,7 +1595,7 @@ TestInterpreterOutputTrace(
       Opid(166): TraceOp(
         opid: Opid(166),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
@@ -1618,7 +1618,7 @@ TestInterpreterOutputTrace(
       Opid(168): TraceOp(
         opid: Opid(168),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
@@ -1654,7 +1654,7 @@ TestInterpreterOutputTrace(
       Opid(173): TraceOp(
         opid: Opid(173),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(20, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(20, [
           2,
           5,
         ])))),
@@ -1673,7 +1673,7 @@ TestInterpreterOutputTrace(
       Opid(175): TraceOp(
         opid: Opid(175),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -1700,7 +1700,7 @@ TestInterpreterOutputTrace(
       Opid(177): TraceOp(
         opid: Opid(177),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -1735,7 +1735,7 @@ TestInterpreterOutputTrace(
       Opid(179): TraceOp(
         opid: Opid(179),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -1777,7 +1777,7 @@ TestInterpreterOutputTrace(
       Opid(184): TraceOp(
         opid: Opid(184),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(21, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(21, [
           3,
           7,
         ])))),
@@ -1796,7 +1796,7 @@ TestInterpreterOutputTrace(
       Opid(186): TraceOp(
         opid: Opid(186),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
@@ -1812,7 +1812,7 @@ TestInterpreterOutputTrace(
       Opid(188): TraceOp(
         opid: Opid(188),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(22, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(22, [
           2,
           11,
         ])))),
@@ -1831,7 +1831,7 @@ TestInterpreterOutputTrace(
       Opid(190): TraceOp(
         opid: Opid(190),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(22, [
             2,
             11,

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         )),
       ),
@@ -54,7 +54,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         ), String("five"))),
       ),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -259,7 +259,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {},
         )),
       ),
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {},
         ), String("seven"))),
       ),
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -285,7 +285,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -308,7 +308,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -351,7 +351,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -385,7 +385,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -416,7 +416,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -463,7 +463,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -473,7 +473,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -483,7 +483,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -497,7 +497,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -511,7 +511,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -528,7 +528,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -576,7 +576,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -587,7 +587,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -598,7 +598,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -614,7 +614,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -630,7 +630,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -649,7 +649,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -696,7 +696,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         )),
       ),
@@ -704,7 +704,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         ), String("eleven"))),
       ),
@@ -712,7 +712,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
@@ -722,7 +722,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
@@ -732,7 +732,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
@@ -745,7 +745,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
@@ -789,7 +789,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -800,7 +800,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -811,7 +811,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -827,7 +827,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -843,7 +843,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -862,7 +862,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -909,7 +909,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         )),
       ),
@@ -917,7 +917,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {},
         ), String("thirteen"))),
       ),
@@ -925,7 +925,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
@@ -935,7 +935,7 @@ TestInterpreterOutputTrace(
         opid: Opid(100),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
@@ -945,7 +945,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
@@ -958,7 +958,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(13))),
+          active_vertex: Some(Prime(PrimeNumber(13))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
@@ -1002,7 +1002,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1013,7 +1013,7 @@ TestInterpreterOutputTrace(
         opid: Opid(109),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1024,7 +1024,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1040,7 +1040,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1056,7 +1056,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1075,7 +1075,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1125,7 +1125,7 @@ TestInterpreterOutputTrace(
         opid: Opid(119),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1136,7 +1136,7 @@ TestInterpreterOutputTrace(
         opid: Opid(120),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1147,7 +1147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(121),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1163,7 +1163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(122),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1179,7 +1179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(123),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1198,7 +1198,7 @@ TestInterpreterOutputTrace(
         opid: Opid(124),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1247,7 +1247,7 @@ TestInterpreterOutputTrace(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -1257,7 +1257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(131),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -1267,7 +1267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1281,7 +1281,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1295,7 +1295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1312,7 +1312,7 @@ TestInterpreterOutputTrace(
         opid: Opid(135),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1357,7 +1357,7 @@ TestInterpreterOutputTrace(
         opid: Opid(141),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {},
         )),
       ),
@@ -1365,7 +1365,7 @@ TestInterpreterOutputTrace(
         opid: Opid(142),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {},
         ), String("seventeen"))),
       ),
@@ -1373,7 +1373,7 @@ TestInterpreterOutputTrace(
         opid: Opid(143),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
@@ -1383,7 +1383,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
@@ -1393,7 +1393,7 @@ TestInterpreterOutputTrace(
         opid: Opid(145),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
         opid: Opid(146),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(17))),
+          active_vertex: Some(Prime(PrimeNumber(17))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
@@ -1450,7 +1450,7 @@ TestInterpreterOutputTrace(
         opid: Opid(152),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1461,7 +1461,7 @@ TestInterpreterOutputTrace(
         opid: Opid(153),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1472,7 +1472,7 @@ TestInterpreterOutputTrace(
         opid: Opid(154),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1488,7 +1488,7 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1504,7 +1504,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1523,7 +1523,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1570,7 +1570,7 @@ TestInterpreterOutputTrace(
         opid: Opid(163),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {},
         )),
       ),
@@ -1578,7 +1578,7 @@ TestInterpreterOutputTrace(
         opid: Opid(164),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {},
         ), String("nineteen"))),
       ),
@@ -1586,7 +1586,7 @@ TestInterpreterOutputTrace(
         opid: Opid(165),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
@@ -1596,7 +1596,7 @@ TestInterpreterOutputTrace(
         opid: Opid(166),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
@@ -1606,7 +1606,7 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
@@ -1619,7 +1619,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(19))),
+          active_vertex: Some(Prime(PrimeNumber(19))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
@@ -1663,7 +1663,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1674,7 +1674,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1685,7 +1685,7 @@ TestInterpreterOutputTrace(
         opid: Opid(176),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1701,7 +1701,7 @@ TestInterpreterOutputTrace(
         opid: Opid(177),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1717,7 +1717,7 @@ TestInterpreterOutputTrace(
         opid: Opid(178),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1736,7 +1736,7 @@ TestInterpreterOutputTrace(
         opid: Opid(179),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -1786,7 +1786,7 @@ TestInterpreterOutputTrace(
         opid: Opid(185),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -1797,7 +1797,7 @@ TestInterpreterOutputTrace(
         opid: Opid(186),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -1821,7 +1821,7 @@ TestInterpreterOutputTrace(
         opid: Opid(189),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(22, [
+          active_vertex: Some(Composite(CompositeNumber(22, [
             2,
             11,
           ]))),
@@ -1832,7 +1832,7 @@ TestInterpreterOutputTrace(
         opid: Opid(190),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(22, [
+          active_vertex: Some(Composite(CompositeNumber(22, [
             2,
             11,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         ), String("five"))),
       ),
       Opid(11): TraceOp(
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), String("five"))),
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           values: [
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           values: [
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(21): TraceOp(
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("six"))),
       ),
       Opid(22): TraceOp(
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -260,7 +260,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(32): TraceOp(
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {},
+          vertices: {},
         ), String("seven"))),
       ),
       Opid(33): TraceOp(
@@ -276,7 +276,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -286,7 +286,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         ), String("seven"))),
@@ -296,7 +296,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
           values: [
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
           values: [
@@ -354,7 +354,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(43): TraceOp(
@@ -364,7 +364,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("eight"))),
       ),
       Opid(44): TraceOp(
@@ -374,7 +374,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -402,7 +402,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -419,7 +419,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -466,7 +466,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(54): TraceOp(
@@ -476,7 +476,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("nine"))),
       ),
       Opid(55): TraceOp(
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -514,7 +514,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -531,7 +531,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -580,7 +580,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(65): TraceOp(
@@ -591,7 +591,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("ten"))),
       ),
       Opid(66): TraceOp(
@@ -602,7 +602,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -634,7 +634,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -653,7 +653,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -697,7 +697,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(76): TraceOp(
@@ -705,7 +705,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         ), String("eleven"))),
       ),
       Opid(77): TraceOp(
@@ -713,7 +713,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
         )),
@@ -723,7 +723,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
         ), String("eleven"))),
@@ -733,7 +733,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
           values: [
@@ -746,7 +746,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(11))),
           },
           values: [
@@ -793,7 +793,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(87): TraceOp(
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twelve"))),
       ),
       Opid(88): TraceOp(
@@ -815,7 +815,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -831,7 +831,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -847,7 +847,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -866,7 +866,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -910,7 +910,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(98): TraceOp(
@@ -918,7 +918,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {},
+          vertices: {},
         ), String("thirteen"))),
       ),
       Opid(99): TraceOp(
@@ -926,7 +926,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
         )),
@@ -936,7 +936,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
         ), String("thirteen"))),
@@ -946,7 +946,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
           values: [
@@ -959,7 +959,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(13))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(13))),
           },
           values: [
@@ -1006,7 +1006,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(109): TraceOp(
@@ -1017,7 +1017,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fourteen"))),
       ),
       Opid(110): TraceOp(
@@ -1028,7 +1028,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -1044,7 +1044,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -1060,7 +1060,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -1079,7 +1079,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -1129,7 +1129,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(120): TraceOp(
@@ -1140,7 +1140,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("fifteen"))),
       ),
       Opid(121): TraceOp(
@@ -1151,7 +1151,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -1167,7 +1167,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -1183,7 +1183,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -1202,7 +1202,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -1250,7 +1250,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(131): TraceOp(
@@ -1260,7 +1260,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("sixteen"))),
       ),
       Opid(132): TraceOp(
@@ -1270,7 +1270,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1284,7 +1284,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1298,7 +1298,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1315,7 +1315,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -1358,7 +1358,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(142): TraceOp(
@@ -1366,7 +1366,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {},
+          vertices: {},
         ), String("seventeen"))),
       ),
       Opid(143): TraceOp(
@@ -1374,7 +1374,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
         )),
@@ -1384,7 +1384,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
         ), String("seventeen"))),
@@ -1394,7 +1394,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
           values: [
@@ -1407,7 +1407,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(17))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(17))),
           },
           values: [
@@ -1454,7 +1454,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(153): TraceOp(
@@ -1465,7 +1465,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("eighteen"))),
       ),
       Opid(154): TraceOp(
@@ -1476,7 +1476,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1492,7 +1492,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1508,7 +1508,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1527,7 +1527,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1571,7 +1571,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(164): TraceOp(
@@ -1579,7 +1579,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {},
+          vertices: {},
         ), String("nineteen"))),
       ),
       Opid(165): TraceOp(
@@ -1587,7 +1587,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
         )),
@@ -1597,7 +1597,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
         ), String("nineteen"))),
@@ -1607,7 +1607,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
           values: [
@@ -1620,7 +1620,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(19))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(19))),
           },
           values: [
@@ -1667,7 +1667,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(175): TraceOp(
@@ -1678,7 +1678,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), String("twenty"))),
       ),
       Opid(176): TraceOp(
@@ -1689,7 +1689,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1705,7 +1705,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1721,7 +1721,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1740,7 +1740,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -1790,7 +1790,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(186): TraceOp(
@@ -1801,7 +1801,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Null)),
       ),
       Opid(187): TraceOp(
@@ -1825,7 +1825,7 @@ TestInterpreterOutputTrace(
             2,
             11,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(190): TraceOp(
@@ -1836,7 +1836,7 @@ TestInterpreterOutputTrace(
             2,
             11,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Null)),
       ),
       Opid(191): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(11): TraceOp(
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(4))),
       ),
       Opid(12): TraceOp(
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(15): TraceOp(
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(6))),
       ),
       Opid(16): TraceOp(
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), Int64(8))),
       ),
       Opid(20): TraceOp(
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -234,7 +234,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "name")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "name")),
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(24)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(24)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(24)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(24)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -68,7 +68,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         )),
       ),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         ), false)),
       ),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -239,7 +239,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -254,7 +254,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -302,13 +302,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -327,7 +327,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -340,13 +340,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {},
         ), false)),
@@ -141,7 +141,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -160,7 +160,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -187,7 +187,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -203,12 +203,12 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(28): TraceOp(
         opid: Opid(28),
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
@@ -238,7 +238,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(20): TraceOp(
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(23): TraceOp(
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(24): TraceOp(
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -255,7 +255,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -293,7 +293,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -303,13 +303,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -331,7 +331,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -341,13 +341,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(20): TraceOp(
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(23): TraceOp(
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(24): TraceOp(
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         )),
       ),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         ), false)),
       ),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,12 +109,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(31)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(31)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
           vertices: {},
         ), false)),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(20): TraceOp(
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(23): TraceOp(
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(24): TraceOp(
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         )),
       ),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         ), false)),
       ),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,12 +109,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(31)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(31)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
           vertices: {},
         ), false)),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(20): TraceOp(
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(23): TraceOp(
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(24): TraceOp(
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         )),
       ),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         ), false)),
       ),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,12 +109,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(31)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(31)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
           vertices: {},
         ), false)),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(20): TraceOp(
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(23): TraceOp(
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(24): TraceOp(
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         )),
       ),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         ), false)),
       ),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(28)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,12 +109,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(31)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(31)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
           vertices: {},
         ), false)),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(29): TraceOp(
         opid: Opid(29),
@@ -240,7 +240,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(28)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         )),
       ),
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         ), Int64(2))),
       ),
@@ -151,7 +151,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         )),
       ),
@@ -159,7 +159,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         ), Int64(3))),
       ),
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         )),
       ),
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         ), Int64(5))),
       ),
@@ -223,7 +223,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(30)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(30)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -248,7 +248,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(30)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -258,7 +258,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(30)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -283,7 +283,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -298,13 +298,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -324,7 +324,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -339,13 +339,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(17): TraceOp(
@@ -134,7 +134,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         ), Int64(2))),
       ),
       Opid(18): TraceOp(
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(21): TraceOp(
@@ -160,7 +160,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         ), Int64(3))),
       ),
       Opid(22): TraceOp(
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(25): TraceOp(
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         ), Int64(5))),
       ),
       Opid(26): TraceOp(
@@ -224,7 +224,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(30)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -234,7 +234,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(30)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(30)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -259,7 +259,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(30)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -299,13 +299,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -329,7 +329,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -340,13 +340,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {},
         ), Int64(2))),
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {},
         ), Int64(3))),
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(5)))),
       ),
       Opid(24): TraceOp(
         opid: Opid(24),
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {},
         ), Int64(5))),
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(30)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(30)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -41,7 +41,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(9)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
@@ -31,7 +31,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
@@ -28,7 +28,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -42,7 +42,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -87,14 +87,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -107,14 +107,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -132,14 +132,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -152,14 +152,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
           },
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
           },
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -191,7 +191,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -86,14 +86,14 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -106,14 +106,14 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -131,14 +131,14 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -151,14 +151,14 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -66,14 +66,14 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -86,14 +86,14 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -67,14 +67,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -87,14 +87,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -77,14 +77,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -104,14 +104,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(15)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             FoldSpecificField(FoldSpecificField(
               fold_eid: Eid(1),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(15)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             FoldSpecificField(FoldSpecificField(
               fold_eid: Eid(1),
@@ -196,14 +196,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
             Eid(2): [
               SerializableContext(
                 active_vertex: Some(Neither(NeitherNumber(1))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
                 imported_tags: {
@@ -231,14 +231,14 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
             Eid(2): [
               SerializableContext(
                 active_vertex: Some(Neither(NeitherNumber(1))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
                 imported_tags: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -76,14 +76,14 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -103,14 +103,14 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(15)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
           imported_tags: {
             FoldSpecificField(FoldSpecificField(
@@ -160,7 +160,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(15)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
           imported_tags: {
             FoldSpecificField(FoldSpecificField(
@@ -195,14 +195,14 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
             ],
             Eid(2): [
               SerializableContext(
-                current_token: Some(Neither(NeitherNumber(1))),
+                active_vertex: Some(Neither(NeitherNumber(1))),
                 tokens: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
@@ -230,14 +230,14 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
             ],
             Eid(2): [
               SerializableContext(
-                current_token: Some(Neither(NeitherNumber(1))),
+                active_vertex: Some(Neither(NeitherNumber(1))),
                 tokens: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(1), "Prime", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -159,7 +159,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
           imported_tags: {
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -45,14 +45,14 @@ TestInterpreterOutputTrace(
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -124,7 +124,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -113,7 +113,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -145,19 +145,19 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -185,19 +185,19 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,17 +109,17 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(5)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -146,19 +146,19 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -175,7 +175,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -186,19 +186,19 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -145,19 +145,19 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -170,7 +170,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -185,19 +185,19 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -109,17 +109,17 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(5)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -146,19 +146,19 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -175,7 +175,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -186,19 +186,19 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(17)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(17)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(17)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
           },
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(17)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
           },
@@ -149,7 +149,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
           },
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
             Vid(3): None,
           },

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -105,12 +105,12 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(2): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -160,7 +160,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -206,7 +206,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -223,7 +223,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -270,7 +270,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -372,7 +372,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(43)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -383,7 +383,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -412,7 +412,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(43)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -423,7 +423,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -45,12 +45,12 @@ TestInterpreterOutputTrace(
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "name")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "name")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "name")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "name")),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -176,7 +176,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -222,7 +222,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -259,7 +259,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
@@ -290,7 +290,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(43)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(2),
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(2),
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(2),
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
           imported_tags: {
             ContextField(ContextField(
               vertex_id: Vid(2),
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -386,7 +386,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -415,7 +415,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -426,7 +426,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
@@ -168,7 +168,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
           ],
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
           ],
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -332,7 +332,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -373,7 +373,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -390,7 +390,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -407,7 +407,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -474,7 +474,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -487,7 +487,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -516,7 +516,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -537,7 +537,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -554,7 +554,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -571,7 +571,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -588,7 +588,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -638,7 +638,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -651,7 +651,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -664,7 +664,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -701,7 +701,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -718,7 +718,7 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -735,7 +735,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -752,7 +752,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
@@ -817,7 +817,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         )),
       ),
@@ -825,7 +825,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(11))),
+          active_vertex: Some(Prime(PrimeNumber(11))),
           tokens: {},
         ), false)),
       ),
@@ -846,7 +846,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -857,7 +857,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -868,7 +868,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -884,7 +884,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -905,7 +905,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -914,7 +914,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
@@ -935,7 +935,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -944,7 +944,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
@@ -965,7 +965,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -977,7 +977,7 @@ TestInterpreterOutputTrace(
           ],
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
@@ -998,7 +998,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1010,7 +1010,7 @@ TestInterpreterOutputTrace(
           ],
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
@@ -1036,7 +1036,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1056,7 +1056,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1076,7 +1076,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1099,7 +1099,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1140,7 +1140,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1157,7 +1157,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1174,7 +1174,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1191,7 +1191,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1241,7 +1241,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1254,7 +1254,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1267,7 +1267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1283,7 +1283,7 @@ TestInterpreterOutputTrace(
         opid: Opid(109),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1304,7 +1304,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1321,7 +1321,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1338,7 +1338,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1355,7 +1355,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1405,7 +1405,7 @@ TestInterpreterOutputTrace(
         opid: Opid(121),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1418,7 +1418,7 @@ TestInterpreterOutputTrace(
         opid: Opid(122),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1431,7 +1431,7 @@ TestInterpreterOutputTrace(
         opid: Opid(123),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1447,7 +1447,7 @@ TestInterpreterOutputTrace(
         opid: Opid(124),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1468,7 +1468,7 @@ TestInterpreterOutputTrace(
         opid: Opid(126),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1485,7 +1485,7 @@ TestInterpreterOutputTrace(
         opid: Opid(127),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1502,7 +1502,7 @@ TestInterpreterOutputTrace(
         opid: Opid(128),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1519,7 +1519,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1571,7 +1571,7 @@ TestInterpreterOutputTrace(
         opid: Opid(136),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1586,7 +1586,7 @@ TestInterpreterOutputTrace(
         opid: Opid(137),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1601,7 +1601,7 @@ TestInterpreterOutputTrace(
         opid: Opid(138),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1616,7 +1616,7 @@ TestInterpreterOutputTrace(
         opid: Opid(139),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1636,7 +1636,7 @@ TestInterpreterOutputTrace(
         opid: Opid(141),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1655,7 +1655,7 @@ TestInterpreterOutputTrace(
         opid: Opid(142),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1674,7 +1674,7 @@ TestInterpreterOutputTrace(
         opid: Opid(143),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1695,7 +1695,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1734,7 +1734,7 @@ TestInterpreterOutputTrace(
         opid: Opid(148),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1751,7 +1751,7 @@ TestInterpreterOutputTrace(
         opid: Opid(149),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1768,7 +1768,7 @@ TestInterpreterOutputTrace(
         opid: Opid(150),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1785,7 +1785,7 @@ TestInterpreterOutputTrace(
         opid: Opid(151),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1825,7 +1825,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1842,7 +1842,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1859,7 +1859,7 @@ TestInterpreterOutputTrace(
         opid: Opid(158),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1876,7 +1876,7 @@ TestInterpreterOutputTrace(
         opid: Opid(159),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -1934,7 +1934,7 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1950,7 +1950,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1966,7 +1966,7 @@ TestInterpreterOutputTrace(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1982,7 +1982,7 @@ TestInterpreterOutputTrace(
         opid: Opid(170),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2003,7 +2003,7 @@ TestInterpreterOutputTrace(
         opid: Opid(172),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2023,7 +2023,7 @@ TestInterpreterOutputTrace(
         opid: Opid(173),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2043,7 +2043,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2066,7 +2066,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2107,7 +2107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(179),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2124,7 +2124,7 @@ TestInterpreterOutputTrace(
         opid: Opid(180),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2141,7 +2141,7 @@ TestInterpreterOutputTrace(
         opid: Opid(181),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -2158,7 +2158,7 @@ TestInterpreterOutputTrace(
         opid: Opid(182),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -2198,7 +2198,7 @@ TestInterpreterOutputTrace(
         opid: Opid(187),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2215,7 +2215,7 @@ TestInterpreterOutputTrace(
         opid: Opid(188),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2232,7 +2232,7 @@ TestInterpreterOutputTrace(
         opid: Opid(189),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -2249,7 +2249,7 @@ TestInterpreterOutputTrace(
         opid: Opid(190),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -2289,7 +2289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(195),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2306,7 +2306,7 @@ TestInterpreterOutputTrace(
         opid: Opid(196),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2323,7 +2323,7 @@ TestInterpreterOutputTrace(
         opid: Opid(197),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
@@ -2340,7 +2340,7 @@ TestInterpreterOutputTrace(
         opid: Opid(198),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(17): TraceOp(
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -199,7 +199,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -244,7 +244,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -293,7 +293,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -313,7 +313,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -336,7 +336,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -377,7 +377,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -394,7 +394,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -408,7 +408,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -425,7 +425,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -475,7 +475,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -488,7 +488,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -501,7 +501,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -517,7 +517,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -541,7 +541,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -558,7 +558,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -572,7 +572,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -589,7 +589,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -639,7 +639,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -652,7 +652,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -665,7 +665,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -681,7 +681,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -705,7 +705,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -722,7 +722,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -736,7 +736,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -753,7 +753,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -818,7 +818,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(76): TraceOp(
@@ -826,7 +826,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(77): TraceOp(
@@ -850,7 +850,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(80): TraceOp(
@@ -861,7 +861,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(81): TraceOp(
@@ -872,7 +872,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -888,7 +888,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -906,7 +906,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -915,7 +915,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -936,7 +936,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -945,7 +945,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -966,7 +966,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -978,7 +978,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -999,7 +999,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1011,7 +1011,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -1040,7 +1040,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1060,7 +1060,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1080,7 +1080,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1103,7 +1103,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1144,7 +1144,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1161,7 +1161,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1175,7 +1175,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1192,7 +1192,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1242,7 +1242,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1255,7 +1255,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1268,7 +1268,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1284,7 +1284,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1308,7 +1308,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1325,7 +1325,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1339,7 +1339,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1356,7 +1356,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1419,7 +1419,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1432,7 +1432,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1448,7 +1448,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1472,7 +1472,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1489,7 +1489,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1503,7 +1503,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1520,7 +1520,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1574,7 +1574,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1589,7 +1589,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1604,7 +1604,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1619,7 +1619,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1640,7 +1640,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1659,7 +1659,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1677,7 +1677,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1698,7 +1698,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1738,7 +1738,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1755,7 +1755,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1769,7 +1769,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1786,7 +1786,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1829,7 +1829,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1846,7 +1846,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1860,7 +1860,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1877,7 +1877,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1938,7 +1938,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1954,7 +1954,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1970,7 +1970,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1986,7 +1986,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2007,7 +2007,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2027,7 +2027,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2047,7 +2047,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2070,7 +2070,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2111,7 +2111,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2128,7 +2128,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2142,7 +2142,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2159,7 +2159,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2202,7 +2202,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2219,7 +2219,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2233,7 +2233,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2250,7 +2250,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2293,7 +2293,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2310,7 +2310,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2324,7 +2324,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2341,7 +2341,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
               2,
               3,

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
                   5,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
                   5,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Neither(NeitherNumber(1))),
           ],
           piggyback: Some([
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
                   5,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -238,7 +238,7 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Neither(NeitherNumber(1))),
           ],
           piggyback: Some([
@@ -250,7 +250,7 @@ TestInterpreterOutputTrace(
                   5,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(10, [
                   2,
                   5,
@@ -507,7 +507,7 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         )),
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         ))),
@@ -671,7 +671,7 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(5))),
           ],
         )),
@@ -687,7 +687,7 @@ TestInterpreterOutputTrace(
               5,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(5))),
           ],
         ))),
@@ -921,7 +921,7 @@ TestInterpreterOutputTrace(
                   3,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -951,7 +951,7 @@ TestInterpreterOutputTrace(
                   3,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -972,7 +972,7 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Neither(NeitherNumber(1))),
           ],
           piggyback: Some([
@@ -984,7 +984,7 @@ TestInterpreterOutputTrace(
                   3,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -1005,7 +1005,7 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Neither(NeitherNumber(1))),
           ],
           piggyback: Some([
@@ -1017,7 +1017,7 @@ TestInterpreterOutputTrace(
                   3,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(12, [
                   2,
                   3,
@@ -1274,7 +1274,7 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         )),
@@ -1290,7 +1290,7 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         ))),
@@ -1438,7 +1438,7 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         )),
@@ -1454,7 +1454,7 @@ TestInterpreterOutputTrace(
               3,
             ]))),
           },
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         ))),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
@@ -5,37 +5,37 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -167,7 +167,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -331,7 +331,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -389,7 +389,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -423,7 +423,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -468,7 +468,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -515,7 +515,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -553,7 +553,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -587,7 +587,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -632,7 +632,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(5)))),
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
@@ -650,7 +650,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -679,7 +679,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
       Opid(63): TraceOp(
         opid: Opid(63),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -751,7 +751,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(10, [
@@ -811,7 +811,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(11)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(11)))),
       ),
       Opid(75): TraceOp(
         opid: Opid(75),
@@ -824,7 +824,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(11))),
           vertices: {},
         ), false)),
@@ -837,7 +837,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -856,7 +856,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -883,7 +883,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -899,7 +899,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
@@ -934,7 +934,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -997,7 +997,7 @@ TestInterpreterOutputTrace(
       Opid(87): TraceOp(
         opid: Opid(87),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1055,7 +1055,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1098,7 +1098,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1156,7 +1156,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1190,7 +1190,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1235,7 +1235,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(106): TraceOp(
         opid: Opid(106),
@@ -1253,7 +1253,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1282,7 +1282,7 @@ TestInterpreterOutputTrace(
       Opid(109): TraceOp(
         opid: Opid(109),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1320,7 +1320,7 @@ TestInterpreterOutputTrace(
       Opid(112): TraceOp(
         opid: Opid(112),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1354,7 +1354,7 @@ TestInterpreterOutputTrace(
       Opid(114): TraceOp(
         opid: Opid(114),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1399,7 +1399,7 @@ TestInterpreterOutputTrace(
       Opid(120): TraceOp(
         opid: Opid(120),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(3)))),
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
@@ -1417,7 +1417,7 @@ TestInterpreterOutputTrace(
       Opid(122): TraceOp(
         opid: Opid(122),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1446,7 +1446,7 @@ TestInterpreterOutputTrace(
       Opid(124): TraceOp(
         opid: Opid(124),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1484,7 +1484,7 @@ TestInterpreterOutputTrace(
       Opid(127): TraceOp(
         opid: Opid(127),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1518,7 +1518,7 @@ TestInterpreterOutputTrace(
       Opid(129): TraceOp(
         opid: Opid(129),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1563,7 +1563,7 @@ TestInterpreterOutputTrace(
       Opid(135): TraceOp(
         opid: Opid(135),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1585,7 +1585,7 @@ TestInterpreterOutputTrace(
       Opid(137): TraceOp(
         opid: Opid(137),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1615,7 +1615,7 @@ TestInterpreterOutputTrace(
       Opid(139): TraceOp(
         opid: Opid(139),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1630,7 +1630,7 @@ TestInterpreterOutputTrace(
       Opid(140): TraceOp(
         opid: Opid(140),
         parent_opid: Some(Opid(139)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(141): TraceOp(
         opid: Opid(141),
@@ -1654,7 +1654,7 @@ TestInterpreterOutputTrace(
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1694,7 +1694,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1750,7 +1750,7 @@ TestInterpreterOutputTrace(
       Opid(149): TraceOp(
         opid: Opid(149),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1784,7 +1784,7 @@ TestInterpreterOutputTrace(
       Opid(151): TraceOp(
         opid: Opid(151),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1819,7 +1819,7 @@ TestInterpreterOutputTrace(
       Opid(155): TraceOp(
         opid: Opid(155),
         parent_opid: Some(Opid(139)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(156): TraceOp(
         opid: Opid(156),
@@ -1841,7 +1841,7 @@ TestInterpreterOutputTrace(
       Opid(157): TraceOp(
         opid: Opid(157),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1875,7 +1875,7 @@ TestInterpreterOutputTrace(
       Opid(159): TraceOp(
         opid: Opid(159),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -1925,7 +1925,7 @@ TestInterpreterOutputTrace(
       Opid(166): TraceOp(
         opid: Opid(166),
         parent_opid: Some(Opid(82)),
-        content: YieldFrom(ProjectNeighborsInner(4, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(4, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1949,7 +1949,7 @@ TestInterpreterOutputTrace(
       Opid(168): TraceOp(
         opid: Opid(168),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1981,7 +1981,7 @@ TestInterpreterOutputTrace(
       Opid(170): TraceOp(
         opid: Opid(170),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1997,7 +1997,7 @@ TestInterpreterOutputTrace(
       Opid(171): TraceOp(
         opid: Opid(171),
         parent_opid: Some(Opid(170)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(172): TraceOp(
         opid: Opid(172),
@@ -2022,7 +2022,7 @@ TestInterpreterOutputTrace(
       Opid(173): TraceOp(
         opid: Opid(173),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -2065,7 +2065,7 @@ TestInterpreterOutputTrace(
       Opid(175): TraceOp(
         opid: Opid(175),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2123,7 +2123,7 @@ TestInterpreterOutputTrace(
       Opid(180): TraceOp(
         opid: Opid(180),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -2157,7 +2157,7 @@ TestInterpreterOutputTrace(
       Opid(182): TraceOp(
         opid: Opid(182),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -2192,7 +2192,7 @@ TestInterpreterOutputTrace(
       Opid(186): TraceOp(
         opid: Opid(186),
         parent_opid: Some(Opid(170)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(187): TraceOp(
         opid: Opid(187),
@@ -2214,7 +2214,7 @@ TestInterpreterOutputTrace(
       Opid(188): TraceOp(
         opid: Opid(188),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -2248,7 +2248,7 @@ TestInterpreterOutputTrace(
       Opid(190): TraceOp(
         opid: Opid(190),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [
@@ -2283,7 +2283,7 @@ TestInterpreterOutputTrace(
       Opid(194): TraceOp(
         opid: Opid(194),
         parent_opid: Some(Opid(170)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(3)))),
       ),
       Opid(195): TraceOp(
         opid: Opid(195),
@@ -2305,7 +2305,7 @@ TestInterpreterOutputTrace(
       Opid(196): TraceOp(
         opid: Opid(196),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -2339,7 +2339,7 @@ TestInterpreterOutputTrace(
       Opid(198): TraceOp(
         opid: Opid(198),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(12, [

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(0))),
@@ -64,7 +64,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(1))),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(2))),
@@ -112,7 +112,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           values: [
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           values: [
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(2),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         )),
@@ -134,7 +134,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(2),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         ), Int64(1))),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
@@ -5,32 +5,32 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(4))),
@@ -114,7 +114,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(6))),
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -84,7 +84,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(13): TraceOp(
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -149,7 +149,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -164,7 +164,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -212,13 +212,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -251,13 +251,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -319,7 +319,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -335,7 +335,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -356,7 +356,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -372,7 +372,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -393,7 +393,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -409,7 +409,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -440,7 +440,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -450,13 +450,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -467,7 +467,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -479,7 +479,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -491,7 +491,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -533,13 +533,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
@@ -550,7 +550,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -562,7 +562,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -574,7 +574,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(18, [
                     2,
                     3,

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -59,7 +59,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -211,13 +211,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -237,7 +237,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -250,13 +250,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -315,7 +315,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(34)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -331,7 +331,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(34)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -352,7 +352,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(34)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -368,7 +368,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(34)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -389,7 +389,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(34)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -405,7 +405,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(34)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -436,7 +436,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -449,13 +449,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -463,7 +463,7 @@ TestInterpreterOutputTrace(
             ],
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -475,7 +475,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -487,7 +487,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -519,7 +519,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -532,13 +532,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
             ],
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -558,7 +558,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -570,7 +570,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(2))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -69,7 +69,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -112,12 +112,12 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -236,7 +236,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -283,7 +283,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
@@ -330,7 +330,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -367,7 +367,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -404,7 +404,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -518,7 +518,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -213,7 +213,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -261,7 +261,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -349,7 +349,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -413,7 +413,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -445,7 +445,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -464,7 +464,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -45,14 +45,14 @@ TestInterpreterOutputTrace(
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -60,14 +60,14 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsInner(4, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(4, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -88,12 +88,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "name")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "name")),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -274,7 +274,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -305,7 +305,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -348,7 +348,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -383,7 +383,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -463,7 +463,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -112,7 +112,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -236,7 +236,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -337,7 +337,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -353,7 +353,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -369,7 +369,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -417,7 +417,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -433,7 +433,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -449,7 +449,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -468,7 +468,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -75,14 +75,14 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -151,7 +151,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -224,7 +224,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -268,12 +268,12 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(25)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(28): TraceOp(
         opid: Opid(28),
@@ -283,7 +283,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
@@ -303,7 +303,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(3): Some(Neither(NeitherNumber(1))),
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(3): Some(Prime(PrimeNumber(2))),
@@ -415,7 +415,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -141,7 +141,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -228,7 +228,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -239,7 +239,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -295,7 +295,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -305,7 +305,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(1))),
@@ -320,7 +320,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -330,7 +330,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -357,7 +357,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -368,7 +368,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -378,7 +378,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -388,13 +388,13 @@ TestInterpreterOutputTrace(
             Eid(2): [
               SerializableContext(
                 active_vertex: Some(Neither(NeitherNumber(1))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -419,7 +419,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -430,7 +430,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -440,7 +440,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -450,13 +450,13 @@ TestInterpreterOutputTrace(
             Eid(2): [
               SerializableContext(
                 active_vertex: Some(Neither(NeitherNumber(1))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -225,7 +225,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -236,7 +236,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(3): Some(Neither(NeitherNumber(1))),
           },
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(3): Some(Neither(NeitherNumber(1))),
           },
@@ -319,7 +319,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(29)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(3): Some(Prime(PrimeNumber(2))),
           },
@@ -329,7 +329,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(29)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(3): Some(Prime(PrimeNumber(2))),
           },
@@ -354,7 +354,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -387,13 +387,13 @@ TestInterpreterOutputTrace(
             ],
             Eid(2): [
               SerializableContext(
-                current_token: Some(Neither(NeitherNumber(1))),
+                active_vertex: Some(Neither(NeitherNumber(1))),
                 tokens: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(3): Some(Prime(PrimeNumber(2))),
                 },
@@ -416,7 +416,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -427,7 +427,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -437,7 +437,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -449,13 +449,13 @@ TestInterpreterOutputTrace(
             ],
             Eid(2): [
               SerializableContext(
-                current_token: Some(Neither(NeitherNumber(1))),
+                active_vertex: Some(Neither(NeitherNumber(1))),
                 tokens: {
                   Vid(3): Some(Neither(NeitherNumber(1))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(3): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -187,7 +187,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -203,7 +203,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(20, [
               2,
               5,
@@ -225,7 +225,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -304,7 +304,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -360,7 +360,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -376,7 +376,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -416,7 +416,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -438,7 +438,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(45, [
               3,
               5,
@@ -454,7 +454,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(45, [
               3,
               5,
@@ -515,7 +515,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -528,7 +528,7 @@ TestInterpreterOutputTrace(
                   2,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(10, [
                     2,
                     5,
@@ -540,7 +540,7 @@ TestInterpreterOutputTrace(
                   2,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(20, [
                     2,
                     5,
@@ -553,7 +553,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(30, [
                     2,
                     3,
@@ -580,7 +580,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(10, [
               2,
               5,
@@ -593,7 +593,7 @@ TestInterpreterOutputTrace(
                   2,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(10, [
                     2,
                     5,
@@ -605,7 +605,7 @@ TestInterpreterOutputTrace(
                   2,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(20, [
                     2,
                     5,
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(30, [
                     2,
                     3,
@@ -650,7 +650,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -663,7 +663,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(15, [
                     3,
                     5,
@@ -676,7 +676,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(30, [
                     2,
                     3,
@@ -689,7 +689,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(45, [
                     3,
                     5,
@@ -715,7 +715,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(15, [
               3,
               5,
@@ -728,7 +728,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(15, [
                     3,
                     5,
@@ -741,7 +741,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(30, [
                     2,
                     3,
@@ -754,7 +754,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(45, [
                     3,
                     5,
@@ -792,7 +792,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           folded_contexts: {
@@ -802,7 +802,7 @@ TestInterpreterOutputTrace(
                   2,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(10, [
                     2,
                     5,
@@ -815,7 +815,7 @@ TestInterpreterOutputTrace(
                         2,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(10, [
                           2,
                           5,
@@ -827,7 +827,7 @@ TestInterpreterOutputTrace(
                         2,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(20, [
                           2,
                           5,
@@ -840,7 +840,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(30, [
                           2,
                           3,
@@ -863,7 +863,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(15, [
                     3,
                     5,
@@ -876,7 +876,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(15, [
                           3,
                           5,
@@ -889,7 +889,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(30, [
                           2,
                           3,
@@ -902,7 +902,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(45, [
                           3,
                           5,
@@ -946,7 +946,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           folded_contexts: {
@@ -956,7 +956,7 @@ TestInterpreterOutputTrace(
                   2,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(10, [
                     2,
                     5,
@@ -969,7 +969,7 @@ TestInterpreterOutputTrace(
                         2,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(10, [
                           2,
                           5,
@@ -981,7 +981,7 @@ TestInterpreterOutputTrace(
                         2,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(20, [
                           2,
                           5,
@@ -994,7 +994,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(30, [
                           2,
                           3,
@@ -1017,7 +1017,7 @@ TestInterpreterOutputTrace(
                   3,
                   5,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(15, [
                     3,
                     5,
@@ -1030,7 +1030,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(15, [
                           3,
                           5,
@@ -1043,7 +1043,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(30, [
                           2,
                           3,
@@ -1056,7 +1056,7 @@ TestInterpreterOutputTrace(
                         3,
                         5,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(45, [
                           3,
                           5,
@@ -1144,7 +1144,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1160,7 +1160,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1194,7 +1194,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1210,7 +1210,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1265,7 +1265,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1281,7 +1281,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1302,7 +1302,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1318,7 +1318,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1339,7 +1339,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1355,7 +1355,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1399,7 +1399,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1415,7 +1415,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1470,7 +1470,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1486,7 +1486,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1507,7 +1507,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(24, [
               2,
               3,
@@ -1523,7 +1523,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(24, [
               2,
               3,
@@ -1544,7 +1544,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(36, [
               2,
               3,
@@ -1560,7 +1560,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(36, [
               2,
               3,
@@ -1604,7 +1604,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1620,7 +1620,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1675,7 +1675,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1691,7 +1691,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -1712,7 +1712,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(36, [
               2,
               3,
@@ -1728,7 +1728,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(36, [
               2,
               3,
@@ -1749,7 +1749,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(54, [
               2,
               3,
@@ -1765,7 +1765,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(54, [
               2,
               3,
@@ -1826,7 +1826,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1839,7 +1839,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -1851,7 +1851,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -1863,7 +1863,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -1889,7 +1889,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1902,7 +1902,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -1914,7 +1914,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -1926,7 +1926,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -1957,7 +1957,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -1970,7 +1970,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -1982,7 +1982,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(24, [
                     2,
                     3,
@@ -1994,7 +1994,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(36, [
                     2,
                     3,
@@ -2020,7 +2020,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(12, [
               2,
               3,
@@ -2033,7 +2033,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -2045,7 +2045,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(24, [
                     2,
                     3,
@@ -2057,7 +2057,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(36, [
                     2,
                     3,
@@ -2088,7 +2088,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -2101,7 +2101,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -2113,7 +2113,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(36, [
                     2,
                     3,
@@ -2125,7 +2125,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(54, [
                     2,
                     3,
@@ -2151,7 +2151,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(18, [
               2,
               3,
@@ -2164,7 +2164,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -2176,7 +2176,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(36, [
                     2,
                     3,
@@ -2188,7 +2188,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(54, [
                     2,
                     3,
@@ -2229,7 +2229,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -2242,7 +2242,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -2255,7 +2255,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(6, [
                           2,
                           3,
@@ -2267,7 +2267,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(12, [
                           2,
                           3,
@@ -2279,7 +2279,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(18, [
                           2,
                           3,
@@ -2301,7 +2301,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -2314,7 +2314,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(12, [
                           2,
                           3,
@@ -2326,7 +2326,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(24, [
                           2,
                           3,
@@ -2338,7 +2338,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(36, [
                           2,
                           3,
@@ -2360,7 +2360,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -2373,7 +2373,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(18, [
                           2,
                           3,
@@ -2385,7 +2385,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(36, [
                           2,
                           3,
@@ -2397,7 +2397,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(54, [
                           2,
                           3,
@@ -2450,7 +2450,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -2463,7 +2463,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -2476,7 +2476,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(6, [
                           2,
                           3,
@@ -2488,7 +2488,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(12, [
                           2,
                           3,
@@ -2500,7 +2500,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(18, [
                           2,
                           3,
@@ -2522,7 +2522,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(12, [
                     2,
                     3,
@@ -2535,7 +2535,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(12, [
                           2,
                           3,
@@ -2547,7 +2547,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(24, [
                           2,
                           3,
@@ -2559,7 +2559,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(36, [
                           2,
                           3,
@@ -2581,7 +2581,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(18, [
                     2,
                     3,
@@ -2594,7 +2594,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(18, [
                           2,
                           3,
@@ -2606,7 +2606,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(36, [
                           2,
                           3,
@@ -2618,7 +2618,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(54, [
                           2,
                           3,
@@ -2712,7 +2712,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -2722,7 +2722,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         ))),
@@ -2753,7 +2753,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -2769,7 +2769,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -2825,7 +2825,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -2841,7 +2841,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -2862,7 +2862,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(28, [
               2,
               7,
@@ -2878,7 +2878,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(28, [
               2,
               7,
@@ -2900,7 +2900,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(42, [
               2,
               3,
@@ -2918,7 +2918,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(42, [
               2,
               3,
@@ -2963,7 +2963,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(21, [
               3,
               7,
@@ -2979,7 +2979,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(21, [
               3,
               7,
@@ -3035,7 +3035,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(21, [
               3,
               7,
@@ -3051,7 +3051,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(21, [
               3,
               7,
@@ -3073,7 +3073,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(42, [
               2,
               3,
@@ -3091,7 +3091,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(42, [
               2,
               3,
@@ -3113,7 +3113,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(63, [
               3,
               7,
@@ -3129,7 +3129,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(63, [
               3,
               7,
@@ -3190,7 +3190,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -3203,7 +3203,7 @@ TestInterpreterOutputTrace(
                   2,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(14, [
                     2,
                     7,
@@ -3215,7 +3215,7 @@ TestInterpreterOutputTrace(
                   2,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(28, [
                     2,
                     7,
@@ -3228,7 +3228,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(42, [
                     2,
                     3,
@@ -3255,7 +3255,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(14, [
               2,
               7,
@@ -3268,7 +3268,7 @@ TestInterpreterOutputTrace(
                   2,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(14, [
                     2,
                     7,
@@ -3280,7 +3280,7 @@ TestInterpreterOutputTrace(
                   2,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(28, [
                     2,
                     7,
@@ -3293,7 +3293,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(42, [
                     2,
                     3,
@@ -3325,7 +3325,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(21, [
               3,
               7,
@@ -3338,7 +3338,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(21, [
                     3,
                     7,
@@ -3351,7 +3351,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(42, [
                     2,
                     3,
@@ -3364,7 +3364,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(63, [
                     3,
                     7,
@@ -3390,7 +3390,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(21, [
               3,
               7,
@@ -3403,7 +3403,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(21, [
                     3,
                     7,
@@ -3416,7 +3416,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(42, [
                     2,
                     3,
@@ -3429,7 +3429,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(63, [
                     3,
                     7,
@@ -3467,7 +3467,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
           folded_contexts: {
@@ -3477,7 +3477,7 @@ TestInterpreterOutputTrace(
                   2,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(14, [
                     2,
                     7,
@@ -3490,7 +3490,7 @@ TestInterpreterOutputTrace(
                         2,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(14, [
                           2,
                           7,
@@ -3502,7 +3502,7 @@ TestInterpreterOutputTrace(
                         2,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(28, [
                           2,
                           7,
@@ -3515,7 +3515,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(42, [
                           2,
                           3,
@@ -3538,7 +3538,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(21, [
                     3,
                     7,
@@ -3551,7 +3551,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(21, [
                           3,
                           7,
@@ -3564,7 +3564,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(42, [
                           2,
                           3,
@@ -3577,7 +3577,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(63, [
                           3,
                           7,
@@ -3621,7 +3621,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
           folded_contexts: {
@@ -3631,7 +3631,7 @@ TestInterpreterOutputTrace(
                   2,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(14, [
                     2,
                     7,
@@ -3644,7 +3644,7 @@ TestInterpreterOutputTrace(
                         2,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(14, [
                           2,
                           7,
@@ -3656,7 +3656,7 @@ TestInterpreterOutputTrace(
                         2,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(28, [
                           2,
                           7,
@@ -3669,7 +3669,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(42, [
                           2,
                           3,
@@ -3692,7 +3692,7 @@ TestInterpreterOutputTrace(
                   3,
                   7,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(21, [
                     3,
                     7,
@@ -3705,7 +3705,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(21, [
                           3,
                           7,
@@ -3718,7 +3718,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(42, [
                           2,
                           3,
@@ -3731,7 +3731,7 @@ TestInterpreterOutputTrace(
                         3,
                         7,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(63, [
                           3,
                           7,

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -199,7 +199,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(20, [
+          active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
           ]))),
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(18)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -238,7 +238,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(18)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -284,7 +284,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -300,7 +300,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -356,7 +356,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(39)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -372,7 +372,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(39)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -393,7 +393,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(39)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(39)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -434,7 +434,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(39)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(45, [
+          active_vertex: Some(Composite(CompositeNumber(45, [
             3,
             5,
           ]))),
@@ -450,7 +450,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(39)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(45, [
+          active_vertex: Some(Composite(CompositeNumber(45, [
             3,
             5,
           ]))),
@@ -511,7 +511,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(56)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -524,7 +524,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(10, [
+                active_vertex: Some(Composite(CompositeNumber(10, [
                   2,
                   5,
                 ]))),
@@ -536,7 +536,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(20, [
+                active_vertex: Some(Composite(CompositeNumber(20, [
                   2,
                   5,
                 ]))),
@@ -548,7 +548,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(30, [
+                active_vertex: Some(Composite(CompositeNumber(30, [
                   2,
                   3,
                   5,
@@ -576,7 +576,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(56)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -589,7 +589,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(10, [
+                active_vertex: Some(Composite(CompositeNumber(10, [
                   2,
                   5,
                 ]))),
@@ -601,7 +601,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(20, [
+                active_vertex: Some(Composite(CompositeNumber(20, [
                   2,
                   5,
                 ]))),
@@ -613,7 +613,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(30, [
+                active_vertex: Some(Composite(CompositeNumber(30, [
                   2,
                   3,
                   5,
@@ -646,7 +646,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(56)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -659,7 +659,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(15, [
+                active_vertex: Some(Composite(CompositeNumber(15, [
                   3,
                   5,
                 ]))),
@@ -671,7 +671,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(30, [
+                active_vertex: Some(Composite(CompositeNumber(30, [
                   2,
                   3,
                   5,
@@ -685,7 +685,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(45, [
+                active_vertex: Some(Composite(CompositeNumber(45, [
                   3,
                   5,
                 ]))),
@@ -711,7 +711,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(56)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -724,7 +724,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(15, [
+                active_vertex: Some(Composite(CompositeNumber(15, [
                   3,
                   5,
                 ]))),
@@ -736,7 +736,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(30, [
+                active_vertex: Some(Composite(CompositeNumber(30, [
                   2,
                   3,
                   5,
@@ -750,7 +750,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(45, [
+                active_vertex: Some(Composite(CompositeNumber(45, [
                   3,
                   5,
                 ]))),
@@ -791,14 +791,14 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(10, [
+                active_vertex: Some(Composite(CompositeNumber(10, [
                   2,
                   5,
                 ]))),
@@ -811,7 +811,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(10, [
+                      active_vertex: Some(Composite(CompositeNumber(10, [
                         2,
                         5,
                       ]))),
@@ -823,7 +823,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(20, [
+                      active_vertex: Some(Composite(CompositeNumber(20, [
                         2,
                         5,
                       ]))),
@@ -835,7 +835,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(30, [
+                      active_vertex: Some(Composite(CompositeNumber(30, [
                         2,
                         3,
                         5,
@@ -859,7 +859,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(15, [
+                active_vertex: Some(Composite(CompositeNumber(15, [
                   3,
                   5,
                 ]))),
@@ -872,7 +872,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(15, [
+                      active_vertex: Some(Composite(CompositeNumber(15, [
                         3,
                         5,
                       ]))),
@@ -884,7 +884,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(30, [
+                      active_vertex: Some(Composite(CompositeNumber(30, [
                         2,
                         3,
                         5,
@@ -898,7 +898,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(45, [
+                      active_vertex: Some(Composite(CompositeNumber(45, [
                         3,
                         5,
                       ]))),
@@ -945,14 +945,14 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(10, [
+                active_vertex: Some(Composite(CompositeNumber(10, [
                   2,
                   5,
                 ]))),
@@ -965,7 +965,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(10, [
+                      active_vertex: Some(Composite(CompositeNumber(10, [
                         2,
                         5,
                       ]))),
@@ -977,7 +977,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(20, [
+                      active_vertex: Some(Composite(CompositeNumber(20, [
                         2,
                         5,
                       ]))),
@@ -989,7 +989,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(30, [
+                      active_vertex: Some(Composite(CompositeNumber(30, [
                         2,
                         3,
                         5,
@@ -1013,7 +1013,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(15, [
+                active_vertex: Some(Composite(CompositeNumber(15, [
                   3,
                   5,
                 ]))),
@@ -1026,7 +1026,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(15, [
+                      active_vertex: Some(Composite(CompositeNumber(15, [
                         3,
                         5,
                       ]))),
@@ -1038,7 +1038,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(30, [
+                      active_vertex: Some(Composite(CompositeNumber(30, [
                         2,
                         3,
                         5,
@@ -1052,7 +1052,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(45, [
+                      active_vertex: Some(Composite(CompositeNumber(45, [
                         3,
                         5,
                       ]))),
@@ -1140,7 +1140,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1156,7 +1156,7 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1190,7 +1190,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(74)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1206,7 +1206,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(74)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1261,7 +1261,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(83)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1277,7 +1277,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(83)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1298,7 +1298,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(83)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1314,7 +1314,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(83)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1335,7 +1335,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(83)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1351,7 +1351,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(83)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1395,7 +1395,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(74)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1411,7 +1411,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(74)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1466,7 +1466,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(104)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1482,7 +1482,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(104)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1503,7 +1503,7 @@ TestInterpreterOutputTrace(
         opid: Opid(109),
         parent_opid: Some(Opid(104)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -1519,7 +1519,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(104)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -1540,7 +1540,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(104)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -1556,7 +1556,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(104)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -1600,7 +1600,7 @@ TestInterpreterOutputTrace(
         opid: Opid(119),
         parent_opid: Some(Opid(74)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1616,7 +1616,7 @@ TestInterpreterOutputTrace(
         opid: Opid(120),
         parent_opid: Some(Opid(74)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1671,7 +1671,7 @@ TestInterpreterOutputTrace(
         opid: Opid(127),
         parent_opid: Some(Opid(125)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1687,7 +1687,7 @@ TestInterpreterOutputTrace(
         opid: Opid(128),
         parent_opid: Some(Opid(125)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1708,7 +1708,7 @@ TestInterpreterOutputTrace(
         opid: Opid(130),
         parent_opid: Some(Opid(125)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -1724,7 +1724,7 @@ TestInterpreterOutputTrace(
         opid: Opid(131),
         parent_opid: Some(Opid(125)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(36, [
+          active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
           ]))),
@@ -1745,7 +1745,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(125)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(54, [
+          active_vertex: Some(Composite(CompositeNumber(54, [
             2,
             3,
           ]))),
@@ -1761,7 +1761,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(125)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(54, [
+          active_vertex: Some(Composite(CompositeNumber(54, [
             2,
             3,
           ]))),
@@ -1822,7 +1822,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(142)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1835,7 +1835,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -1847,7 +1847,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -1859,7 +1859,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -1885,7 +1885,7 @@ TestInterpreterOutputTrace(
         opid: Opid(145),
         parent_opid: Some(Opid(142)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1898,7 +1898,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -1910,7 +1910,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -1922,7 +1922,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -1953,7 +1953,7 @@ TestInterpreterOutputTrace(
         opid: Opid(147),
         parent_opid: Some(Opid(142)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1966,7 +1966,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -1978,7 +1978,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(24, [
+                active_vertex: Some(Composite(CompositeNumber(24, [
                   2,
                   3,
                 ]))),
@@ -1990,7 +1990,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(36, [
+                active_vertex: Some(Composite(CompositeNumber(36, [
                   2,
                   3,
                 ]))),
@@ -2016,7 +2016,7 @@ TestInterpreterOutputTrace(
         opid: Opid(148),
         parent_opid: Some(Opid(142)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2029,7 +2029,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -2041,7 +2041,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(24, [
+                active_vertex: Some(Composite(CompositeNumber(24, [
                   2,
                   3,
                 ]))),
@@ -2053,7 +2053,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(36, [
+                active_vertex: Some(Composite(CompositeNumber(36, [
                   2,
                   3,
                 ]))),
@@ -2084,7 +2084,7 @@ TestInterpreterOutputTrace(
         opid: Opid(150),
         parent_opid: Some(Opid(142)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -2097,7 +2097,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -2109,7 +2109,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(36, [
+                active_vertex: Some(Composite(CompositeNumber(36, [
                   2,
                   3,
                 ]))),
@@ -2121,7 +2121,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(54, [
+                active_vertex: Some(Composite(CompositeNumber(54, [
                   2,
                   3,
                 ]))),
@@ -2147,7 +2147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(151),
         parent_opid: Some(Opid(142)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -2160,7 +2160,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -2172,7 +2172,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(36, [
+                active_vertex: Some(Composite(CompositeNumber(36, [
                   2,
                   3,
                 ]))),
@@ -2184,7 +2184,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(54, [
+                active_vertex: Some(Composite(CompositeNumber(54, [
                   2,
                   3,
                 ]))),
@@ -2225,7 +2225,7 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2238,7 +2238,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -2251,7 +2251,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(6, [
+                      active_vertex: Some(Composite(CompositeNumber(6, [
                         2,
                         3,
                       ]))),
@@ -2263,7 +2263,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(12, [
+                      active_vertex: Some(Composite(CompositeNumber(12, [
                         2,
                         3,
                       ]))),
@@ -2275,7 +2275,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(18, [
+                      active_vertex: Some(Composite(CompositeNumber(18, [
                         2,
                         3,
                       ]))),
@@ -2297,7 +2297,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -2310,7 +2310,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(12, [
+                      active_vertex: Some(Composite(CompositeNumber(12, [
                         2,
                         3,
                       ]))),
@@ -2322,7 +2322,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(24, [
+                      active_vertex: Some(Composite(CompositeNumber(24, [
                         2,
                         3,
                       ]))),
@@ -2334,7 +2334,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(36, [
+                      active_vertex: Some(Composite(CompositeNumber(36, [
                         2,
                         3,
                       ]))),
@@ -2356,7 +2356,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -2369,7 +2369,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(18, [
+                      active_vertex: Some(Composite(CompositeNumber(18, [
                         2,
                         3,
                       ]))),
@@ -2381,7 +2381,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(36, [
+                      active_vertex: Some(Composite(CompositeNumber(36, [
                         2,
                         3,
                       ]))),
@@ -2393,7 +2393,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(54, [
+                      active_vertex: Some(Composite(CompositeNumber(54, [
                         2,
                         3,
                       ]))),
@@ -2446,7 +2446,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2459,7 +2459,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -2472,7 +2472,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(6, [
+                      active_vertex: Some(Composite(CompositeNumber(6, [
                         2,
                         3,
                       ]))),
@@ -2484,7 +2484,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(12, [
+                      active_vertex: Some(Composite(CompositeNumber(12, [
                         2,
                         3,
                       ]))),
@@ -2496,7 +2496,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(18, [
+                      active_vertex: Some(Composite(CompositeNumber(18, [
                         2,
                         3,
                       ]))),
@@ -2518,7 +2518,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(12, [
+                active_vertex: Some(Composite(CompositeNumber(12, [
                   2,
                   3,
                 ]))),
@@ -2531,7 +2531,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(12, [
+                      active_vertex: Some(Composite(CompositeNumber(12, [
                         2,
                         3,
                       ]))),
@@ -2543,7 +2543,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(24, [
+                      active_vertex: Some(Composite(CompositeNumber(24, [
                         2,
                         3,
                       ]))),
@@ -2555,7 +2555,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(36, [
+                      active_vertex: Some(Composite(CompositeNumber(36, [
                         2,
                         3,
                       ]))),
@@ -2577,7 +2577,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(18, [
+                active_vertex: Some(Composite(CompositeNumber(18, [
                   2,
                   3,
                 ]))),
@@ -2590,7 +2590,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(18, [
+                      active_vertex: Some(Composite(CompositeNumber(18, [
                         2,
                         3,
                       ]))),
@@ -2602,7 +2602,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(36, [
+                      active_vertex: Some(Composite(CompositeNumber(36, [
                         2,
                         3,
                       ]))),
@@ -2614,7 +2614,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(54, [
+                      active_vertex: Some(Composite(CompositeNumber(54, [
                         2,
                         3,
                       ]))),
@@ -2711,7 +2711,7 @@ TestInterpreterOutputTrace(
         opid: Opid(161),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -2721,7 +2721,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -2749,7 +2749,7 @@ TestInterpreterOutputTrace(
         opid: Opid(166),
         parent_opid: Some(Opid(163)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -2765,7 +2765,7 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(163)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -2821,7 +2821,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -2837,7 +2837,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -2858,7 +2858,7 @@ TestInterpreterOutputTrace(
         opid: Opid(177),
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -2874,7 +2874,7 @@ TestInterpreterOutputTrace(
         opid: Opid(178),
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -2895,7 +2895,7 @@ TestInterpreterOutputTrace(
         opid: Opid(180),
         parent_opid: Some(Opid(172)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(42, [
+          active_vertex: Some(Composite(CompositeNumber(42, [
             2,
             3,
             7,
@@ -2913,7 +2913,7 @@ TestInterpreterOutputTrace(
         opid: Opid(181),
         parent_opid: Some(Opid(172)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(42, [
+          active_vertex: Some(Composite(CompositeNumber(42, [
             2,
             3,
             7,
@@ -2959,7 +2959,7 @@ TestInterpreterOutputTrace(
         opid: Opid(187),
         parent_opid: Some(Opid(163)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -2975,7 +2975,7 @@ TestInterpreterOutputTrace(
         opid: Opid(188),
         parent_opid: Some(Opid(163)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3031,7 +3031,7 @@ TestInterpreterOutputTrace(
         opid: Opid(195),
         parent_opid: Some(Opid(193)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3047,7 +3047,7 @@ TestInterpreterOutputTrace(
         opid: Opid(196),
         parent_opid: Some(Opid(193)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3068,7 +3068,7 @@ TestInterpreterOutputTrace(
         opid: Opid(198),
         parent_opid: Some(Opid(193)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(42, [
+          active_vertex: Some(Composite(CompositeNumber(42, [
             2,
             3,
             7,
@@ -3086,7 +3086,7 @@ TestInterpreterOutputTrace(
         opid: Opid(199),
         parent_opid: Some(Opid(193)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(42, [
+          active_vertex: Some(Composite(CompositeNumber(42, [
             2,
             3,
             7,
@@ -3109,7 +3109,7 @@ TestInterpreterOutputTrace(
         opid: Opid(201),
         parent_opid: Some(Opid(193)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(63, [
+          active_vertex: Some(Composite(CompositeNumber(63, [
             3,
             7,
           ]))),
@@ -3125,7 +3125,7 @@ TestInterpreterOutputTrace(
         opid: Opid(202),
         parent_opid: Some(Opid(193)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(63, [
+          active_vertex: Some(Composite(CompositeNumber(63, [
             3,
             7,
           ]))),
@@ -3186,7 +3186,7 @@ TestInterpreterOutputTrace(
         opid: Opid(212),
         parent_opid: Some(Opid(210)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -3199,7 +3199,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(14, [
+                active_vertex: Some(Composite(CompositeNumber(14, [
                   2,
                   7,
                 ]))),
@@ -3211,7 +3211,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(28, [
+                active_vertex: Some(Composite(CompositeNumber(28, [
                   2,
                   7,
                 ]))),
@@ -3223,7 +3223,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(42, [
+                active_vertex: Some(Composite(CompositeNumber(42, [
                   2,
                   3,
                   7,
@@ -3251,7 +3251,7 @@ TestInterpreterOutputTrace(
         opid: Opid(213),
         parent_opid: Some(Opid(210)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -3264,7 +3264,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(14, [
+                active_vertex: Some(Composite(CompositeNumber(14, [
                   2,
                   7,
                 ]))),
@@ -3276,7 +3276,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(28, [
+                active_vertex: Some(Composite(CompositeNumber(28, [
                   2,
                   7,
                 ]))),
@@ -3288,7 +3288,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(42, [
+                active_vertex: Some(Composite(CompositeNumber(42, [
                   2,
                   3,
                   7,
@@ -3321,7 +3321,7 @@ TestInterpreterOutputTrace(
         opid: Opid(215),
         parent_opid: Some(Opid(210)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3334,7 +3334,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(21, [
+                active_vertex: Some(Composite(CompositeNumber(21, [
                   3,
                   7,
                 ]))),
@@ -3346,7 +3346,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(42, [
+                active_vertex: Some(Composite(CompositeNumber(42, [
                   2,
                   3,
                   7,
@@ -3360,7 +3360,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(63, [
+                active_vertex: Some(Composite(CompositeNumber(63, [
                   3,
                   7,
                 ]))),
@@ -3386,7 +3386,7 @@ TestInterpreterOutputTrace(
         opid: Opid(216),
         parent_opid: Some(Opid(210)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3399,7 +3399,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(21, [
+                active_vertex: Some(Composite(CompositeNumber(21, [
                   3,
                   7,
                 ]))),
@@ -3411,7 +3411,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(42, [
+                active_vertex: Some(Composite(CompositeNumber(42, [
                   2,
                   3,
                   7,
@@ -3425,7 +3425,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(63, [
+                active_vertex: Some(Composite(CompositeNumber(63, [
                   3,
                   7,
                 ]))),
@@ -3466,14 +3466,14 @@ TestInterpreterOutputTrace(
         opid: Opid(220),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(14, [
+                active_vertex: Some(Composite(CompositeNumber(14, [
                   2,
                   7,
                 ]))),
@@ -3486,7 +3486,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(14, [
+                      active_vertex: Some(Composite(CompositeNumber(14, [
                         2,
                         7,
                       ]))),
@@ -3498,7 +3498,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(28, [
+                      active_vertex: Some(Composite(CompositeNumber(28, [
                         2,
                         7,
                       ]))),
@@ -3510,7 +3510,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(42, [
+                      active_vertex: Some(Composite(CompositeNumber(42, [
                         2,
                         3,
                         7,
@@ -3534,7 +3534,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(21, [
+                active_vertex: Some(Composite(CompositeNumber(21, [
                   3,
                   7,
                 ]))),
@@ -3547,7 +3547,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(21, [
+                      active_vertex: Some(Composite(CompositeNumber(21, [
                         3,
                         7,
                       ]))),
@@ -3559,7 +3559,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(42, [
+                      active_vertex: Some(Composite(CompositeNumber(42, [
                         2,
                         3,
                         7,
@@ -3573,7 +3573,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(63, [
+                      active_vertex: Some(Composite(CompositeNumber(63, [
                         3,
                         7,
                       ]))),
@@ -3620,14 +3620,14 @@ TestInterpreterOutputTrace(
         opid: Opid(221),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(14, [
+                active_vertex: Some(Composite(CompositeNumber(14, [
                   2,
                   7,
                 ]))),
@@ -3640,7 +3640,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(14, [
+                      active_vertex: Some(Composite(CompositeNumber(14, [
                         2,
                         7,
                       ]))),
@@ -3652,7 +3652,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(28, [
+                      active_vertex: Some(Composite(CompositeNumber(28, [
                         2,
                         7,
                       ]))),
@@ -3664,7 +3664,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(42, [
+                      active_vertex: Some(Composite(CompositeNumber(42, [
                         2,
                         3,
                         7,
@@ -3688,7 +3688,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(21, [
+                active_vertex: Some(Composite(CompositeNumber(21, [
                   3,
                   7,
                 ]))),
@@ -3701,7 +3701,7 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(21, [
+                      active_vertex: Some(Composite(CompositeNumber(21, [
                         3,
                         7,
                       ]))),
@@ -3713,7 +3713,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(42, [
+                      active_vertex: Some(Composite(CompositeNumber(42, [
                         2,
                         3,
                         7,
@@ -3727,7 +3727,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(63, [
+                      active_vertex: Some(Composite(CompositeNumber(63, [
                         3,
                         7,
                       ]))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(9)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -113,7 +113,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(20, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(20, [
           2,
           5,
         ])))),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(20, [
             2,
             5,
@@ -237,7 +237,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(9)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -315,7 +315,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -332,7 +332,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(45, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(45, [
           3,
           5,
         ])))),
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(40): TraceOp(
         opid: Opid(40),
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -410,7 +410,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -449,7 +449,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(45, [
             3,
             5,
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
@@ -575,7 +575,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(56)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -710,7 +710,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(56)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -944,7 +944,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1131,7 +1131,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1155,7 +1155,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1171,7 +1171,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(75): TraceOp(
         opid: Opid(75),
@@ -1181,7 +1181,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1205,7 +1205,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(74)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1221,7 +1221,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(78)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1229,7 +1229,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(78)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -1237,7 +1237,7 @@ TestInterpreterOutputTrace(
       Opid(81): TraceOp(
         opid: Opid(81),
         parent_opid: Some(Opid(78)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -1250,7 +1250,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(84): TraceOp(
         opid: Opid(84),
@@ -1276,7 +1276,7 @@ TestInterpreterOutputTrace(
       Opid(86): TraceOp(
         opid: Opid(86),
         parent_opid: Some(Opid(83)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1313,7 +1313,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: Some(Opid(83)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1350,7 +1350,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(83)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1386,7 +1386,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -1410,7 +1410,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(74)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1426,7 +1426,7 @@ TestInterpreterOutputTrace(
       Opid(100): TraceOp(
         opid: Opid(100),
         parent_opid: Some(Opid(99)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -1434,7 +1434,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(99)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(24, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(24, [
           2,
           3,
         ])))),
@@ -1442,7 +1442,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(99)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(36, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(36, [
           2,
           3,
         ])))),
@@ -1455,7 +1455,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(105): TraceOp(
         opid: Opid(105),
@@ -1481,7 +1481,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1518,7 +1518,7 @@ TestInterpreterOutputTrace(
       Opid(110): TraceOp(
         opid: Opid(110),
         parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
@@ -1555,7 +1555,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
@@ -1591,7 +1591,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -1615,7 +1615,7 @@ TestInterpreterOutputTrace(
       Opid(120): TraceOp(
         opid: Opid(120),
         parent_opid: Some(Opid(74)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1631,7 +1631,7 @@ TestInterpreterOutputTrace(
       Opid(121): TraceOp(
         opid: Opid(121),
         parent_opid: Some(Opid(120)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -1639,7 +1639,7 @@ TestInterpreterOutputTrace(
       Opid(122): TraceOp(
         opid: Opid(122),
         parent_opid: Some(Opid(120)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(36, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(36, [
           2,
           3,
         ])))),
@@ -1647,7 +1647,7 @@ TestInterpreterOutputTrace(
       Opid(123): TraceOp(
         opid: Opid(123),
         parent_opid: Some(Opid(120)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(54, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(54, [
           2,
           3,
         ])))),
@@ -1660,7 +1660,7 @@ TestInterpreterOutputTrace(
       Opid(125): TraceOp(
         opid: Opid(125),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(126): TraceOp(
         opid: Opid(126),
@@ -1686,7 +1686,7 @@ TestInterpreterOutputTrace(
       Opid(128): TraceOp(
         opid: Opid(128),
         parent_opid: Some(Opid(125)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1723,7 +1723,7 @@ TestInterpreterOutputTrace(
       Opid(131): TraceOp(
         opid: Opid(131),
         parent_opid: Some(Opid(125)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(36, [
             2,
             3,
@@ -1760,7 +1760,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(125)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(54, [
             2,
             3,
@@ -1811,7 +1811,7 @@ TestInterpreterOutputTrace(
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(143): TraceOp(
         opid: Opid(143),
@@ -1884,7 +1884,7 @@ TestInterpreterOutputTrace(
       Opid(145): TraceOp(
         opid: Opid(145),
         parent_opid: Some(Opid(142)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2015,7 +2015,7 @@ TestInterpreterOutputTrace(
       Opid(148): TraceOp(
         opid: Opid(148),
         parent_opid: Some(Opid(142)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -2146,7 +2146,7 @@ TestInterpreterOutputTrace(
       Opid(151): TraceOp(
         opid: Opid(151),
         parent_opid: Some(Opid(142)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -2445,7 +2445,7 @@ TestInterpreterOutputTrace(
       Opid(156): TraceOp(
         opid: Opid(156),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2705,7 +2705,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(7)))),
       ),
       Opid(161): TraceOp(
         opid: Opid(161),
@@ -2720,7 +2720,7 @@ TestInterpreterOutputTrace(
       Opid(162): TraceOp(
         opid: Opid(162),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
@@ -2730,7 +2730,7 @@ TestInterpreterOutputTrace(
       Opid(163): TraceOp(
         opid: Opid(163),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(164): TraceOp(
         opid: Opid(164),
@@ -2740,7 +2740,7 @@ TestInterpreterOutputTrace(
       Opid(165): TraceOp(
         opid: Opid(165),
         parent_opid: Some(Opid(162)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -2764,7 +2764,7 @@ TestInterpreterOutputTrace(
       Opid(167): TraceOp(
         opid: Opid(167),
         parent_opid: Some(Opid(163)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -2780,7 +2780,7 @@ TestInterpreterOutputTrace(
       Opid(168): TraceOp(
         opid: Opid(168),
         parent_opid: Some(Opid(167)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -2788,7 +2788,7 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(167)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(28, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(28, [
           2,
           7,
         ])))),
@@ -2796,7 +2796,7 @@ TestInterpreterOutputTrace(
       Opid(170): TraceOp(
         opid: Opid(170),
         parent_opid: Some(Opid(167)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(42, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(42, [
           2,
           3,
           7,
@@ -2810,7 +2810,7 @@ TestInterpreterOutputTrace(
       Opid(172): TraceOp(
         opid: Opid(172),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(173): TraceOp(
         opid: Opid(173),
@@ -2836,7 +2836,7 @@ TestInterpreterOutputTrace(
       Opid(175): TraceOp(
         opid: Opid(175),
         parent_opid: Some(Opid(172)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -2873,7 +2873,7 @@ TestInterpreterOutputTrace(
       Opid(178): TraceOp(
         opid: Opid(178),
         parent_opid: Some(Opid(172)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
@@ -2912,7 +2912,7 @@ TestInterpreterOutputTrace(
       Opid(181): TraceOp(
         opid: Opid(181),
         parent_opid: Some(Opid(172)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(42, [
             2,
             3,
@@ -2950,7 +2950,7 @@ TestInterpreterOutputTrace(
       Opid(186): TraceOp(
         opid: Opid(186),
         parent_opid: Some(Opid(162)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(21, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(21, [
           3,
           7,
         ])))),
@@ -2974,7 +2974,7 @@ TestInterpreterOutputTrace(
       Opid(188): TraceOp(
         opid: Opid(188),
         parent_opid: Some(Opid(163)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
@@ -2990,7 +2990,7 @@ TestInterpreterOutputTrace(
       Opid(189): TraceOp(
         opid: Opid(189),
         parent_opid: Some(Opid(188)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(21, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(21, [
           3,
           7,
         ])))),
@@ -2998,7 +2998,7 @@ TestInterpreterOutputTrace(
       Opid(190): TraceOp(
         opid: Opid(190),
         parent_opid: Some(Opid(188)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(42, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(42, [
           2,
           3,
           7,
@@ -3007,7 +3007,7 @@ TestInterpreterOutputTrace(
       Opid(191): TraceOp(
         opid: Opid(191),
         parent_opid: Some(Opid(188)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(63, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(63, [
           3,
           7,
         ])))),
@@ -3020,7 +3020,7 @@ TestInterpreterOutputTrace(
       Opid(193): TraceOp(
         opid: Opid(193),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(194): TraceOp(
         opid: Opid(194),
@@ -3046,7 +3046,7 @@ TestInterpreterOutputTrace(
       Opid(196): TraceOp(
         opid: Opid(196),
         parent_opid: Some(Opid(193)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
@@ -3085,7 +3085,7 @@ TestInterpreterOutputTrace(
       Opid(199): TraceOp(
         opid: Opid(199),
         parent_opid: Some(Opid(193)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(42, [
             2,
             3,
@@ -3124,7 +3124,7 @@ TestInterpreterOutputTrace(
       Opid(202): TraceOp(
         opid: Opid(202),
         parent_opid: Some(Opid(193)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(63, [
             3,
             7,
@@ -3175,7 +3175,7 @@ TestInterpreterOutputTrace(
       Opid(210): TraceOp(
         opid: Opid(210),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(211): TraceOp(
         opid: Opid(211),
@@ -3250,7 +3250,7 @@ TestInterpreterOutputTrace(
       Opid(213): TraceOp(
         opid: Opid(213),
         parent_opid: Some(Opid(210)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -3385,7 +3385,7 @@ TestInterpreterOutputTrace(
       Opid(216): TraceOp(
         opid: Opid(216),
         parent_opid: Some(Opid(210)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
@@ -3619,7 +3619,7 @@ TestInterpreterOutputTrace(
       Opid(221): TraceOp(
         opid: Opid(221),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -168,7 +168,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(21)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(21)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(21)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(21)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -258,7 +258,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -308,7 +308,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(38)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -324,7 +324,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(38)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(38)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -359,7 +359,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(38)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -418,14 +418,14 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(52)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -435,7 +435,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -461,14 +461,14 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(52)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -478,7 +478,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -509,14 +509,14 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(52)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -528,7 +528,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(9, [
+                active_vertex: Some(Composite(CompositeNumber(9, [
                   3,
                 ]))),
                 tokens: {
@@ -552,14 +552,14 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(52)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
             Eid(2): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(6, [
+                active_vertex: Some(Composite(CompositeNumber(6, [
                   2,
                   3,
                 ]))),
@@ -571,7 +571,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(9, [
+                active_vertex: Some(Composite(CompositeNumber(9, [
                   3,
                 ]))),
                 tokens: {
@@ -610,7 +610,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -623,14 +623,14 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -640,7 +640,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(6, [
+                      active_vertex: Some(Composite(CompositeNumber(6, [
                         2,
                         3,
                       ]))),
@@ -662,14 +662,14 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(6, [
+                      active_vertex: Some(Composite(CompositeNumber(6, [
                         2,
                         3,
                       ]))),
@@ -681,7 +681,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(9, [
+                      active_vertex: Some(Composite(CompositeNumber(9, [
                         3,
                       ]))),
                       tokens: {
@@ -729,7 +729,7 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -742,14 +742,14 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -759,7 +759,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(6, [
+                      active_vertex: Some(Composite(CompositeNumber(6, [
                         2,
                         3,
                       ]))),
@@ -781,14 +781,14 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(6, [
+                      active_vertex: Some(Composite(CompositeNumber(6, [
                         2,
                         3,
                       ]))),
@@ -800,7 +800,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(9, [
+                      active_vertex: Some(Composite(CompositeNumber(9, [
                         3,
                       ]))),
                       tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
@@ -53,7 +53,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -64,7 +64,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -221,7 +221,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -259,7 +259,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -312,7 +312,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -348,7 +348,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(3): Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -419,7 +419,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(52)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -439,7 +439,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -462,7 +462,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(52)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
           folded_contexts: {
@@ -471,7 +471,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -482,7 +482,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -510,7 +510,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(52)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -531,7 +531,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(9, [
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(9, [
                     3,
                   ]))),
@@ -553,7 +553,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(52)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
           folded_contexts: {
@@ -563,7 +563,7 @@ TestInterpreterOutputTrace(
                   2,
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(6, [
                     2,
                     3,
@@ -574,7 +574,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(9, [
                   3,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(3): Some(Composite(CompositeNumber(9, [
                     3,
                   ]))),
@@ -614,7 +614,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -624,7 +624,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
                 folded_contexts: {
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -644,7 +644,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(6, [
                           2,
                           3,
@@ -663,7 +663,7 @@ TestInterpreterOutputTrace(
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
                 folded_contexts: {
@@ -673,7 +673,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(6, [
                           2,
                           3,
@@ -684,7 +684,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(9, [
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(9, [
                           3,
                         ]))),
@@ -733,7 +733,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -743,7 +743,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
                 folded_contexts: {
@@ -752,7 +752,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -763,7 +763,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(6, [
                           2,
                           3,
@@ -782,7 +782,7 @@ TestInterpreterOutputTrace(
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
                 folded_contexts: {
@@ -792,7 +792,7 @@ TestInterpreterOutputTrace(
                         2,
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(6, [
                           2,
                           3,
@@ -803,7 +803,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(9, [
                         3,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(9, [
                           3,
                         ]))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -59,7 +59,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Prime", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Prime", Eid(2))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -112,7 +112,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -137,14 +137,14 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(21)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(21)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -252,7 +252,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -285,7 +285,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(39): TraceOp(
         opid: Opid(39),
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(38)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -358,7 +358,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(38)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -407,7 +407,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(53): TraceOp(
         opid: Opid(53),
@@ -460,7 +460,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(52)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -551,7 +551,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(52)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -728,7 +728,7 @@ TestInterpreterOutputTrace(
       Opid(63): TraceOp(
         opid: Opid(63),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(64, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(64, [
           2,
         ])))),
       ),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
@@ -95,12 +95,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(2), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(2), "Number", "Composite")),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
         ), false)),
@@ -141,7 +141,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {},
         ), false)),
@@ -167,7 +167,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -222,12 +222,12 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(29)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
@@ -247,7 +247,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -302,17 +302,17 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(39)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(4, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(4, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -351,7 +351,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -389,24 +389,24 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(50)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(50)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(50)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(50)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(5, Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveNeighborsInner(5, Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -445,7 +445,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -483,31 +483,31 @@ TestInterpreterOutputTrace(
       Opid(63): TraceOp(
         opid: Opid(63),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(2)))),
       ),
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(3, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(3, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(62)),
-        content: YieldFrom(ProjectNeighborsInner(4, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(4, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -736,7 +736,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
@@ -48,7 +48,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(64, [
+          active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
           tokens: {},
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(64, [
+          active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
           tokens: {},
@@ -68,7 +68,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(64, [
+          active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
           tokens: {
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(64, [
+          active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
           tokens: {
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         )),
       ),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         ), false)),
       ),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         )),
       ),
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         ), false)),
       ),
@@ -175,7 +175,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -255,7 +255,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -265,7 +265,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -289,7 +289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -352,7 +352,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {},
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -376,7 +376,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -436,7 +436,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -446,7 +446,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -456,7 +456,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(14)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -470,7 +470,7 @@ TestInterpreterOutputTrace(
         opid: Opid(62),
         parent_opid: Some(Opid(14)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -555,7 +555,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(64, [
+          active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
           tokens: {
@@ -566,7 +566,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -577,13 +577,13 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
@@ -592,7 +592,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -603,19 +603,19 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -628,7 +628,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(16, [
+                active_vertex: Some(Composite(CompositeNumber(16, [
                   2,
                 ]))),
                 tokens: {
@@ -639,19 +639,19 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -661,7 +661,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(8, [
+                      active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
                       tokens: {
@@ -674,7 +674,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(32, [
+                active_vertex: Some(Composite(CompositeNumber(32, [
                   2,
                 ]))),
                 tokens: {
@@ -685,19 +685,19 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -707,7 +707,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(8, [
+                      active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
                       tokens: {
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(16, [
+                      active_vertex: Some(Composite(CompositeNumber(16, [
                         2,
                       ]))),
                       tokens: {
@@ -737,7 +737,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(64, [
+          active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
           tokens: {
@@ -748,7 +748,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(4, [
+                active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
                 tokens: {
@@ -759,13 +759,13 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
@@ -774,7 +774,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(8, [
+                active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
                 tokens: {
@@ -785,19 +785,19 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -810,7 +810,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(16, [
+                active_vertex: Some(Composite(CompositeNumber(16, [
                   2,
                 ]))),
                 tokens: {
@@ -821,19 +821,19 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -843,7 +843,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(8, [
+                      active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
                       tokens: {
@@ -856,7 +856,7 @@ TestInterpreterOutputTrace(
                 },
               ),
               SerializableContext(
-                current_token: Some(Composite(CompositeNumber(32, [
+                active_vertex: Some(Composite(CompositeNumber(32, [
                   2,
                 ]))),
                 tokens: {
@@ -867,19 +867,19 @@ TestInterpreterOutputTrace(
                 folded_contexts: {
                   Eid(2): [
                     SerializableContext(
-                      current_token: Some(Neither(NeitherNumber(1))),
+                      active_vertex: Some(Neither(NeitherNumber(1))),
                       tokens: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Prime(PrimeNumber(2))),
+                      active_vertex: Some(Prime(PrimeNumber(2))),
                       tokens: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(4, [
+                      active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
                       tokens: {
@@ -889,7 +889,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(8, [
+                      active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
                       tokens: {
@@ -899,7 +899,7 @@ TestInterpreterOutputTrace(
                       },
                     ),
                     SerializableContext(
-                      current_token: Some(Composite(CompositeNumber(16, [
+                      active_vertex: Some(Composite(CompositeNumber(16, [
                         2,
                       ]))),
                       tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(64, [
               2,
             ]))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(64, [
               2,
             ]))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(19): TraceOp(
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(20): TraceOp(
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(23): TraceOp(
@@ -156,7 +156,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(24): TraceOp(
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(27): TraceOp(
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(28): TraceOp(
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -258,7 +258,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(37): TraceOp(
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(38): TraceOp(
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(48): TraceOp(
@@ -355,7 +355,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(49): TraceOp(
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -379,7 +379,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(16, [
               2,
             ]))),
@@ -439,7 +439,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(60): TraceOp(
@@ -449,7 +449,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(61): TraceOp(
@@ -459,7 +459,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -473,7 +473,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -558,7 +558,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(64, [
               2,
             ]))),
@@ -569,7 +569,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -578,13 +578,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -595,7 +595,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -604,13 +604,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -631,7 +631,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(16, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(16, [
                     2,
                   ]))),
@@ -640,13 +640,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -654,7 +654,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -664,7 +664,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(8, [
                           2,
                         ]))),
@@ -677,7 +677,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(32, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(32, [
                     2,
                   ]))),
@@ -686,13 +686,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -700,7 +700,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -710,7 +710,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(8, [
                           2,
                         ]))),
@@ -720,7 +720,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(16, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(16, [
                           2,
                         ]))),
@@ -740,7 +740,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(64, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(64, [
               2,
             ]))),
@@ -751,7 +751,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(4, [
                     2,
                   ]))),
@@ -760,13 +760,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -777,7 +777,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(8, [
                     2,
                   ]))),
@@ -786,13 +786,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -800,7 +800,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -813,7 +813,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(16, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(16, [
                     2,
                   ]))),
@@ -822,13 +822,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -836,7 +836,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -846,7 +846,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(8, [
                           2,
                         ]))),
@@ -859,7 +859,7 @@ TestInterpreterOutputTrace(
                 active_vertex: Some(Composite(CompositeNumber(32, [
                   2,
                 ]))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Composite(CompositeNumber(32, [
                     2,
                   ]))),
@@ -868,13 +868,13 @@ TestInterpreterOutputTrace(
                   Eid(2): [
                     SerializableContext(
                       active_vertex: Some(Neither(NeitherNumber(1))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Neither(NeitherNumber(1))),
                       },
                     ),
                     SerializableContext(
                       active_vertex: Some(Prime(PrimeNumber(2))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Prime(PrimeNumber(2))),
                       },
                     ),
@@ -882,7 +882,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(4, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(4, [
                           2,
                         ]))),
@@ -892,7 +892,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(8, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(8, [
                           2,
                         ]))),
@@ -902,7 +902,7 @@ TestInterpreterOutputTrace(
                       active_vertex: Some(Composite(CompositeNumber(16, [
                         2,
                       ]))),
-                      tokens: {
+                      vertices: {
                         Vid(3): Some(Composite(CompositeNumber(16, [
                           2,
                         ]))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -191,7 +191,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -310,7 +310,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -324,7 +324,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -400,7 +400,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -415,7 +415,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -444,7 +444,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(23)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -214,7 +214,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -256,7 +256,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
@@ -271,7 +271,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -281,7 +281,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(36)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(38): TraceOp(
         opid: Opid(38),
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -322,7 +322,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -364,7 +364,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(48): TraceOp(
         opid: Opid(48),
@@ -379,7 +379,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -389,7 +389,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(49)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -442,7 +442,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -164,7 +164,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -179,7 +179,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -272,7 +272,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -287,7 +287,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -370,7 +370,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -380,7 +380,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -397,7 +397,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -412,7 +412,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -427,7 +427,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -443,7 +443,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [

--- a/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Prime", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -126,7 +126,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -144,7 +144,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -164,7 +164,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -127,7 +127,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -142,7 +142,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -103,7 +103,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -119,7 +119,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
             Vid(3): None,
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
             Vid(3): None,
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
             Vid(3): None,
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
             Vid(3): None,
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
             Vid(3): None,
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
             Vid(3): None,

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
@@ -5,32 +5,32 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Number", "value")),
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -156,7 +156,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -187,7 +187,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -106,7 +106,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -143,7 +143,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(21): TraceOp(
         opid: Opid(21),
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
@@ -261,7 +261,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -271,7 +271,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -293,7 +293,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -324,7 +324,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -358,7 +358,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -383,7 +383,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -417,7 +417,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -462,7 +462,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(54): TraceOp(
         opid: Opid(54),
@@ -477,7 +477,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -487,7 +487,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(55)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -512,7 +512,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -581,7 +581,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(55)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -603,7 +603,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -634,7 +634,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -678,7 +678,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -699,7 +699,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -713,7 +713,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -737,7 +737,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -774,7 +774,7 @@ TestInterpreterOutputTrace(
       Opid(81): TraceOp(
         opid: Opid(81),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -812,7 +812,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -836,7 +836,7 @@ TestInterpreterOutputTrace(
       Opid(87): TraceOp(
         opid: Opid(87),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -873,7 +873,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -911,7 +911,7 @@ TestInterpreterOutputTrace(
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -938,7 +938,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -978,7 +978,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -83,7 +83,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
           },
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -160,7 +160,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -175,7 +175,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
           },
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
           },
@@ -197,7 +197,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
           },
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
           },
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -282,7 +282,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -310,7 +310,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -371,7 +371,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -388,7 +388,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -402,7 +402,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -419,7 +419,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -479,7 +479,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -517,7 +517,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -531,7 +531,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -548,7 +548,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -592,7 +592,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -607,7 +607,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -620,7 +620,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -636,7 +636,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -689,7 +689,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -703,7 +703,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -724,7 +724,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -741,7 +741,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -758,7 +758,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -778,7 +778,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -823,7 +823,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -840,7 +840,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -857,7 +857,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -877,7 +877,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -924,7 +924,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -943,7 +943,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -961,7 +961,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -982,7 +982,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -107,7 +107,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): None,
@@ -149,7 +149,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -159,7 +159,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
@@ -196,7 +196,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): None,
@@ -252,7 +252,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -279,7 +279,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -309,7 +309,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -325,7 +325,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -367,7 +367,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -384,7 +384,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -401,7 +401,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -418,7 +418,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -468,7 +468,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -478,7 +478,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -496,7 +496,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -513,7 +513,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -530,7 +530,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -547,7 +547,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -589,7 +589,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -604,7 +604,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -619,7 +619,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
@@ -635,7 +635,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
@@ -686,7 +686,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -700,7 +700,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -721,7 +721,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -738,7 +738,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -755,7 +755,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -775,7 +775,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -820,7 +820,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -837,7 +837,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -854,7 +854,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -874,7 +874,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -920,7 +920,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -939,7 +939,7 @@ TestInterpreterOutputTrace(
         opid: Opid(95),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -958,7 +958,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -979,7 +979,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
@@ -38,7 +38,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -52,7 +52,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -151,7 +151,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -51,7 +51,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
@@ -41,7 +41,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -124,7 +124,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Composite")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Composite")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(28, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(28, [
           2,
           7,
         ])))),
@@ -59,7 +59,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
@@ -102,12 +102,12 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(7)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(29)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(29)))),
       ),
       Opid(33): TraceOp(
         opid: Opid(33),
@@ -305,7 +305,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(29))),
           vertices: {},
         ), false)),
@@ -318,7 +318,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(30, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(30, [
           2,
           3,
           5,
@@ -339,7 +339,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -369,7 +369,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -387,17 +387,17 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(40)),
-        content: YieldFrom(ProjectNeighborsInner(2, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(2, Prime(PrimeNumber(5)))),
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
@@ -407,7 +407,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(46): TraceOp(
         opid: Opid(46),
@@ -427,7 +427,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -452,7 +452,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -477,7 +477,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -550,7 +550,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
@@ -626,7 +626,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(31)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(31)))),
       ),
       Opid(65): TraceOp(
         opid: Opid(65),
@@ -639,7 +639,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
           vertices: {},
         ), false)),
@@ -652,7 +652,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -669,7 +669,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -693,7 +693,7 @@ TestInterpreterOutputTrace(
       Opid(72): TraceOp(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
@@ -707,7 +707,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(72)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(74): TraceOp(
         opid: Opid(74),
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
       Opid(75): TraceOp(
         opid: Opid(75),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(2), "Prime", "value")),
       ),
       Opid(76): TraceOp(
         opid: Opid(76),
@@ -737,7 +737,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(75)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -792,7 +792,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
@@ -53,7 +53,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -64,7 +64,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(11): TraceOp(
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(28, [
               2,
               7,
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(28, [
               2,
               7,
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -164,7 +164,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
         ), Int64(7))),
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(28, [
               2,
               7,
@@ -202,13 +202,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(7))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
               ),
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(28, [
               2,
               7,
@@ -241,13 +241,13 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(7))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
               ),
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(29))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(34): TraceOp(
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(29))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(35): TraceOp(
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(38): TraceOp(
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(39): TraceOp(
@@ -357,7 +357,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -375,7 +375,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -419,7 +419,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(45)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(45)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -444,7 +444,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(45)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -454,7 +454,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(45)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(45)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -479,7 +479,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(45)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -508,7 +508,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -519,19 +519,19 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -556,7 +556,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(30, [
               2,
               3,
@@ -567,19 +567,19 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(3))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(5))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
               ),
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(66): TraceOp(
@@ -641,7 +641,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(31))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(67): TraceOp(
@@ -663,7 +663,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(70): TraceOp(
@@ -673,7 +673,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(71): TraceOp(
@@ -683,7 +683,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -697,7 +697,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -729,7 +729,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(75)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -739,7 +739,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(75)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -766,7 +766,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -775,7 +775,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
@@ -796,7 +796,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(32, [
               2,
             ]))),
@@ -805,7 +805,7 @@ TestInterpreterOutputTrace(
             Eid(1): [
               SerializableContext(
                 active_vertex: Some(Prime(PrimeNumber(2))),
-                tokens: {
+                vertices: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
@@ -49,7 +49,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(16)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(16)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -201,13 +201,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(7))),
+                active_vertex: Some(Prime(PrimeNumber(7))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
@@ -227,7 +227,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(28, [
+          active_vertex: Some(Composite(CompositeNumber(28, [
             2,
             7,
           ]))),
@@ -240,13 +240,13 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(7))),
+                active_vertex: Some(Prime(PrimeNumber(7))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(7))),
                 },
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(29))),
+          active_vertex: Some(Prime(PrimeNumber(29))),
           tokens: {},
         )),
       ),
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(29))),
+          active_vertex: Some(Prime(PrimeNumber(29))),
           tokens: {},
         ), false)),
       ),
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -340,7 +340,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -352,7 +352,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -370,7 +370,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -418,7 +418,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(45)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(45)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -443,7 +443,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(45)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -453,7 +453,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(45)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -468,7 +468,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(45)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -478,7 +478,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(45)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -503,7 +503,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -518,19 +518,19 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -551,7 +551,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(30, [
+          active_vertex: Some(Composite(CompositeNumber(30, [
             2,
             3,
             5,
@@ -566,19 +566,19 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(3))),
+                active_vertex: Some(Prime(PrimeNumber(3))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(3))),
                 },
               ),
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(5))),
+                active_vertex: Some(Prime(PrimeNumber(5))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(5))),
                 },
@@ -632,7 +632,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         )),
       ),
@@ -640,7 +640,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(31))),
+          active_vertex: Some(Prime(PrimeNumber(31))),
           tokens: {},
         ), false)),
       ),
@@ -660,7 +660,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -670,7 +670,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {},
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -694,7 +694,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -728,7 +728,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(75)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -738,7 +738,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(75)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -763,7 +763,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -774,7 +774,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },
@@ -793,7 +793,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
           folded_contexts: {
             Eid(1): [
               SerializableContext(
-                current_token: Some(Prime(PrimeNumber(2))),
+                active_vertex: Some(Prime(PrimeNumber(2))),
                 tokens: {
                   Vid(2): Some(Prime(PrimeNumber(2))),
                 },

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
@@ -135,7 +135,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -200,7 +200,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -211,7 +211,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -254,7 +254,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -2196,7 +2196,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
             ),
@@ -2220,7 +2220,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
             ),
@@ -2246,7 +2246,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(6, [
                   2,
                   3,
@@ -2258,7 +2258,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(5))),
                   ],
                 ),
@@ -2281,7 +2281,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(6, [
                   2,
                   3,
@@ -2293,7 +2293,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(5))),
                   ],
                 ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
@@ -5,42 +5,42 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(21)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -225,7 +225,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(26): TraceOp(
         opid: Opid(26),
@@ -290,7 +290,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(27)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -334,7 +334,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -377,7 +377,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -472,7 +472,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(27)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -499,7 +499,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -542,7 +542,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -589,7 +589,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -637,7 +637,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(27)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -666,7 +666,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -712,7 +712,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -762,7 +762,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -834,7 +834,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -847,7 +847,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(64)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -874,7 +874,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -916,7 +916,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -960,7 +960,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1005,7 +1005,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(64)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -1032,7 +1032,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1074,7 +1074,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -1118,7 +1118,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1192,7 +1192,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1211,7 +1211,7 @@ TestInterpreterOutputTrace(
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(90)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1241,7 +1241,7 @@ TestInterpreterOutputTrace(
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1289,7 +1289,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1342,7 +1342,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1393,7 +1393,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(90)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -1423,7 +1423,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1471,7 +1471,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -1524,7 +1524,7 @@ TestInterpreterOutputTrace(
       Opid(108): TraceOp(
         opid: Opid(108),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1575,7 +1575,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(90)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -1605,7 +1605,7 @@ TestInterpreterOutputTrace(
       Opid(115): TraceOp(
         opid: Opid(115),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1653,7 +1653,7 @@ TestInterpreterOutputTrace(
       Opid(117): TraceOp(
         opid: Opid(117),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -1706,7 +1706,7 @@ TestInterpreterOutputTrace(
       Opid(119): TraceOp(
         opid: Opid(119),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1780,7 +1780,7 @@ TestInterpreterOutputTrace(
       Opid(127): TraceOp(
         opid: Opid(127),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1793,7 +1793,7 @@ TestInterpreterOutputTrace(
       Opid(128): TraceOp(
         opid: Opid(128),
         parent_opid: Some(Opid(127)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -1820,7 +1820,7 @@ TestInterpreterOutputTrace(
       Opid(130): TraceOp(
         opid: Opid(130),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1862,7 +1862,7 @@ TestInterpreterOutputTrace(
       Opid(132): TraceOp(
         opid: Opid(132),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -1906,7 +1906,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1951,7 +1951,7 @@ TestInterpreterOutputTrace(
       Opid(139): TraceOp(
         opid: Opid(139),
         parent_opid: Some(Opid(127)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(21, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(21, [
           3,
           7,
         ])))),
@@ -1978,7 +1978,7 @@ TestInterpreterOutputTrace(
       Opid(141): TraceOp(
         opid: Opid(141),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -2020,7 +2020,7 @@ TestInterpreterOutputTrace(
       Opid(143): TraceOp(
         opid: Opid(143),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
@@ -2064,7 +2064,7 @@ TestInterpreterOutputTrace(
       Opid(145): TraceOp(
         opid: Opid(145),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -2149,7 +2149,7 @@ TestInterpreterOutputTrace(
       Opid(158): TraceOp(
         opid: Opid(158),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(159): TraceOp(
         opid: Opid(159),
@@ -2164,7 +2164,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2174,7 +2174,7 @@ TestInterpreterOutputTrace(
       Opid(161): TraceOp(
         opid: Opid(161),
         parent_opid: Some(Opid(160)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -2206,7 +2206,7 @@ TestInterpreterOutputTrace(
       Opid(163): TraceOp(
         opid: Opid(163),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2230,7 +2230,7 @@ TestInterpreterOutputTrace(
       Opid(164): TraceOp(
         opid: Opid(164),
         parent_opid: Some(Opid(163)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(165): TraceOp(
         opid: Opid(165),
@@ -2270,7 +2270,7 @@ TestInterpreterOutputTrace(
       Opid(166): TraceOp(
         opid: Opid(166),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2305,7 +2305,7 @@ TestInterpreterOutputTrace(
       Opid(167): TraceOp(
         opid: Opid(167),
         parent_opid: Some(Opid(166)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -2323,7 +2323,7 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2334,7 +2334,7 @@ TestInterpreterOutputTrace(
       Opid(170): TraceOp(
         opid: Opid(170),
         parent_opid: Some(Opid(169)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -2357,7 +2357,7 @@ TestInterpreterOutputTrace(
       Opid(172): TraceOp(
         opid: Opid(172),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2393,7 +2393,7 @@ TestInterpreterOutputTrace(
       Opid(174): TraceOp(
         opid: Opid(174),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
@@ -2433,7 +2433,7 @@ TestInterpreterOutputTrace(
       Opid(176): TraceOp(
         opid: Opid(176),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2476,7 +2476,7 @@ TestInterpreterOutputTrace(
       Opid(181): TraceOp(
         opid: Opid(181),
         parent_opid: Some(Opid(169)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(15, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(15, [
           3,
           5,
         ])))),
@@ -2499,7 +2499,7 @@ TestInterpreterOutputTrace(
       Opid(183): TraceOp(
         opid: Opid(183),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2535,7 +2535,7 @@ TestInterpreterOutputTrace(
       Opid(185): TraceOp(
         opid: Opid(185),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
@@ -2575,7 +2575,7 @@ TestInterpreterOutputTrace(
       Opid(187): TraceOp(
         opid: Opid(187),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2645,7 +2645,7 @@ TestInterpreterOutputTrace(
       Opid(195): TraceOp(
         opid: Opid(195),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2662,7 +2662,7 @@ TestInterpreterOutputTrace(
       Opid(196): TraceOp(
         opid: Opid(196),
         parent_opid: Some(Opid(195)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -2688,7 +2688,7 @@ TestInterpreterOutputTrace(
       Opid(198): TraceOp(
         opid: Opid(198),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2730,7 +2730,7 @@ TestInterpreterOutputTrace(
       Opid(200): TraceOp(
         opid: Opid(200),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2779,7 +2779,7 @@ TestInterpreterOutputTrace(
       Opid(202): TraceOp(
         opid: Opid(202),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2828,7 +2828,7 @@ TestInterpreterOutputTrace(
       Opid(207): TraceOp(
         opid: Opid(207),
         parent_opid: Some(Opid(195)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(12, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(12, [
           2,
           3,
         ])))),
@@ -2854,7 +2854,7 @@ TestInterpreterOutputTrace(
       Opid(209): TraceOp(
         opid: Opid(209),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -2896,7 +2896,7 @@ TestInterpreterOutputTrace(
       Opid(211): TraceOp(
         opid: Opid(211),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
@@ -2945,7 +2945,7 @@ TestInterpreterOutputTrace(
       Opid(213): TraceOp(
         opid: Opid(213),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -2994,7 +2994,7 @@ TestInterpreterOutputTrace(
       Opid(218): TraceOp(
         opid: Opid(218),
         parent_opid: Some(Opid(195)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(18, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(18, [
           2,
           3,
         ])))),
@@ -3020,7 +3020,7 @@ TestInterpreterOutputTrace(
       Opid(220): TraceOp(
         opid: Opid(220),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3062,7 +3062,7 @@ TestInterpreterOutputTrace(
       Opid(222): TraceOp(
         opid: Opid(222),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
@@ -3111,7 +3111,7 @@ TestInterpreterOutputTrace(
       Opid(224): TraceOp(
         opid: Opid(224),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -3181,7 +3181,7 @@ TestInterpreterOutputTrace(
       Opid(232): TraceOp(
         opid: Opid(232),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3192,7 +3192,7 @@ TestInterpreterOutputTrace(
       Opid(233): TraceOp(
         opid: Opid(233),
         parent_opid: Some(Opid(232)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(14, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(14, [
           2,
           7,
         ])))),
@@ -3215,7 +3215,7 @@ TestInterpreterOutputTrace(
       Opid(235): TraceOp(
         opid: Opid(235),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3251,7 +3251,7 @@ TestInterpreterOutputTrace(
       Opid(237): TraceOp(
         opid: Opid(237),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
@@ -3291,7 +3291,7 @@ TestInterpreterOutputTrace(
       Opid(239): TraceOp(
         opid: Opid(239),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3334,7 +3334,7 @@ TestInterpreterOutputTrace(
       Opid(244): TraceOp(
         opid: Opid(244),
         parent_opid: Some(Opid(232)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(21, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(21, [
           3,
           7,
         ])))),
@@ -3357,7 +3357,7 @@ TestInterpreterOutputTrace(
       Opid(246): TraceOp(
         opid: Opid(246),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3393,7 +3393,7 @@ TestInterpreterOutputTrace(
       Opid(248): TraceOp(
         opid: Opid(248),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
@@ -3433,7 +3433,7 @@ TestInterpreterOutputTrace(
       Opid(250): TraceOp(
         opid: Opid(250),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3501,7 +3501,7 @@ TestInterpreterOutputTrace(
       Opid(258): TraceOp(
         opid: Opid(258),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -3516,7 +3516,7 @@ TestInterpreterOutputTrace(
       Opid(259): TraceOp(
         opid: Opid(259),
         parent_opid: Some(Opid(258)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -3539,7 +3539,7 @@ TestInterpreterOutputTrace(
       Opid(261): TraceOp(
         opid: Opid(261),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3576,7 +3576,7 @@ TestInterpreterOutputTrace(
       Opid(263): TraceOp(
         opid: Opid(263),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -3619,7 +3619,7 @@ TestInterpreterOutputTrace(
       Opid(265): TraceOp(
         opid: Opid(265),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -3665,7 +3665,7 @@ TestInterpreterOutputTrace(
       Opid(270): TraceOp(
         opid: Opid(270),
         parent_opid: Some(Opid(258)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -3688,7 +3688,7 @@ TestInterpreterOutputTrace(
       Opid(272): TraceOp(
         opid: Opid(272),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3725,7 +3725,7 @@ TestInterpreterOutputTrace(
       Opid(274): TraceOp(
         opid: Opid(274),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -3768,7 +3768,7 @@ TestInterpreterOutputTrace(
       Opid(276): TraceOp(
         opid: Opid(276),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -3814,7 +3814,7 @@ TestInterpreterOutputTrace(
       Opid(281): TraceOp(
         opid: Opid(281),
         parent_opid: Some(Opid(258)),
-        content: YieldFrom(ProjectNeighborsInner(2, Composite(CompositeNumber(24, [
+        content: YieldFrom(ResolveNeighborsInner(2, Composite(CompositeNumber(24, [
           2,
           3,
         ])))),
@@ -3839,7 +3839,7 @@ TestInterpreterOutputTrace(
       Opid(283): TraceOp(
         opid: Opid(283),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -3879,7 +3879,7 @@ TestInterpreterOutputTrace(
       Opid(285): TraceOp(
         opid: Opid(285),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
@@ -3925,7 +3925,7 @@ TestInterpreterOutputTrace(
       Opid(287): TraceOp(
         opid: Opid(287),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -129,7 +129,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -156,7 +156,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -194,7 +194,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -237,7 +237,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -248,7 +248,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -274,7 +274,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -315,7 +315,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -335,7 +335,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -355,7 +355,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -378,7 +378,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -401,7 +401,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -425,7 +425,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -480,7 +480,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -543,7 +543,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -566,7 +566,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -590,7 +590,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -646,7 +646,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -667,7 +667,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -688,7 +688,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -713,7 +713,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -738,7 +738,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -763,7 +763,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -822,7 +822,7 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -835,7 +835,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -856,7 +856,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -875,7 +875,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -894,7 +894,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -917,7 +917,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -940,7 +940,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -961,7 +961,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1014,7 +1014,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1033,7 +1033,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1052,7 +1052,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1075,7 +1075,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -1098,7 +1098,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1119,7 +1119,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1174,7 +1174,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1193,7 +1193,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1220,7 +1220,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1242,7 +1242,7 @@ TestInterpreterOutputTrace(
         opid: Opid(93),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1264,7 +1264,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1290,7 +1290,7 @@ TestInterpreterOutputTrace(
         opid: Opid(95),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1316,7 +1316,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1343,7 +1343,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1402,7 +1402,7 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1424,7 +1424,7 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1446,7 +1446,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1472,7 +1472,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -1498,7 +1498,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1525,7 +1525,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1584,7 +1584,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1606,7 +1606,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1628,7 +1628,7 @@ TestInterpreterOutputTrace(
         opid: Opid(116),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1654,7 +1654,7 @@ TestInterpreterOutputTrace(
         opid: Opid(117),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -1680,7 +1680,7 @@ TestInterpreterOutputTrace(
         opid: Opid(118),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1707,7 +1707,7 @@ TestInterpreterOutputTrace(
         opid: Opid(119),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1768,7 +1768,7 @@ TestInterpreterOutputTrace(
         opid: Opid(126),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1781,7 +1781,7 @@ TestInterpreterOutputTrace(
         opid: Opid(127),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1802,7 +1802,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1821,7 +1821,7 @@ TestInterpreterOutputTrace(
         opid: Opid(130),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1840,7 +1840,7 @@ TestInterpreterOutputTrace(
         opid: Opid(131),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1863,7 +1863,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -1886,7 +1886,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1907,7 +1907,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1960,7 +1960,7 @@ TestInterpreterOutputTrace(
         opid: Opid(140),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1979,7 +1979,7 @@ TestInterpreterOutputTrace(
         opid: Opid(141),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1998,7 +1998,7 @@ TestInterpreterOutputTrace(
         opid: Opid(142),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -2021,7 +2021,7 @@ TestInterpreterOutputTrace(
         opid: Opid(143),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -2044,7 +2044,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2065,7 +2065,7 @@ TestInterpreterOutputTrace(
         opid: Opid(145),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -2155,7 +2155,7 @@ TestInterpreterOutputTrace(
         opid: Opid(159),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -2165,7 +2165,7 @@ TestInterpreterOutputTrace(
         opid: Opid(160),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -2183,7 +2183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2192,7 +2192,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -2207,7 +2207,7 @@ TestInterpreterOutputTrace(
         opid: Opid(163),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2216,7 +2216,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -2236,13 +2236,13 @@ TestInterpreterOutputTrace(
         opid: Opid(165),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -2254,7 +2254,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
@@ -2271,13 +2271,13 @@ TestInterpreterOutputTrace(
         opid: Opid(166),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -2289,7 +2289,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
@@ -2313,7 +2313,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2324,7 +2324,7 @@ TestInterpreterOutputTrace(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2343,7 +2343,7 @@ TestInterpreterOutputTrace(
         opid: Opid(171),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2358,7 +2358,7 @@ TestInterpreterOutputTrace(
         opid: Opid(172),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2373,7 +2373,7 @@ TestInterpreterOutputTrace(
         opid: Opid(173),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -2394,7 +2394,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -2415,7 +2415,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2434,7 +2434,7 @@ TestInterpreterOutputTrace(
         opid: Opid(176),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2485,7 +2485,7 @@ TestInterpreterOutputTrace(
         opid: Opid(182),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2500,7 +2500,7 @@ TestInterpreterOutputTrace(
         opid: Opid(183),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2515,7 +2515,7 @@ TestInterpreterOutputTrace(
         opid: Opid(184),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -2536,7 +2536,7 @@ TestInterpreterOutputTrace(
         opid: Opid(185),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(15, [
+          active_vertex: Some(Composite(CompositeNumber(15, [
             3,
             5,
           ]))),
@@ -2557,7 +2557,7 @@ TestInterpreterOutputTrace(
         opid: Opid(186),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2576,7 +2576,7 @@ TestInterpreterOutputTrace(
         opid: Opid(187),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -2629,7 +2629,7 @@ TestInterpreterOutputTrace(
         opid: Opid(194),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2646,7 +2646,7 @@ TestInterpreterOutputTrace(
         opid: Opid(195),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2671,7 +2671,7 @@ TestInterpreterOutputTrace(
         opid: Opid(197),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -2689,7 +2689,7 @@ TestInterpreterOutputTrace(
         opid: Opid(198),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -2707,7 +2707,7 @@ TestInterpreterOutputTrace(
         opid: Opid(199),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2731,7 +2731,7 @@ TestInterpreterOutputTrace(
         opid: Opid(200),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2755,7 +2755,7 @@ TestInterpreterOutputTrace(
         opid: Opid(201),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2780,7 +2780,7 @@ TestInterpreterOutputTrace(
         opid: Opid(202),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2837,7 +2837,7 @@ TestInterpreterOutputTrace(
         opid: Opid(208),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -2855,7 +2855,7 @@ TestInterpreterOutputTrace(
         opid: Opid(209),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -2873,7 +2873,7 @@ TestInterpreterOutputTrace(
         opid: Opid(210),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2897,7 +2897,7 @@ TestInterpreterOutputTrace(
         opid: Opid(211),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(12, [
+          active_vertex: Some(Composite(CompositeNumber(12, [
             2,
             3,
           ]))),
@@ -2921,7 +2921,7 @@ TestInterpreterOutputTrace(
         opid: Opid(212),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -2946,7 +2946,7 @@ TestInterpreterOutputTrace(
         opid: Opid(213),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -3003,7 +3003,7 @@ TestInterpreterOutputTrace(
         opid: Opid(219),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -3021,7 +3021,7 @@ TestInterpreterOutputTrace(
         opid: Opid(220),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -3039,7 +3039,7 @@ TestInterpreterOutputTrace(
         opid: Opid(221),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -3063,7 +3063,7 @@ TestInterpreterOutputTrace(
         opid: Opid(222),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(18, [
+          active_vertex: Some(Composite(CompositeNumber(18, [
             2,
             3,
           ]))),
@@ -3087,7 +3087,7 @@ TestInterpreterOutputTrace(
         opid: Opid(223),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -3112,7 +3112,7 @@ TestInterpreterOutputTrace(
         opid: Opid(224),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -3171,7 +3171,7 @@ TestInterpreterOutputTrace(
         opid: Opid(231),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3182,7 +3182,7 @@ TestInterpreterOutputTrace(
         opid: Opid(232),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3201,7 +3201,7 @@ TestInterpreterOutputTrace(
         opid: Opid(234),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3216,7 +3216,7 @@ TestInterpreterOutputTrace(
         opid: Opid(235),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3231,7 +3231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(236),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -3252,7 +3252,7 @@ TestInterpreterOutputTrace(
         opid: Opid(237),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(14, [
+          active_vertex: Some(Composite(CompositeNumber(14, [
             2,
             7,
           ]))),
@@ -3273,7 +3273,7 @@ TestInterpreterOutputTrace(
         opid: Opid(238),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3292,7 +3292,7 @@ TestInterpreterOutputTrace(
         opid: Opid(239),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3343,7 +3343,7 @@ TestInterpreterOutputTrace(
         opid: Opid(245),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3358,7 +3358,7 @@ TestInterpreterOutputTrace(
         opid: Opid(246),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3373,7 +3373,7 @@ TestInterpreterOutputTrace(
         opid: Opid(247),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3394,7 +3394,7 @@ TestInterpreterOutputTrace(
         opid: Opid(248),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(21, [
+          active_vertex: Some(Composite(CompositeNumber(21, [
             3,
             7,
           ]))),
@@ -3415,7 +3415,7 @@ TestInterpreterOutputTrace(
         opid: Opid(249),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3434,7 +3434,7 @@ TestInterpreterOutputTrace(
         opid: Opid(250),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
@@ -3487,7 +3487,7 @@ TestInterpreterOutputTrace(
         opid: Opid(257),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3502,7 +3502,7 @@ TestInterpreterOutputTrace(
         opid: Opid(258),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3524,7 +3524,7 @@ TestInterpreterOutputTrace(
         opid: Opid(260),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
@@ -3540,7 +3540,7 @@ TestInterpreterOutputTrace(
         opid: Opid(261),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
@@ -3556,7 +3556,7 @@ TestInterpreterOutputTrace(
         opid: Opid(262),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3577,7 +3577,7 @@ TestInterpreterOutputTrace(
         opid: Opid(263),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3598,7 +3598,7 @@ TestInterpreterOutputTrace(
         opid: Opid(264),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3620,7 +3620,7 @@ TestInterpreterOutputTrace(
         opid: Opid(265),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3673,7 +3673,7 @@ TestInterpreterOutputTrace(
         opid: Opid(271),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
@@ -3689,7 +3689,7 @@ TestInterpreterOutputTrace(
         opid: Opid(272),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
@@ -3705,7 +3705,7 @@ TestInterpreterOutputTrace(
         opid: Opid(273),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -3726,7 +3726,7 @@ TestInterpreterOutputTrace(
         opid: Opid(274),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -3747,7 +3747,7 @@ TestInterpreterOutputTrace(
         opid: Opid(275),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3769,7 +3769,7 @@ TestInterpreterOutputTrace(
         opid: Opid(276),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3823,7 +3823,7 @@ TestInterpreterOutputTrace(
         opid: Opid(282),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
@@ -3840,7 +3840,7 @@ TestInterpreterOutputTrace(
         opid: Opid(283),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
@@ -3857,7 +3857,7 @@ TestInterpreterOutputTrace(
         opid: Opid(284),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -3880,7 +3880,7 @@ TestInterpreterOutputTrace(
         opid: Opid(285),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(24, [
+          active_vertex: Some(Composite(CompositeNumber(24, [
             2,
             3,
           ]))),
@@ -3903,7 +3903,7 @@ TestInterpreterOutputTrace(
         opid: Opid(286),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -3926,7 +3926,7 @@ TestInterpreterOutputTrace(
         opid: Opid(287),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -149,7 +149,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -187,7 +187,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -206,7 +206,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -238,7 +238,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -294,7 +294,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -318,7 +318,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -338,7 +338,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -358,7 +358,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -404,7 +404,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -428,7 +428,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -483,7 +483,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -503,7 +503,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -569,7 +569,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -593,7 +593,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -649,7 +649,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -670,7 +670,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -692,7 +692,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -741,7 +741,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -766,7 +766,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -823,7 +823,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -836,7 +836,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -859,7 +859,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -878,7 +878,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -898,7 +898,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -921,7 +921,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -941,7 +941,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -962,7 +962,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1017,7 +1017,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1036,7 +1036,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1056,7 +1056,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1079,7 +1079,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1099,7 +1099,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1120,7 +1120,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1178,7 +1178,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1197,7 +1197,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1223,7 +1223,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1245,7 +1245,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1268,7 +1268,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1294,7 +1294,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1320,7 +1320,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1347,7 +1347,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1405,7 +1405,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1427,7 +1427,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1450,7 +1450,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1476,7 +1476,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1502,7 +1502,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1529,7 +1529,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1587,7 +1587,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1609,7 +1609,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1632,7 +1632,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1658,7 +1658,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1684,7 +1684,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1711,7 +1711,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1769,7 +1769,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1782,7 +1782,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1805,7 +1805,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1824,7 +1824,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1844,7 +1844,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1867,7 +1867,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1887,7 +1887,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1908,7 +1908,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1963,7 +1963,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1982,7 +1982,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2002,7 +2002,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2025,7 +2025,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2045,7 +2045,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2066,7 +2066,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -2156,7 +2156,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -2166,7 +2166,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -2187,13 +2187,13 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -2211,13 +2211,13 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -2237,13 +2237,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -2255,7 +2255,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
                   suspended_vertices: [
@@ -2272,13 +2272,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -2290,7 +2290,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
                   suspended_vertices: [
@@ -2314,7 +2314,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -2325,7 +2325,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -2344,7 +2344,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(10, [
@@ -2359,7 +2359,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(10, [
@@ -2377,7 +2377,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(10, [
@@ -2398,7 +2398,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(10, [
@@ -2416,7 +2416,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(10, [
@@ -2435,7 +2435,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(10, [
@@ -2486,7 +2486,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(15, [
@@ -2501,7 +2501,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(15, [
@@ -2519,7 +2519,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(15, [
@@ -2540,7 +2540,7 @@ TestInterpreterOutputTrace(
             3,
             5,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(15, [
@@ -2558,7 +2558,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(15, [
@@ -2577,7 +2577,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(5))),
             Vid(3): Some(Composite(CompositeNumber(15, [
@@ -2633,7 +2633,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2650,7 +2650,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2672,7 +2672,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2690,7 +2690,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2711,7 +2711,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2735,7 +2735,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2759,7 +2759,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2784,7 +2784,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2838,7 +2838,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2856,7 +2856,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2877,7 +2877,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2901,7 +2901,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2925,7 +2925,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -2950,7 +2950,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3004,7 +3004,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3022,7 +3022,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3043,7 +3043,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3067,7 +3067,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3091,7 +3091,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3116,7 +3116,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -3172,7 +3172,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
@@ -3183,7 +3183,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
           },
@@ -3202,7 +3202,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(14, [
@@ -3217,7 +3217,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(14, [
@@ -3235,7 +3235,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(14, [
@@ -3256,7 +3256,7 @@ TestInterpreterOutputTrace(
             2,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(14, [
@@ -3274,7 +3274,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(14, [
@@ -3293,7 +3293,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(14, [
@@ -3344,7 +3344,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(21, [
@@ -3359,7 +3359,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(21, [
@@ -3377,7 +3377,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(21, [
@@ -3398,7 +3398,7 @@ TestInterpreterOutputTrace(
             3,
             7,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(21, [
@@ -3416,7 +3416,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(21, [
@@ -3435,7 +3435,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Prime(PrimeNumber(7))),
             Vid(3): Some(Composite(CompositeNumber(21, [
@@ -3490,7 +3490,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3505,7 +3505,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3525,7 +3525,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3541,7 +3541,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3559,7 +3559,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3580,7 +3580,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3601,7 +3601,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3623,7 +3623,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3674,7 +3674,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3690,7 +3690,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3708,7 +3708,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3729,7 +3729,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3750,7 +3750,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3772,7 +3772,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3824,7 +3824,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3841,7 +3841,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3861,7 +3861,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3884,7 +3884,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3906,7 +3906,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -3929,7 +3929,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -549,7 +549,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -570,7 +570,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -596,7 +596,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -605,7 +605,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -628,7 +628,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -637,7 +637,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -1011,7 +1011,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -1032,7 +1032,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -1062,7 +1062,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -1071,7 +1071,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -1096,7 +1096,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -1105,7 +1105,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -1481,7 +1481,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -1504,7 +1504,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -1530,7 +1530,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1541,7 +1541,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1564,7 +1564,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1575,7 +1575,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
@@ -5,32 +5,32 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -285,7 +285,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -310,7 +310,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -353,7 +353,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -378,7 +378,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -421,7 +421,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -446,7 +446,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -508,7 +508,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(57): TraceOp(
         opid: Opid(57),
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -533,7 +533,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(58)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(60): TraceOp(
         opid: Opid(60),
@@ -559,7 +559,7 @@ TestInterpreterOutputTrace(
       Opid(61): TraceOp(
         opid: Opid(61),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -580,7 +580,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(61)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(63): TraceOp(
         opid: Opid(63),
@@ -617,7 +617,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -649,7 +649,7 @@ TestInterpreterOutputTrace(
       Opid(65): TraceOp(
         opid: Opid(65),
         parent_opid: Some(Opid(64)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -667,7 +667,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -692,7 +692,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -735,7 +735,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -760,7 +760,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -803,7 +803,7 @@ TestInterpreterOutputTrace(
       Opid(81): TraceOp(
         opid: Opid(81),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -828,7 +828,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -875,7 +875,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -906,7 +906,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -970,7 +970,7 @@ TestInterpreterOutputTrace(
       Opid(100): TraceOp(
         opid: Opid(100),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(101): TraceOp(
         opid: Opid(101),
@@ -985,7 +985,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -995,7 +995,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(102)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(104): TraceOp(
         opid: Opid(104),
@@ -1021,7 +1021,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1042,7 +1042,7 @@ TestInterpreterOutputTrace(
       Opid(106): TraceOp(
         opid: Opid(106),
         parent_opid: Some(Opid(105)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1083,7 +1083,7 @@ TestInterpreterOutputTrace(
       Opid(108): TraceOp(
         opid: Opid(108),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1117,7 +1117,7 @@ TestInterpreterOutputTrace(
       Opid(109): TraceOp(
         opid: Opid(109),
         parent_opid: Some(Opid(108)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(110): TraceOp(
         opid: Opid(110),
@@ -1133,7 +1133,7 @@ TestInterpreterOutputTrace(
       Opid(111): TraceOp(
         opid: Opid(111),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1158,7 +1158,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1201,7 +1201,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1226,7 +1226,7 @@ TestInterpreterOutputTrace(
       Opid(120): TraceOp(
         opid: Opid(120),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1273,7 +1273,7 @@ TestInterpreterOutputTrace(
       Opid(125): TraceOp(
         opid: Opid(125),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1304,7 +1304,7 @@ TestInterpreterOutputTrace(
       Opid(127): TraceOp(
         opid: Opid(127),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1349,7 +1349,7 @@ TestInterpreterOutputTrace(
       Opid(132): TraceOp(
         opid: Opid(132),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1374,7 +1374,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1436,7 +1436,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(145): TraceOp(
         opid: Opid(145),
@@ -1451,7 +1451,7 @@ TestInterpreterOutputTrace(
       Opid(146): TraceOp(
         opid: Opid(146),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1461,7 +1461,7 @@ TestInterpreterOutputTrace(
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(146)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1491,7 +1491,7 @@ TestInterpreterOutputTrace(
       Opid(149): TraceOp(
         opid: Opid(149),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1514,7 +1514,7 @@ TestInterpreterOutputTrace(
       Opid(150): TraceOp(
         opid: Opid(150),
         parent_opid: Some(Opid(149)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(151): TraceOp(
         opid: Opid(151),
@@ -1553,7 +1553,7 @@ TestInterpreterOutputTrace(
       Opid(152): TraceOp(
         opid: Opid(152),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1587,7 +1587,7 @@ TestInterpreterOutputTrace(
       Opid(153): TraceOp(
         opid: Opid(153),
         parent_opid: Some(Opid(152)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1606,7 +1606,7 @@ TestInterpreterOutputTrace(
       Opid(155): TraceOp(
         opid: Opid(155),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1631,7 +1631,7 @@ TestInterpreterOutputTrace(
       Opid(157): TraceOp(
         opid: Opid(157),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1678,7 +1678,7 @@ TestInterpreterOutputTrace(
       Opid(162): TraceOp(
         opid: Opid(162),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1709,7 +1709,7 @@ TestInterpreterOutputTrace(
       Opid(164): TraceOp(
         opid: Opid(164),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1754,7 +1754,7 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1779,7 +1779,7 @@ TestInterpreterOutputTrace(
       Opid(171): TraceOp(
         opid: Opid(171),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1828,7 +1828,7 @@ TestInterpreterOutputTrace(
       Opid(176): TraceOp(
         opid: Opid(176),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1862,7 +1862,7 @@ TestInterpreterOutputTrace(
       Opid(178): TraceOp(
         opid: Opid(178),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -92,13 +92,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -113,13 +113,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -139,13 +139,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -171,13 +171,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -219,7 +219,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -244,7 +244,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
           },
@@ -276,7 +276,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -287,7 +287,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -312,7 +312,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -344,7 +344,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -355,7 +355,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -366,7 +366,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -380,7 +380,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -412,7 +412,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -423,7 +423,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -434,7 +434,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -448,7 +448,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -515,7 +515,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -525,7 +525,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -540,13 +540,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -561,13 +561,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -587,13 +587,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -602,7 +602,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -619,13 +619,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -634,7 +634,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -658,7 +658,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -669,7 +669,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -694,7 +694,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -726,7 +726,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -737,7 +737,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -748,7 +748,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -762,7 +762,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -794,7 +794,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -805,7 +805,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -816,7 +816,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -830,7 +830,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -864,7 +864,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -879,7 +879,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -892,7 +892,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -908,7 +908,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -977,7 +977,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -987,7 +987,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -1002,13 +1002,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -1023,13 +1023,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -1053,13 +1053,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -1068,7 +1068,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -1087,13 +1087,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -1102,7 +1102,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -1124,7 +1124,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1135,7 +1135,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1146,7 +1146,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1160,7 +1160,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -1192,7 +1192,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1203,7 +1203,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1214,7 +1214,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1228,7 +1228,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1262,7 +1262,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1277,7 +1277,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1290,7 +1290,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1306,7 +1306,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1340,7 +1340,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1351,7 +1351,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1362,7 +1362,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1376,7 +1376,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1443,7 +1443,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1453,7 +1453,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -1472,13 +1472,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1495,13 +1495,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1521,13 +1521,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1538,7 +1538,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1555,13 +1555,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1572,7 +1572,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1597,7 +1597,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1608,7 +1608,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1619,7 +1619,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1633,7 +1633,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -1667,7 +1667,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1682,7 +1682,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1695,7 +1695,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1711,7 +1711,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -1745,7 +1745,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1756,7 +1756,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1767,7 +1767,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1781,7 +1781,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
           },
@@ -1816,7 +1816,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1833,7 +1833,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1847,7 +1847,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1864,7 +1864,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -91,13 +91,13 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -112,13 +112,13 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -138,13 +138,13 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -170,13 +170,13 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -207,7 +207,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(0))),
@@ -275,7 +275,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -286,7 +286,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -311,7 +311,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -354,7 +354,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -379,7 +379,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -422,7 +422,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -433,7 +433,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -447,7 +447,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -514,7 +514,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -524,7 +524,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -539,13 +539,13 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -560,13 +560,13 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -586,13 +586,13 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -601,7 +601,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -618,13 +618,13 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -657,7 +657,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -668,7 +668,7 @@ TestInterpreterOutputTrace(
         opid: Opid(67),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -679,7 +679,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -693,7 +693,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -725,7 +725,7 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -736,7 +736,7 @@ TestInterpreterOutputTrace(
         opid: Opid(74),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -747,7 +747,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -761,7 +761,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -793,7 +793,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -815,7 +815,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -829,7 +829,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -861,7 +861,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -876,7 +876,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -891,7 +891,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -907,7 +907,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -976,7 +976,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -986,7 +986,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -1001,13 +1001,13 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -1022,13 +1022,13 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -1050,7 +1050,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1058,7 +1058,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -1067,7 +1067,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -1084,7 +1084,7 @@ TestInterpreterOutputTrace(
         opid: Opid(108),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1092,7 +1092,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -1101,7 +1101,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -1123,7 +1123,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1134,7 +1134,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1145,7 +1145,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1159,7 +1159,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -1191,7 +1191,7 @@ TestInterpreterOutputTrace(
         opid: Opid(117),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1202,7 +1202,7 @@ TestInterpreterOutputTrace(
         opid: Opid(118),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1213,7 +1213,7 @@ TestInterpreterOutputTrace(
         opid: Opid(119),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1227,7 +1227,7 @@ TestInterpreterOutputTrace(
         opid: Opid(120),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1259,7 +1259,7 @@ TestInterpreterOutputTrace(
         opid: Opid(124),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1274,7 +1274,7 @@ TestInterpreterOutputTrace(
         opid: Opid(125),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1289,7 +1289,7 @@ TestInterpreterOutputTrace(
         opid: Opid(126),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1305,7 +1305,7 @@ TestInterpreterOutputTrace(
         opid: Opid(127),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1339,7 +1339,7 @@ TestInterpreterOutputTrace(
         opid: Opid(131),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1350,7 +1350,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1361,7 +1361,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1375,7 +1375,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1442,7 +1442,7 @@ TestInterpreterOutputTrace(
         opid: Opid(145),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1452,7 +1452,7 @@ TestInterpreterOutputTrace(
         opid: Opid(146),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1469,7 +1469,7 @@ TestInterpreterOutputTrace(
         opid: Opid(148),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1477,7 +1477,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1492,7 +1492,7 @@ TestInterpreterOutputTrace(
         opid: Opid(149),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1500,7 +1500,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1520,13 +1520,13 @@ TestInterpreterOutputTrace(
         opid: Opid(151),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1537,7 +1537,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1554,13 +1554,13 @@ TestInterpreterOutputTrace(
         opid: Opid(152),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1571,7 +1571,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1596,7 +1596,7 @@ TestInterpreterOutputTrace(
         opid: Opid(154),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1607,7 +1607,7 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1618,7 +1618,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1632,7 +1632,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -1664,7 +1664,7 @@ TestInterpreterOutputTrace(
         opid: Opid(161),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1679,7 +1679,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1694,7 +1694,7 @@ TestInterpreterOutputTrace(
         opid: Opid(163),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1710,7 +1710,7 @@ TestInterpreterOutputTrace(
         opid: Opid(164),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -1744,7 +1744,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1755,7 +1755,7 @@ TestInterpreterOutputTrace(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1766,7 +1766,7 @@ TestInterpreterOutputTrace(
         opid: Opid(170),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1780,7 +1780,7 @@ TestInterpreterOutputTrace(
         opid: Opid(171),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(5))),
@@ -1812,7 +1812,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1829,7 +1829,7 @@ TestInterpreterOutputTrace(
         opid: Opid(176),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1846,7 +1846,7 @@ TestInterpreterOutputTrace(
         opid: Opid(177),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1863,7 +1863,7 @@ TestInterpreterOutputTrace(
         opid: Opid(178),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Composite", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -315,7 +315,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -407,7 +407,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -436,7 +436,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -460,7 +460,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -499,7 +499,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(15)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -534,7 +534,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -558,7 +558,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -604,7 +604,7 @@ TestInterpreterOutputTrace(
       Opid(52): TraceOp(
         opid: Opid(52),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -657,7 +657,7 @@ TestInterpreterOutputTrace(
       Opid(57): TraceOp(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -706,7 +706,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -727,7 +727,7 @@ TestInterpreterOutputTrace(
       Opid(66): TraceOp(
         opid: Opid(66),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -741,7 +741,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(66)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -777,7 +777,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -806,7 +806,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(69)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -830,7 +830,7 @@ TestInterpreterOutputTrace(
       Opid(72): TraceOp(
         opid: Opid(72),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -876,7 +876,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -922,7 +922,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -951,7 +951,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(69)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -975,7 +975,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1014,7 +1014,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(66)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -1035,7 +1035,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1049,7 +1049,7 @@ TestInterpreterOutputTrace(
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(92)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(16, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(16, [
           2,
         ])))),
       ),
@@ -1073,7 +1073,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1119,7 +1119,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
@@ -1148,7 +1148,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(92)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(32, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(32, [
           2,
         ])))),
       ),
@@ -1172,7 +1172,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -58,7 +58,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -93,7 +93,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -103,7 +103,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -168,7 +168,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -202,7 +202,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -225,7 +225,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -270,7 +270,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -299,7 +299,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -316,7 +316,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -362,7 +362,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -391,7 +391,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -408,7 +408,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -444,7 +444,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -461,7 +461,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -507,7 +507,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -521,7 +521,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -542,7 +542,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -559,7 +559,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -588,7 +588,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -605,7 +605,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -641,7 +641,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -658,7 +658,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -714,7 +714,7 @@ TestInterpreterOutputTrace(
         opid: Opid(65),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -728,7 +728,7 @@ TestInterpreterOutputTrace(
         opid: Opid(66),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -749,7 +749,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -759,7 +759,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -778,7 +778,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -788,7 +788,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -814,7 +814,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -831,7 +831,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -860,7 +860,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -877,7 +877,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -906,7 +906,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -923,7 +923,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -959,7 +959,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -976,7 +976,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1022,7 +1022,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1036,7 +1036,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1057,7 +1057,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1074,7 +1074,7 @@ TestInterpreterOutputTrace(
         opid: Opid(95),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1103,7 +1103,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1120,7 +1120,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(16, [
+          active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
           tokens: {
@@ -1156,7 +1156,7 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {
@@ -1173,7 +1173,7 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(32, [
+          active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -61,7 +61,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -125,7 +125,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -133,7 +133,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -161,7 +161,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -205,7 +205,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -213,7 +213,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -256,7 +256,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -302,7 +302,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -319,7 +319,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -348,7 +348,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -394,7 +394,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -411,7 +411,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -447,7 +447,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -464,7 +464,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -510,7 +510,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -524,7 +524,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -545,7 +545,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -562,7 +562,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -591,7 +591,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -608,7 +608,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -644,7 +644,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -661,7 +661,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -731,7 +731,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -752,7 +752,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -760,7 +760,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -781,7 +781,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -789,7 +789,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -817,7 +817,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -834,7 +834,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -863,7 +863,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -880,7 +880,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -909,7 +909,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -926,7 +926,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -962,7 +962,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -979,7 +979,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1025,7 +1025,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1039,7 +1039,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1060,7 +1060,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1077,7 +1077,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1106,7 +1106,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1123,7 +1123,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(16, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1159,7 +1159,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1176,7 +1176,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(32, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -174,7 +174,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -187,7 +187,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -765,7 +765,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),
@@ -794,7 +794,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(8, [
                   2,
                 ]))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -5,32 +5,32 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -336,7 +336,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(41): TraceOp(
         opid: Opid(41),
@@ -351,7 +351,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(42)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
@@ -387,7 +387,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -408,7 +408,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
@@ -445,7 +445,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -477,7 +477,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(48)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -494,7 +494,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -519,7 +519,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -544,7 +544,7 @@ TestInterpreterOutputTrace(
       Opid(57): TraceOp(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -571,7 +571,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(69): TraceOp(
         opid: Opid(69),
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -643,7 +643,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(70)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(72): TraceOp(
         opid: Opid(72),
@@ -669,7 +669,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -690,7 +690,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -731,7 +731,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -765,7 +765,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(78): TraceOp(
         opid: Opid(78),
@@ -780,7 +780,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -805,7 +805,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -832,7 +832,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -859,7 +859,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -904,7 +904,7 @@ TestInterpreterOutputTrace(
       Opid(96): TraceOp(
         opid: Opid(96),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
@@ -919,7 +919,7 @@ TestInterpreterOutputTrace(
       Opid(98): TraceOp(
         opid: Opid(98),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -929,7 +929,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(98)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -959,7 +959,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -982,7 +982,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(101)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(103): TraceOp(
         opid: Opid(103),
@@ -1021,7 +1021,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1055,7 +1055,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1073,7 +1073,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1100,7 +1100,7 @@ TestInterpreterOutputTrace(
       Opid(110): TraceOp(
         opid: Opid(110),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1127,7 +1127,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1155,7 +1155,7 @@ TestInterpreterOutputTrace(
       Opid(116): TraceOp(
         opid: Opid(116),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1185,7 +1185,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1249,7 +1249,7 @@ TestInterpreterOutputTrace(
       Opid(128): TraceOp(
         opid: Opid(128),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1270,7 +1270,7 @@ TestInterpreterOutputTrace(
       Opid(130): TraceOp(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1284,7 +1284,7 @@ TestInterpreterOutputTrace(
       Opid(131): TraceOp(
         opid: Opid(131),
         parent_opid: Some(Opid(130)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(132): TraceOp(
         opid: Opid(132),
@@ -1316,7 +1316,7 @@ TestInterpreterOutputTrace(
       Opid(133): TraceOp(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1343,7 +1343,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(133)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1394,7 +1394,7 @@ TestInterpreterOutputTrace(
       Opid(136): TraceOp(
         opid: Opid(136),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1437,7 +1437,7 @@ TestInterpreterOutputTrace(
       Opid(137): TraceOp(
         opid: Opid(137),
         parent_opid: Some(Opid(136)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(138): TraceOp(
         opid: Opid(138),
@@ -1456,7 +1456,7 @@ TestInterpreterOutputTrace(
       Opid(139): TraceOp(
         opid: Opid(139),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1487,7 +1487,7 @@ TestInterpreterOutputTrace(
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1519,7 +1519,7 @@ TestInterpreterOutputTrace(
       Opid(145): TraceOp(
         opid: Opid(145),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1553,7 +1553,7 @@ TestInterpreterOutputTrace(
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1601,7 +1601,7 @@ TestInterpreterOutputTrace(
       Opid(152): TraceOp(
         opid: Opid(152),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1648,7 +1648,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(161): TraceOp(
         opid: Opid(161),
@@ -1663,7 +1663,7 @@ TestInterpreterOutputTrace(
       Opid(162): TraceOp(
         opid: Opid(162),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1673,7 +1673,7 @@ TestInterpreterOutputTrace(
       Opid(163): TraceOp(
         opid: Opid(163),
         parent_opid: Some(Opid(162)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1705,7 +1705,7 @@ TestInterpreterOutputTrace(
       Opid(165): TraceOp(
         opid: Opid(165),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1729,7 +1729,7 @@ TestInterpreterOutputTrace(
       Opid(166): TraceOp(
         opid: Opid(166),
         parent_opid: Some(Opid(165)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(167): TraceOp(
         opid: Opid(167),
@@ -1769,7 +1769,7 @@ TestInterpreterOutputTrace(
       Opid(168): TraceOp(
         opid: Opid(168),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1804,7 +1804,7 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(168)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -1821,7 +1821,7 @@ TestInterpreterOutputTrace(
       Opid(171): TraceOp(
         opid: Opid(171),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1849,7 +1849,7 @@ TestInterpreterOutputTrace(
       Opid(174): TraceOp(
         opid: Opid(174),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1879,7 +1879,7 @@ TestInterpreterOutputTrace(
       Opid(176): TraceOp(
         opid: Opid(176),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1923,7 +1923,7 @@ TestInterpreterOutputTrace(
       Opid(181): TraceOp(
         opid: Opid(181),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1950,7 +1950,7 @@ TestInterpreterOutputTrace(
       Opid(184): TraceOp(
         opid: Opid(184),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -92,13 +92,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -113,13 +113,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -139,13 +139,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -171,13 +171,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(0))),
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(1))),
@@ -258,7 +258,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(2))),
@@ -283,7 +283,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -293,7 +293,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(3))),
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -353,7 +353,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -368,13 +368,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -389,13 +389,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -415,13 +415,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -430,7 +430,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -447,13 +447,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -462,7 +462,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -496,7 +496,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(1))),
@@ -511,7 +511,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -521,7 +521,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(2))),
@@ -536,7 +536,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(3))),
@@ -563,7 +563,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -575,7 +575,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(4))),
@@ -625,7 +625,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -635,7 +635,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -650,13 +650,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -671,13 +671,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -701,13 +701,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -716,7 +716,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -735,13 +735,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -750,7 +750,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -772,7 +772,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -782,7 +782,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -797,7 +797,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -807,7 +807,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(3))),
@@ -824,7 +824,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -836,7 +836,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(4))),
@@ -851,7 +851,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -861,7 +861,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(5))),
@@ -911,7 +911,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -921,7 +921,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -940,13 +940,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -963,13 +963,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -989,13 +989,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1006,7 +1006,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1023,13 +1023,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1040,7 +1040,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1065,7 +1065,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1075,7 +1075,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -1092,7 +1092,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1104,7 +1104,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(4))),
@@ -1119,7 +1119,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1129,7 +1129,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(5))),
@@ -1147,7 +1147,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1160,7 +1160,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(6))),
@@ -1173,7 +1173,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1190,7 +1190,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1260,7 +1260,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1274,7 +1274,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1291,7 +1291,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1299,7 +1299,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1318,7 +1318,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1326,7 +1326,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1356,7 +1356,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1364,7 +1364,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1375,7 +1375,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1399,7 +1399,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1407,7 +1407,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1418,7 +1418,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1446,7 +1446,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1460,7 +1460,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1477,7 +1477,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1489,7 +1489,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1509,7 +1509,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1524,7 +1524,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1539,7 +1539,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1558,7 +1558,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1591,7 +1591,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1603,7 +1603,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1655,7 +1655,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1665,7 +1665,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -1686,13 +1686,13 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1710,13 +1710,13 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1736,13 +1736,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1754,7 +1754,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
                   suspended_vertices: [
@@ -1771,13 +1771,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1789,7 +1789,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
                   suspended_vertices: [
@@ -1813,7 +1813,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1823,7 +1823,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -1841,7 +1841,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1854,7 +1854,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(6))),
@@ -1867,7 +1867,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1884,7 +1884,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1915,7 +1915,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1925,7 +1925,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(7))),
@@ -1942,7 +1942,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1954,7 +1954,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(8))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -91,13 +91,13 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -112,13 +112,13 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -138,13 +138,13 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -170,13 +170,13 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -207,7 +207,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -282,7 +282,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -352,7 +352,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -367,13 +367,13 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -388,13 +388,13 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -414,13 +414,13 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -446,13 +446,13 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -461,7 +461,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -485,7 +485,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -495,7 +495,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -510,7 +510,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -535,7 +535,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -545,7 +545,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -560,7 +560,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -572,7 +572,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -624,7 +624,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -634,7 +634,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -649,13 +649,13 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -670,13 +670,13 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -698,7 +698,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -706,7 +706,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -715,7 +715,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -732,7 +732,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -740,7 +740,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -749,7 +749,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -771,7 +771,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -781,7 +781,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -796,7 +796,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -806,7 +806,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -821,7 +821,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -833,7 +833,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -850,7 +850,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -860,7 +860,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -910,7 +910,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -920,7 +920,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -937,7 +937,7 @@ TestInterpreterOutputTrace(
         opid: Opid(100),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -945,7 +945,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -960,7 +960,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -968,7 +968,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -988,13 +988,13 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1005,7 +1005,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1022,13 +1022,13 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1039,7 +1039,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1064,7 +1064,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1074,7 +1074,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1089,7 +1089,7 @@ TestInterpreterOutputTrace(
         opid: Opid(109),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1101,7 +1101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1118,7 +1118,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1128,7 +1128,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1143,7 +1143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1156,7 +1156,7 @@ TestInterpreterOutputTrace(
         opid: Opid(116),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1169,7 +1169,7 @@ TestInterpreterOutputTrace(
         opid: Opid(117),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1186,7 +1186,7 @@ TestInterpreterOutputTrace(
         opid: Opid(118),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1257,7 +1257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1271,7 +1271,7 @@ TestInterpreterOutputTrace(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1290,7 +1290,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1298,7 +1298,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1317,7 +1317,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1325,7 +1325,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1352,7 +1352,7 @@ TestInterpreterOutputTrace(
         opid: Opid(135),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1363,7 +1363,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1374,7 +1374,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -1395,7 +1395,7 @@ TestInterpreterOutputTrace(
         opid: Opid(136),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1417,7 +1417,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -1443,7 +1443,7 @@ TestInterpreterOutputTrace(
         opid: Opid(138),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1457,7 +1457,7 @@ TestInterpreterOutputTrace(
         opid: Opid(139),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1476,7 +1476,7 @@ TestInterpreterOutputTrace(
         opid: Opid(141),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1488,7 +1488,7 @@ TestInterpreterOutputTrace(
         opid: Opid(142),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1505,7 +1505,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1520,7 +1520,7 @@ TestInterpreterOutputTrace(
         opid: Opid(145),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1535,7 +1535,7 @@ TestInterpreterOutputTrace(
         opid: Opid(146),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1554,7 +1554,7 @@ TestInterpreterOutputTrace(
         opid: Opid(147),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1590,7 +1590,7 @@ TestInterpreterOutputTrace(
         opid: Opid(151),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1602,7 +1602,7 @@ TestInterpreterOutputTrace(
         opid: Opid(152),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1654,7 +1654,7 @@ TestInterpreterOutputTrace(
         opid: Opid(161),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1664,7 +1664,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1682,7 +1682,7 @@ TestInterpreterOutputTrace(
         opid: Opid(164),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1691,7 +1691,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1706,7 +1706,7 @@ TestInterpreterOutputTrace(
         opid: Opid(165),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1715,7 +1715,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1735,13 +1735,13 @@ TestInterpreterOutputTrace(
         opid: Opid(167),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1753,7 +1753,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
@@ -1770,13 +1770,13 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1788,7 +1788,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
@@ -1812,7 +1812,7 @@ TestInterpreterOutputTrace(
         opid: Opid(170),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1822,7 +1822,7 @@ TestInterpreterOutputTrace(
         opid: Opid(171),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1837,7 +1837,7 @@ TestInterpreterOutputTrace(
         opid: Opid(173),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1850,7 +1850,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1863,7 +1863,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1880,7 +1880,7 @@ TestInterpreterOutputTrace(
         opid: Opid(176),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1914,7 +1914,7 @@ TestInterpreterOutputTrace(
         opid: Opid(180),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1924,7 +1924,7 @@ TestInterpreterOutputTrace(
         opid: Opid(181),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1939,7 +1939,7 @@ TestInterpreterOutputTrace(
         opid: Opid(183),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -1951,7 +1951,7 @@ TestInterpreterOutputTrace(
         opid: Opid(184),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -377,7 +377,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -433,7 +433,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -456,7 +456,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -465,7 +465,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -659,7 +659,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -710,7 +710,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -719,7 +719,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -744,7 +744,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -753,7 +753,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -949,7 +949,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -972,7 +972,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -998,7 +998,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1009,7 +1009,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1032,7 +1032,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1043,7 +1043,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1304,7 +1304,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1331,7 +1331,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1369,7 +1369,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -1380,7 +1380,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1412,7 +1412,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -1423,7 +1423,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1695,7 +1695,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
             ),
@@ -1719,7 +1719,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
             ),
@@ -1745,7 +1745,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(6, [
                   2,
                   3,
@@ -1757,7 +1757,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(5))),
                   ],
                 ),
@@ -1780,7 +1780,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(6, [
                   2,
                   3,
@@ -1792,7 +1792,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(5))),
                   ],
                 ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -5,32 +5,32 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "value")),
+        content: Call(ResolveProperty(Vid(2), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -60,7 +60,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(14)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -132,7 +132,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(17)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(20)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -241,7 +241,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -266,7 +266,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -291,7 +291,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -336,7 +336,7 @@ TestInterpreterOutputTrace(
       Opid(40): TraceOp(
         opid: Opid(40),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(41): TraceOp(
         opid: Opid(41),
@@ -351,7 +351,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(42)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(44): TraceOp(
         opid: Opid(44),
@@ -387,7 +387,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -408,7 +408,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
@@ -445,7 +445,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -477,7 +477,7 @@ TestInterpreterOutputTrace(
       Opid(49): TraceOp(
         opid: Opid(49),
         parent_opid: Some(Opid(48)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -494,7 +494,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -519,7 +519,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -544,7 +544,7 @@ TestInterpreterOutputTrace(
       Opid(57): TraceOp(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -571,7 +571,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -618,7 +618,7 @@ TestInterpreterOutputTrace(
       Opid(68): TraceOp(
         opid: Opid(68),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(69): TraceOp(
         opid: Opid(69),
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -643,7 +643,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(70)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(72): TraceOp(
         opid: Opid(72),
@@ -669,7 +669,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -690,7 +690,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -731,7 +731,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -765,7 +765,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(78): TraceOp(
         opid: Opid(78),
@@ -780,7 +780,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -805,7 +805,7 @@ TestInterpreterOutputTrace(
       Opid(82): TraceOp(
         opid: Opid(82),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -832,7 +832,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -859,7 +859,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -904,7 +904,7 @@ TestInterpreterOutputTrace(
       Opid(96): TraceOp(
         opid: Opid(96),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
@@ -919,7 +919,7 @@ TestInterpreterOutputTrace(
       Opid(98): TraceOp(
         opid: Opid(98),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -929,7 +929,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(98)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -959,7 +959,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -982,7 +982,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(101)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(103): TraceOp(
         opid: Opid(103),
@@ -1021,7 +1021,7 @@ TestInterpreterOutputTrace(
       Opid(104): TraceOp(
         opid: Opid(104),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1055,7 +1055,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(104)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1073,7 +1073,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1100,7 +1100,7 @@ TestInterpreterOutputTrace(
       Opid(110): TraceOp(
         opid: Opid(110),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1127,7 +1127,7 @@ TestInterpreterOutputTrace(
       Opid(113): TraceOp(
         opid: Opid(113),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1155,7 +1155,7 @@ TestInterpreterOutputTrace(
       Opid(116): TraceOp(
         opid: Opid(116),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1203,7 +1203,7 @@ TestInterpreterOutputTrace(
       Opid(124): TraceOp(
         opid: Opid(124),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1224,7 +1224,7 @@ TestInterpreterOutputTrace(
       Opid(126): TraceOp(
         opid: Opid(126),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1238,7 +1238,7 @@ TestInterpreterOutputTrace(
       Opid(127): TraceOp(
         opid: Opid(127),
         parent_opid: Some(Opid(126)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(128): TraceOp(
         opid: Opid(128),
@@ -1270,7 +1270,7 @@ TestInterpreterOutputTrace(
       Opid(129): TraceOp(
         opid: Opid(129),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1297,7 +1297,7 @@ TestInterpreterOutputTrace(
       Opid(130): TraceOp(
         opid: Opid(130),
         parent_opid: Some(Opid(129)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1348,7 +1348,7 @@ TestInterpreterOutputTrace(
       Opid(132): TraceOp(
         opid: Opid(132),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1391,7 +1391,7 @@ TestInterpreterOutputTrace(
       Opid(133): TraceOp(
         opid: Opid(133),
         parent_opid: Some(Opid(132)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(134): TraceOp(
         opid: Opid(134),
@@ -1410,7 +1410,7 @@ TestInterpreterOutputTrace(
       Opid(135): TraceOp(
         opid: Opid(135),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1441,7 +1441,7 @@ TestInterpreterOutputTrace(
       Opid(138): TraceOp(
         opid: Opid(138),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1473,7 +1473,7 @@ TestInterpreterOutputTrace(
       Opid(141): TraceOp(
         opid: Opid(141),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1505,7 +1505,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -1552,7 +1552,7 @@ TestInterpreterOutputTrace(
       Opid(152): TraceOp(
         opid: Opid(152),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(153): TraceOp(
         opid: Opid(153),
@@ -1567,7 +1567,7 @@ TestInterpreterOutputTrace(
       Opid(154): TraceOp(
         opid: Opid(154),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1577,7 +1577,7 @@ TestInterpreterOutputTrace(
       Opid(155): TraceOp(
         opid: Opid(155),
         parent_opid: Some(Opid(154)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1609,7 +1609,7 @@ TestInterpreterOutputTrace(
       Opid(157): TraceOp(
         opid: Opid(157),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1633,7 +1633,7 @@ TestInterpreterOutputTrace(
       Opid(158): TraceOp(
         opid: Opid(158),
         parent_opid: Some(Opid(157)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(7)))),
       ),
       Opid(159): TraceOp(
         opid: Opid(159),
@@ -1673,7 +1673,7 @@ TestInterpreterOutputTrace(
       Opid(160): TraceOp(
         opid: Opid(160),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1708,7 +1708,7 @@ TestInterpreterOutputTrace(
       Opid(161): TraceOp(
         opid: Opid(161),
         parent_opid: Some(Opid(160)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -1725,7 +1725,7 @@ TestInterpreterOutputTrace(
       Opid(163): TraceOp(
         opid: Opid(163),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1753,7 +1753,7 @@ TestInterpreterOutputTrace(
       Opid(166): TraceOp(
         opid: Opid(166),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1781,7 +1781,7 @@ TestInterpreterOutputTrace(
       Opid(169): TraceOp(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -1808,7 +1808,7 @@ TestInterpreterOutputTrace(
       Opid(172): TraceOp(
         opid: Opid(172),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -1835,7 +1835,7 @@ TestInterpreterOutputTrace(
       Opid(174): TraceOp(
         opid: Opid(174),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(0))),
               ],
             ),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -157,7 +157,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
               piggyback: Some([
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(0))),
                   ],
                 ),
@@ -377,7 +377,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Neither(NeitherNumber(1))),
               ],
             ),
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -433,7 +433,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -456,7 +456,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
               piggyback: Some([
@@ -465,7 +465,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Neither(NeitherNumber(1))),
                   ],
                 ),
@@ -659,7 +659,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(2))),
               ],
             ),
@@ -710,7 +710,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -719,7 +719,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -744,7 +744,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
               piggyback: Some([
@@ -753,7 +753,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(2))),
                   ],
                 ),
@@ -949,7 +949,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -972,7 +972,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(3))),
               ],
             ),
@@ -998,7 +998,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1009,7 +1009,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1032,7 +1032,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1043,7 +1043,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(3))),
                   ],
                 ),
@@ -1258,7 +1258,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1285,7 +1285,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1323,7 +1323,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -1334,7 +1334,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1366,7 +1366,7 @@ TestInterpreterOutputTrace(
                   2,
                 ]))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
               piggyback: Some([
@@ -1377,7 +1377,7 @@ TestInterpreterOutputTrace(
                       2,
                     ]))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1599,7 +1599,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
             ),
@@ -1623,7 +1623,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Prime(PrimeNumber(5))),
               ],
             ),
@@ -1649,7 +1649,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(6, [
                   2,
                   3,
@@ -1661,7 +1661,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(5))),
                   ],
                 ),
@@ -1684,7 +1684,7 @@ TestInterpreterOutputTrace(
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
-              suspended_tokens: [
+              suspended_vertices: [
                 Some(Composite(CompositeNumber(6, [
                   2,
                   3,
@@ -1696,7 +1696,7 @@ TestInterpreterOutputTrace(
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
-                  suspended_tokens: [
+                  suspended_vertices: [
                     Some(Prime(PrimeNumber(5))),
                   ],
                 ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -91,13 +91,13 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -112,13 +112,13 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -138,13 +138,13 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -170,13 +170,13 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
@@ -185,7 +185,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
@@ -207,7 +207,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -217,7 +217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -232,7 +232,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -242,7 +242,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -257,7 +257,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -267,7 +267,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -282,7 +282,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -352,7 +352,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -367,13 +367,13 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -388,13 +388,13 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -414,13 +414,13 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -446,13 +446,13 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
@@ -461,7 +461,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
@@ -485,7 +485,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -495,7 +495,7 @@ TestInterpreterOutputTrace(
         opid: Opid(51),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -510,7 +510,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -535,7 +535,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -545,7 +545,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -560,7 +560,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -572,7 +572,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -624,7 +624,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -634,7 +634,7 @@ TestInterpreterOutputTrace(
         opid: Opid(70),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -649,13 +649,13 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -670,13 +670,13 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -698,7 +698,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -706,7 +706,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -715,7 +715,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -732,7 +732,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -740,7 +740,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
@@ -749,7 +749,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
@@ -771,7 +771,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -781,7 +781,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -796,7 +796,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -806,7 +806,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -821,7 +821,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -833,7 +833,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -850,7 +850,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -860,7 +860,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -910,7 +910,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -920,7 +920,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -937,7 +937,7 @@ TestInterpreterOutputTrace(
         opid: Opid(100),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -945,7 +945,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -960,7 +960,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -968,7 +968,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -988,13 +988,13 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1005,7 +1005,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1022,13 +1022,13 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
@@ -1039,7 +1039,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
@@ -1064,7 +1064,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1074,7 +1074,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1089,7 +1089,7 @@ TestInterpreterOutputTrace(
         opid: Opid(109),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1101,7 +1101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(110),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1118,7 +1118,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1128,7 +1128,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1143,7 +1143,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1156,7 +1156,7 @@ TestInterpreterOutputTrace(
         opid: Opid(116),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1211,7 +1211,7 @@ TestInterpreterOutputTrace(
         opid: Opid(125),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1225,7 +1225,7 @@ TestInterpreterOutputTrace(
         opid: Opid(126),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1244,7 +1244,7 @@ TestInterpreterOutputTrace(
         opid: Opid(128),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1252,7 +1252,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1271,7 +1271,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1279,7 +1279,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1306,7 +1306,7 @@ TestInterpreterOutputTrace(
         opid: Opid(131),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1317,7 +1317,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1328,7 +1328,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -1349,7 +1349,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1360,7 +1360,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
@@ -1371,7 +1371,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
@@ -1397,7 +1397,7 @@ TestInterpreterOutputTrace(
         opid: Opid(134),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1411,7 +1411,7 @@ TestInterpreterOutputTrace(
         opid: Opid(135),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1430,7 +1430,7 @@ TestInterpreterOutputTrace(
         opid: Opid(137),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1442,7 +1442,7 @@ TestInterpreterOutputTrace(
         opid: Opid(138),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1459,7 +1459,7 @@ TestInterpreterOutputTrace(
         opid: Opid(140),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1474,7 +1474,7 @@ TestInterpreterOutputTrace(
         opid: Opid(141),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1494,7 +1494,7 @@ TestInterpreterOutputTrace(
         opid: Opid(143),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1506,7 +1506,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -1558,7 +1558,7 @@ TestInterpreterOutputTrace(
         opid: Opid(153),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1568,7 +1568,7 @@ TestInterpreterOutputTrace(
         opid: Opid(154),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1586,7 +1586,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1595,7 +1595,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1610,7 +1610,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1619,7 +1619,7 @@ TestInterpreterOutputTrace(
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1639,13 +1639,13 @@ TestInterpreterOutputTrace(
         opid: Opid(159),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1657,7 +1657,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
@@ -1674,13 +1674,13 @@ TestInterpreterOutputTrace(
         opid: Opid(160),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
-              current_token: None,
+              active_vertex: None,
               tokens: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
@@ -1692,7 +1692,7 @@ TestInterpreterOutputTrace(
               ],
               piggyback: Some([
                 SerializableContext(
-                  current_token: None,
+                  active_vertex: None,
                   tokens: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
@@ -1716,7 +1716,7 @@ TestInterpreterOutputTrace(
         opid: Opid(162),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1726,7 +1726,7 @@ TestInterpreterOutputTrace(
         opid: Opid(163),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1741,7 +1741,7 @@ TestInterpreterOutputTrace(
         opid: Opid(165),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1754,7 +1754,7 @@ TestInterpreterOutputTrace(
         opid: Opid(166),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1772,7 +1772,7 @@ TestInterpreterOutputTrace(
         opid: Opid(168),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1782,7 +1782,7 @@ TestInterpreterOutputTrace(
         opid: Opid(169),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -1797,7 +1797,7 @@ TestInterpreterOutputTrace(
         opid: Opid(171),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -1809,7 +1809,7 @@ TestInterpreterOutputTrace(
         opid: Opid(172),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -1821,7 +1821,7 @@ TestInterpreterOutputTrace(
         opid: Opid(173),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -1836,7 +1836,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -92,13 +92,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -113,13 +113,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -139,13 +139,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -171,13 +171,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(0))),
               },
               suspended_vertices: [
@@ -186,7 +186,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(0))),
                   },
                   suspended_vertices: [
@@ -208,7 +208,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(0))),
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(1))),
@@ -258,7 +258,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(2))),
@@ -283,7 +283,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -293,7 +293,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), Int64(3))),
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -353,7 +353,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -368,13 +368,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -389,13 +389,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -415,13 +415,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -430,7 +430,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -447,13 +447,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Neither(NeitherNumber(1))),
               },
               suspended_vertices: [
@@ -462,7 +462,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Neither(NeitherNumber(1))),
                   },
                   suspended_vertices: [
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -496,7 +496,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(1))),
@@ -511,7 +511,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -521,7 +521,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(2))),
@@ -536,7 +536,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -546,7 +546,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(3))),
@@ -563,7 +563,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -575,7 +575,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), Int64(4))),
@@ -625,7 +625,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -635,7 +635,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -650,13 +650,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -671,13 +671,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -701,13 +701,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -716,7 +716,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -735,13 +735,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(2))),
               },
               suspended_vertices: [
@@ -750,7 +750,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(2))),
                   },
                   suspended_vertices: [
@@ -772,7 +772,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -782,7 +782,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -797,7 +797,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -807,7 +807,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(3))),
@@ -824,7 +824,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -836,7 +836,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(4))),
@@ -851,7 +851,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -861,7 +861,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(5))),
@@ -911,7 +911,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -921,7 +921,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -940,13 +940,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -963,13 +963,13 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -989,13 +989,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1006,7 +1006,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1023,13 +1023,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(3))),
               },
               suspended_vertices: [
@@ -1040,7 +1040,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(3))),
                   },
                   suspended_vertices: [
@@ -1065,7 +1065,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1075,7 +1075,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -1092,7 +1092,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1104,7 +1104,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(4))),
@@ -1119,7 +1119,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1129,7 +1129,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(5))),
@@ -1147,7 +1147,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1160,7 +1160,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(6))),
@@ -1214,7 +1214,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1228,7 +1228,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1245,7 +1245,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1253,7 +1253,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1272,7 +1272,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1280,7 +1280,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1310,7 +1310,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1318,7 +1318,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1329,7 +1329,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1353,7 +1353,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1361,7 +1361,7 @@ TestInterpreterOutputTrace(
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Composite(CompositeNumber(4, [
                   2,
                 ]))),
@@ -1372,7 +1372,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Composite(CompositeNumber(4, [
                       2,
                     ]))),
@@ -1400,7 +1400,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1414,7 +1414,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1431,7 +1431,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1443,7 +1443,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1463,7 +1463,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1478,7 +1478,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1495,7 +1495,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1507,7 +1507,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1559,7 +1559,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1569,7 +1569,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ))),
@@ -1590,13 +1590,13 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1614,13 +1614,13 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1640,13 +1640,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1658,7 +1658,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
                   suspended_vertices: [
@@ -1675,13 +1675,13 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
           piggyback: Some([
             SerializableContext(
               active_vertex: None,
-              tokens: {
+              vertices: {
                 Vid(1): Some(Prime(PrimeNumber(5))),
               },
               suspended_vertices: [
@@ -1693,7 +1693,7 @@ TestInterpreterOutputTrace(
               piggyback: Some([
                 SerializableContext(
                   active_vertex: None,
-                  tokens: {
+                  vertices: {
                     Vid(1): Some(Prime(PrimeNumber(5))),
                   },
                   suspended_vertices: [
@@ -1717,7 +1717,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1727,7 +1727,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -1745,7 +1745,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1758,7 +1758,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(6))),
@@ -1773,7 +1773,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1783,7 +1783,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(7))),
@@ -1800,7 +1800,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -1812,7 +1812,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(8))),
@@ -1824,7 +1824,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,
@@ -1839,7 +1839,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
             Vid(2): Some(Composite(CompositeNumber(8, [
               2,

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(CanCoerceToType(Vid(1), "Number", "Prime")),
+        content: Call(ResolveCoercion(Vid(1), "Number", "Prime")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(1), "Prime", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {},
         ), false)),
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -69,7 +69,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
         ), false)),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {},
         ), true)),
@@ -113,7 +113,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
@@ -153,7 +153,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {},
         ), true)),
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
       Opid(30): TraceOp(
         opid: Opid(30),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
       Opid(35): TraceOp(
         opid: Opid(35),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {},
         ), true)),
@@ -261,7 +261,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -323,7 +323,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(7)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(7)))),
       ),
       Opid(47): TraceOp(
         opid: Opid(47),
@@ -336,7 +336,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {},
         ), true)),
@@ -354,7 +354,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -398,7 +398,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -413,7 +413,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -430,7 +430,7 @@ TestInterpreterOutputTrace(
       Opid(60): TraceOp(
         opid: Opid(60),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -445,7 +445,7 @@ TestInterpreterOutputTrace(
       Opid(62): TraceOp(
         opid: Opid(62),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(10, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(10, [
           2,
           5,
         ])))),
@@ -464,7 +464,7 @@ TestInterpreterOutputTrace(
       Opid(64): TraceOp(
         opid: Opid(64),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(CanCoerceToType(SerializableContext(
+        content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(9): TraceOp(
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(13): TraceOp(
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(17): TraceOp(
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(24): TraceOp(
@@ -155,7 +155,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(25): TraceOp(
@@ -163,7 +163,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -173,7 +173,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), Int64(3))),
@@ -209,7 +209,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(32): TraceOp(
@@ -219,7 +219,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(33): TraceOp(
@@ -237,7 +237,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(36): TraceOp(
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(37): TraceOp(
@@ -253,7 +253,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         )),
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
         ), Int64(5))),
@@ -301,7 +301,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(44): TraceOp(
@@ -312,7 +312,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(45): TraceOp(
@@ -330,7 +330,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(48): TraceOp(
@@ -338,7 +338,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {},
+          vertices: {},
         ), true)),
       ),
       Opid(49): TraceOp(
@@ -346,7 +346,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         )),
@@ -356,7 +356,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(7))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
         ), Int64(7))),
@@ -392,7 +392,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(56): TraceOp(
@@ -402,7 +402,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(57): TraceOp(
@@ -424,7 +424,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(60): TraceOp(
@@ -434,7 +434,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(61): TraceOp(
@@ -458,7 +458,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(64): TraceOp(
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
             2,
             5,
           ]))),
-          tokens: {},
+          vertices: {},
         ), false)),
       ),
       Opid(65): TraceOp(

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {},
         )),
       ),
@@ -44,7 +44,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {},
         ), false)),
       ),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         )),
       ),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         ), false)),
       ),
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         )),
       ),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         ), true)),
       ),
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -114,7 +114,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         )),
       ),
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         ), true)),
       ),
@@ -162,7 +162,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -206,7 +206,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {},
@@ -236,7 +236,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         )),
       ),
@@ -244,7 +244,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {},
         ), true)),
       ),
@@ -252,7 +252,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(5))),
           },
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -308,7 +308,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -329,7 +329,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {},
         )),
       ),
@@ -337,7 +337,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {},
         ), true)),
       ),
@@ -345,7 +345,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -355,7 +355,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(7))),
+          active_vertex: Some(Prime(PrimeNumber(7))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(7))),
           },
@@ -389,7 +389,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -399,7 +399,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {},
@@ -421,7 +421,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -431,7 +431,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {},
@@ -454,7 +454,7 @@ TestInterpreterOutputTrace(
         opid: Opid(63),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),
@@ -465,7 +465,7 @@ TestInterpreterOutputTrace(
         opid: Opid(64),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(CanCoerceToType(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(10, [
+          active_vertex: Some(Composite(CompositeNumber(10, [
             2,
             5,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {},
         )),
       ),
@@ -44,7 +44,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {},
         ), Int64(0))),
       ),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         )),
       ),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         ), Int64(1))),
       ),
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         )),
       ),
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         ), Int64(2))),
       ),
@@ -114,7 +114,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         )),
       ),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {},
         ), Int64(3))),
       ),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -140,7 +140,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {},
+          vertices: {},
         ), Int64(0))),
       ),
       Opid(9): TraceOp(
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         ), Int64(1))),
       ),
       Opid(13): TraceOp(
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(16): TraceOp(
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         ), Int64(2))),
       ),
       Opid(17): TraceOp(
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(20): TraceOp(
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {},
+          vertices: {},
         ), Int64(3))),
       ),
       Opid(21): TraceOp(
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -141,7 +141,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), String("three"))),

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {},
         ), Int64(0))),
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -69,7 +69,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
         ), Int64(1))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {},
         ), Int64(2))),
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {},
         ), Int64(3))),
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -73,7 +73,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -110,7 +110,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -72,7 +72,7 @@ TestInterpreterOutputTrace(
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -94,7 +94,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -109,7 +109,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -131,7 +131,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), String("zero"))),
@@ -64,7 +64,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -74,7 +74,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), String("one"))),
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), String("two"))),
@@ -138,7 +138,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -148,7 +148,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ), String("three"))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -112,7 +112,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -123,7 +123,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
           },
@@ -159,7 +159,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -195,7 +195,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
           },
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -231,7 +231,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -250,7 +250,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -264,7 +264,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -278,7 +278,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -298,7 +298,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -318,7 +318,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -333,7 +333,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -348,7 +348,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -366,7 +366,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(4, [
@@ -433,7 +433,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(6, [
@@ -451,7 +451,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(6, [
@@ -471,7 +471,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(6, [
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(6, [
@@ -501,7 +501,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(6, [
@@ -522,7 +522,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
             Vid(3): Some(Composite(CompositeNumber(6, [
@@ -592,7 +592,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -606,7 +606,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -623,7 +623,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -636,7 +636,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -660,7 +660,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -702,7 +702,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -719,7 +719,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -738,7 +738,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -763,7 +763,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -815,7 +815,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -833,7 +833,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -858,7 +858,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -876,7 +876,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -894,7 +894,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -920,7 +920,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -5,42 +5,42 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(3), "Composite", Eid(3))),
+        content: Call(ResolveNeighbors(Vid(3), "Composite", Eid(3))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(4), "Number", "value")),
+        content: Call(ResolveProperty(Vid(4), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(4), "Number", "value")),
+        content: Call(ResolveProperty(Vid(4), "Number", "value")),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(18): TraceOp(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -105,7 +105,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(18)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
@@ -121,7 +121,7 @@ TestInterpreterOutputTrace(
       Opid(21): TraceOp(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -167,7 +167,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(28)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(30): TraceOp(
         opid: Opid(30),
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -204,7 +204,7 @@ TestInterpreterOutputTrace(
       Opid(32): TraceOp(
         opid: Opid(32),
         parent_opid: Some(Opid(31)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -227,7 +227,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -243,7 +243,7 @@ TestInterpreterOutputTrace(
       Opid(35): TraceOp(
         opid: Opid(35),
         parent_opid: Some(Opid(34)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(36): TraceOp(
         opid: Opid(36),
@@ -262,7 +262,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -296,7 +296,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -331,7 +331,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -364,7 +364,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -420,7 +420,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(31)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -446,7 +446,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -464,7 +464,7 @@ TestInterpreterOutputTrace(
       Opid(54): TraceOp(
         opid: Opid(54),
         parent_opid: Some(Opid(53)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(55): TraceOp(
         opid: Opid(55),
@@ -484,7 +484,7 @@ TestInterpreterOutputTrace(
       Opid(56): TraceOp(
         opid: Opid(56),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -520,7 +520,7 @@ TestInterpreterOutputTrace(
       Opid(58): TraceOp(
         opid: Opid(58),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -581,7 +581,7 @@ TestInterpreterOutputTrace(
       Opid(67): TraceOp(
         opid: Opid(67),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -602,7 +602,7 @@ TestInterpreterOutputTrace(
       Opid(69): TraceOp(
         opid: Opid(69),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -616,7 +616,7 @@ TestInterpreterOutputTrace(
       Opid(70): TraceOp(
         opid: Opid(70),
         parent_opid: Some(Opid(69)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(71): TraceOp(
         opid: Opid(71),
@@ -634,7 +634,7 @@ TestInterpreterOutputTrace(
       Opid(72): TraceOp(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -647,7 +647,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(72)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -675,7 +675,7 @@ TestInterpreterOutputTrace(
       Opid(75): TraceOp(
         opid: Opid(75),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -695,7 +695,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(75)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(5)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
       Opid(77): TraceOp(
         opid: Opid(77),
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
           vertices: {
             Vid(1): Some(Composite(CompositeNumber(4, [
@@ -759,7 +759,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(72)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -829,7 +829,7 @@ TestInterpreterOutputTrace(
       Opid(87): TraceOp(
         opid: Opid(87),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -847,7 +847,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(87)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(8, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(8, [
           2,
         ])))),
       ),
@@ -872,7 +872,7 @@ TestInterpreterOutputTrace(
       Opid(90): TraceOp(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
@@ -916,7 +916,7 @@ TestInterpreterOutputTrace(
       Opid(92): TraceOp(
         opid: Opid(92),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -288,7 +288,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(3),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         )),
@@ -308,7 +308,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(3),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         ), Int64(3))),
@@ -512,7 +512,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(5),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(5))),
           ],
         )),
@@ -533,7 +533,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(5),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(5))),
           ],
         ), Int64(3))),
@@ -751,7 +751,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(5),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(5))),
           ],
         )),
@@ -776,7 +776,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(5),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(5))),
           ],
         ), Int64(4))),
@@ -906,7 +906,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(8),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(8, [
               2,
             ]))),
@@ -932,7 +932,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(8),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(8, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -96,7 +96,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -111,7 +111,7 @@ TestInterpreterOutputTrace(
         opid: Opid(20),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -122,7 +122,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Neither(NeitherNumber(1))),
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -168,7 +168,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -194,7 +194,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -228,7 +228,7 @@ TestInterpreterOutputTrace(
         opid: Opid(34),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -249,7 +249,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -263,7 +263,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -277,7 +277,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -297,7 +297,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -317,7 +317,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -332,7 +332,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -347,7 +347,7 @@ TestInterpreterOutputTrace(
         opid: Opid(42),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -429,7 +429,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -447,7 +447,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -470,7 +470,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -485,7 +485,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -500,7 +500,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -521,7 +521,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Prime(PrimeNumber(2))),
@@ -589,7 +589,7 @@ TestInterpreterOutputTrace(
         opid: Opid(68),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -603,7 +603,7 @@ TestInterpreterOutputTrace(
         opid: Opid(69),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -622,7 +622,7 @@ TestInterpreterOutputTrace(
         opid: Opid(71),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -635,7 +635,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -656,7 +656,7 @@ TestInterpreterOutputTrace(
         opid: Opid(74),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -676,7 +676,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -701,7 +701,7 @@ TestInterpreterOutputTrace(
         opid: Opid(77),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -718,7 +718,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(5))),
+          active_vertex: Some(Prime(PrimeNumber(5))),
           tokens: {
             Vid(1): Some(Composite(CompositeNumber(4, [
               2,
@@ -735,7 +735,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -760,7 +760,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -812,7 +812,7 @@ TestInterpreterOutputTrace(
         opid: Opid(86),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -830,7 +830,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -855,7 +855,7 @@ TestInterpreterOutputTrace(
         opid: Opid(89),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -873,7 +873,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(8, [
+          active_vertex: Some(Composite(CompositeNumber(8, [
             2,
           ]))),
           tokens: {
@@ -891,7 +891,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -917,7 +917,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(9),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         )),
       ),
@@ -54,7 +54,7 @@ TestInterpreterOutputTrace(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         ), List([
           String("o"),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
           values: [
             List([
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
           values: [
             List([

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
@@ -5,22 +5,22 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "vowelsInName")),
+        content: Call(ResolveProperty(Vid(1), "Number", "vowelsInName")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "name")),
+        content: Call(ResolveProperty(Vid(1), "Number", "name")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -40,7 +40,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
@@ -53,7 +53,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
         ), List([
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
           values: [

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(10): TraceOp(
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         ), List([
           String("o"),
           String("e"),
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
           values: [
             List([
               String("o"),
@@ -80,7 +80,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
           values: [
             List([
               String("o"),

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -77,7 +77,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -104,7 +104,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -139,7 +139,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -154,7 +154,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -215,7 +215,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -251,7 +251,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -272,7 +272,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -330,7 +330,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -346,7 +346,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -361,7 +361,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -385,7 +385,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -435,7 +435,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -449,7 +449,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -472,7 +472,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -488,7 +488,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -505,7 +505,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -530,7 +530,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -573,7 +573,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -590,7 +590,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -607,7 +607,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -633,7 +633,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -659,7 +659,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -680,7 +680,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -701,7 +701,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -725,7 +725,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -799,7 +799,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -809,7 +809,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -827,7 +827,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -841,7 +841,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -866,7 +866,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -883,7 +883,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -900,7 +900,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -926,7 +926,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -952,7 +952,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -973,7 +973,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -994,7 +994,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1018,7 +1018,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1076,7 +1076,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1092,7 +1092,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1109,7 +1109,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1134,7 +1134,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1183,7 +1183,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1196,7 +1196,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1220,7 +1220,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1236,7 +1236,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1251,7 +1251,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1275,7 +1275,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1316,7 +1316,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1331,7 +1331,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1346,7 +1346,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1369,7 +1369,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1392,7 +1392,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1410,7 +1410,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1428,7 +1428,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1449,7 +1449,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -5,37 +5,37 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(3), "Composite", "value")),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(15): TraceOp(
         opid: Opid(15),
@@ -85,7 +85,7 @@ TestInterpreterOutputTrace(
       Opid(16): TraceOp(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -95,7 +95,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -115,7 +115,7 @@ TestInterpreterOutputTrace(
       Opid(19): TraceOp(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -128,7 +128,7 @@ TestInterpreterOutputTrace(
       Opid(20): TraceOp(
         opid: Opid(20),
         parent_opid: Some(Opid(19)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -150,7 +150,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -188,7 +188,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -229,7 +229,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -268,7 +268,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -317,7 +317,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(19)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -341,7 +341,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
       Opid(38): TraceOp(
         opid: Opid(38),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -425,7 +425,7 @@ TestInterpreterOutputTrace(
       Opid(43): TraceOp(
         opid: Opid(43),
         parent_opid: Some(Opid(16)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -447,7 +447,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -461,7 +461,7 @@ TestInterpreterOutputTrace(
       Opid(46): TraceOp(
         opid: Opid(46),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -484,7 +484,7 @@ TestInterpreterOutputTrace(
       Opid(48): TraceOp(
         opid: Opid(48),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -525,7 +525,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -560,7 +560,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(45)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -585,7 +585,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -628,7 +628,7 @@ TestInterpreterOutputTrace(
       Opid(57): TraceOp(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -675,7 +675,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -720,7 +720,7 @@ TestInterpreterOutputTrace(
       Opid(61): TraceOp(
         opid: Opid(61),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -792,7 +792,7 @@ TestInterpreterOutputTrace(
       Opid(71): TraceOp(
         opid: Opid(71),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(72): TraceOp(
         opid: Opid(72),
@@ -807,7 +807,7 @@ TestInterpreterOutputTrace(
       Opid(73): TraceOp(
         opid: Opid(73),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -817,7 +817,7 @@ TestInterpreterOutputTrace(
       Opid(74): TraceOp(
         opid: Opid(74),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -839,7 +839,7 @@ TestInterpreterOutputTrace(
       Opid(76): TraceOp(
         opid: Opid(76),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -853,7 +853,7 @@ TestInterpreterOutputTrace(
       Opid(77): TraceOp(
         opid: Opid(77),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -878,7 +878,7 @@ TestInterpreterOutputTrace(
       Opid(79): TraceOp(
         opid: Opid(79),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -921,7 +921,7 @@ TestInterpreterOutputTrace(
       Opid(81): TraceOp(
         opid: Opid(81),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -968,7 +968,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1013,7 +1013,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1065,7 +1065,7 @@ TestInterpreterOutputTrace(
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(76)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -1088,7 +1088,7 @@ TestInterpreterOutputTrace(
       Opid(93): TraceOp(
         opid: Opid(93),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1129,7 +1129,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1174,7 +1174,7 @@ TestInterpreterOutputTrace(
       Opid(100): TraceOp(
         opid: Opid(100),
         parent_opid: Some(Opid(73)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -1194,7 +1194,7 @@ TestInterpreterOutputTrace(
       Opid(102): TraceOp(
         opid: Opid(102),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1207,7 +1207,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(102)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1231,7 +1231,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1271,7 +1271,7 @@ TestInterpreterOutputTrace(
       Opid(107): TraceOp(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1305,7 +1305,7 @@ TestInterpreterOutputTrace(
       Opid(110): TraceOp(
         opid: Opid(110),
         parent_opid: Some(Opid(102)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -1327,7 +1327,7 @@ TestInterpreterOutputTrace(
       Opid(112): TraceOp(
         opid: Opid(112),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1365,7 +1365,7 @@ TestInterpreterOutputTrace(
       Opid(114): TraceOp(
         opid: Opid(114),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
       Opid(116): TraceOp(
         opid: Opid(116),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1445,7 +1445,7 @@ TestInterpreterOutputTrace(
       Opid(118): TraceOp(
         opid: Opid(118),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -178,7 +178,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(4),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(4),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -370,7 +370,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -394,7 +394,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -515,7 +515,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(4),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -540,7 +540,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(4),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -617,7 +617,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -643,7 +643,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -910,7 +910,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -936,7 +936,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1119,7 +1119,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(9),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1144,7 +1144,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(9),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1260,7 +1260,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1284,7 +1284,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(6),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(6, [
               2,
               3,
@@ -1355,7 +1355,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(9),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(9, [
               3,
             ]))),
@@ -1378,7 +1378,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(9),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(9, [
               3,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -76,7 +76,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -86,7 +86,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -103,7 +103,7 @@ TestInterpreterOutputTrace(
         opid: Opid(18),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
         opid: Opid(19),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         opid: Opid(21),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -151,7 +151,7 @@ TestInterpreterOutputTrace(
         opid: Opid(22),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -166,7 +166,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -189,7 +189,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
         opid: Opid(25),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -230,7 +230,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -248,7 +248,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -269,7 +269,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -326,7 +326,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -358,7 +358,7 @@ TestInterpreterOutputTrace(
         opid: Opid(37),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -382,7 +382,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -434,7 +434,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -448,7 +448,7 @@ TestInterpreterOutputTrace(
         opid: Opid(45),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -469,7 +469,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -485,7 +485,7 @@ TestInterpreterOutputTrace(
         opid: Opid(48),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -501,7 +501,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -526,7 +526,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -569,7 +569,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -586,7 +586,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -603,7 +603,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -629,7 +629,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -655,7 +655,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -676,7 +676,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -697,7 +697,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -721,7 +721,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -798,7 +798,7 @@ TestInterpreterOutputTrace(
         opid: Opid(72),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -808,7 +808,7 @@ TestInterpreterOutputTrace(
         opid: Opid(73),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -826,7 +826,7 @@ TestInterpreterOutputTrace(
         opid: Opid(75),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -840,7 +840,7 @@ TestInterpreterOutputTrace(
         opid: Opid(76),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -862,7 +862,7 @@ TestInterpreterOutputTrace(
         opid: Opid(78),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -879,7 +879,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -896,7 +896,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -922,7 +922,7 @@ TestInterpreterOutputTrace(
         opid: Opid(81),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -948,7 +948,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -969,7 +969,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -990,7 +990,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1014,7 +1014,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1073,7 +1073,7 @@ TestInterpreterOutputTrace(
         opid: Opid(92),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1089,7 +1089,7 @@ TestInterpreterOutputTrace(
         opid: Opid(93),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1105,7 +1105,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1130,7 +1130,7 @@ TestInterpreterOutputTrace(
         opid: Opid(95),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1182,7 +1182,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
@@ -1195,7 +1195,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
@@ -1216,7 +1216,7 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1232,7 +1232,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1248,7 +1248,7 @@ TestInterpreterOutputTrace(
         opid: Opid(106),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1272,7 +1272,7 @@ TestInterpreterOutputTrace(
         opid: Opid(107),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1313,7 +1313,7 @@ TestInterpreterOutputTrace(
         opid: Opid(111),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1328,7 +1328,7 @@ TestInterpreterOutputTrace(
         opid: Opid(112),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1343,7 +1343,7 @@ TestInterpreterOutputTrace(
         opid: Opid(113),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1366,7 +1366,7 @@ TestInterpreterOutputTrace(
         opid: Opid(114),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1389,7 +1389,7 @@ TestInterpreterOutputTrace(
         opid: Opid(115),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1407,7 +1407,7 @@ TestInterpreterOutputTrace(
         opid: Opid(116),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1425,7 +1425,7 @@ TestInterpreterOutputTrace(
         opid: Opid(117),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1446,7 +1446,7 @@ TestInterpreterOutputTrace(
         opid: Opid(118),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -136,7 +136,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -146,7 +146,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -171,7 +171,7 @@ TestInterpreterOutputTrace(
         opid: Opid(32),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -181,7 +181,7 @@ TestInterpreterOutputTrace(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -198,7 +198,7 @@ TestInterpreterOutputTrace(
         opid: Opid(35),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -213,7 +213,7 @@ TestInterpreterOutputTrace(
         opid: Opid(36),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -233,7 +233,7 @@ TestInterpreterOutputTrace(
         opid: Opid(38),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -259,7 +259,7 @@ TestInterpreterOutputTrace(
         opid: Opid(40),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -273,7 +273,7 @@ TestInterpreterOutputTrace(
         opid: Opid(41),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -292,7 +292,7 @@ TestInterpreterOutputTrace(
         opid: Opid(43),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -307,7 +307,7 @@ TestInterpreterOutputTrace(
         opid: Opid(44),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -327,7 +327,7 @@ TestInterpreterOutputTrace(
         opid: Opid(46),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -343,7 +343,7 @@ TestInterpreterOutputTrace(
         opid: Opid(47),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -364,7 +364,7 @@ TestInterpreterOutputTrace(
         opid: Opid(49),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -381,7 +381,7 @@ TestInterpreterOutputTrace(
         opid: Opid(50),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -403,7 +403,7 @@ TestInterpreterOutputTrace(
         opid: Opid(52),
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -420,7 +420,7 @@ TestInterpreterOutputTrace(
         opid: Opid(53),
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -437,7 +437,7 @@ TestInterpreterOutputTrace(
         opid: Opid(54),
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -460,7 +460,7 @@ TestInterpreterOutputTrace(
         opid: Opid(55),
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -483,7 +483,7 @@ TestInterpreterOutputTrace(
         opid: Opid(56),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -503,7 +503,7 @@ TestInterpreterOutputTrace(
         opid: Opid(57),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -523,7 +523,7 @@ TestInterpreterOutputTrace(
         opid: Opid(58),
         parent_opid: Some(Opid(12)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -544,7 +544,7 @@ TestInterpreterOutputTrace(
         opid: Opid(59),
         parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -565,7 +565,7 @@ TestInterpreterOutputTrace(
         opid: Opid(60),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -587,7 +587,7 @@ TestInterpreterOutputTrace(
         opid: Opid(61),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
@@ -701,7 +701,7 @@ TestInterpreterOutputTrace(
         opid: Opid(79),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -718,7 +718,7 @@ TestInterpreterOutputTrace(
         opid: Opid(80),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -740,7 +740,7 @@ TestInterpreterOutputTrace(
         opid: Opid(82),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -754,7 +754,7 @@ TestInterpreterOutputTrace(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -768,7 +768,7 @@ TestInterpreterOutputTrace(
         opid: Opid(84),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -783,7 +783,7 @@ TestInterpreterOutputTrace(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -803,7 +803,7 @@ TestInterpreterOutputTrace(
         opid: Opid(87),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -819,7 +819,7 @@ TestInterpreterOutputTrace(
         opid: Opid(88),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -840,7 +840,7 @@ TestInterpreterOutputTrace(
         opid: Opid(90),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -857,7 +857,7 @@ TestInterpreterOutputTrace(
         opid: Opid(91),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -879,7 +879,7 @@ TestInterpreterOutputTrace(
         opid: Opid(93),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -897,7 +897,7 @@ TestInterpreterOutputTrace(
         opid: Opid(94),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -920,7 +920,7 @@ TestInterpreterOutputTrace(
         opid: Opid(96),
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -938,7 +938,7 @@ TestInterpreterOutputTrace(
         opid: Opid(97),
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -956,7 +956,7 @@ TestInterpreterOutputTrace(
         opid: Opid(98),
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -980,7 +980,7 @@ TestInterpreterOutputTrace(
         opid: Opid(99),
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1004,7 +1004,7 @@ TestInterpreterOutputTrace(
         opid: Opid(100),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1026,7 +1026,7 @@ TestInterpreterOutputTrace(
         opid: Opid(101),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1048,7 +1048,7 @@ TestInterpreterOutputTrace(
         opid: Opid(102),
         parent_opid: Some(Opid(12)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1070,7 +1070,7 @@ TestInterpreterOutputTrace(
         opid: Opid(103),
         parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1092,7 +1092,7 @@ TestInterpreterOutputTrace(
         opid: Opid(104),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1115,7 +1115,7 @@ TestInterpreterOutputTrace(
         opid: Opid(105),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1217,7 +1217,7 @@ TestInterpreterOutputTrace(
         opid: Opid(121),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1231,7 +1231,7 @@ TestInterpreterOutputTrace(
         opid: Opid(122),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1275,7 +1275,7 @@ TestInterpreterOutputTrace(
         opid: Opid(129),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1285,7 +1285,7 @@ TestInterpreterOutputTrace(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
@@ -1303,7 +1303,7 @@ TestInterpreterOutputTrace(
         opid: Opid(132),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1320,7 +1320,7 @@ TestInterpreterOutputTrace(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1342,7 +1342,7 @@ TestInterpreterOutputTrace(
         opid: Opid(135),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1356,7 +1356,7 @@ TestInterpreterOutputTrace(
         opid: Opid(136),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1370,7 +1370,7 @@ TestInterpreterOutputTrace(
         opid: Opid(137),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1385,7 +1385,7 @@ TestInterpreterOutputTrace(
         opid: Opid(138),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1405,7 +1405,7 @@ TestInterpreterOutputTrace(
         opid: Opid(140),
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1421,7 +1421,7 @@ TestInterpreterOutputTrace(
         opid: Opid(141),
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1442,7 +1442,7 @@ TestInterpreterOutputTrace(
         opid: Opid(143),
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1459,7 +1459,7 @@ TestInterpreterOutputTrace(
         opid: Opid(144),
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1481,7 +1481,7 @@ TestInterpreterOutputTrace(
         opid: Opid(146),
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1499,7 +1499,7 @@ TestInterpreterOutputTrace(
         opid: Opid(147),
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1524,7 +1524,7 @@ TestInterpreterOutputTrace(
         opid: Opid(149),
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1544,7 +1544,7 @@ TestInterpreterOutputTrace(
         opid: Opid(150),
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1564,7 +1564,7 @@ TestInterpreterOutputTrace(
         opid: Opid(151),
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1590,7 +1590,7 @@ TestInterpreterOutputTrace(
         opid: Opid(152),
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: None,
+          active_vertex: None,
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1616,7 +1616,7 @@ TestInterpreterOutputTrace(
         opid: Opid(153),
         parent_opid: Some(Opid(11)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1640,7 +1640,7 @@ TestInterpreterOutputTrace(
         opid: Opid(154),
         parent_opid: Some(Opid(11)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(6, [
+          active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
           ]))),
@@ -1664,7 +1664,7 @@ TestInterpreterOutputTrace(
         opid: Opid(155),
         parent_opid: Some(Opid(12)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1688,7 +1688,7 @@ TestInterpreterOutputTrace(
         opid: Opid(156),
         parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1712,7 +1712,7 @@ TestInterpreterOutputTrace(
         opid: Opid(157),
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1739,7 +1739,7 @@ TestInterpreterOutputTrace(
         opid: Opid(158),
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(4, [
+          active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
           tokens: {
@@ -1845,7 +1845,7 @@ TestInterpreterOutputTrace(
         opid: Opid(174),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1859,7 +1859,7 @@ TestInterpreterOutputTrace(
         opid: Opid(175),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
@@ -1895,7 +1895,7 @@ TestInterpreterOutputTrace(
         opid: Opid(180),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1910,7 +1910,7 @@ TestInterpreterOutputTrace(
         opid: Opid(181),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Composite(CompositeNumber(9, [
+          active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
           tokens: {
@@ -1930,7 +1930,7 @@ TestInterpreterOutputTrace(
         opid: Opid(183),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
@@ -1943,7 +1943,7 @@ TestInterpreterOutputTrace(
         opid: Opid(184),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -451,7 +451,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(3),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         )),
@@ -474,7 +474,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(3),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         ), Null)),
@@ -971,7 +971,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(3),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         )),
@@ -995,7 +995,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(3),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         ), Null)),
@@ -1579,7 +1579,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(4),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(4, [
               2,
             ]))),
@@ -1605,7 +1605,7 @@ TestInterpreterOutputTrace(
           values: [
             Int64(4),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Composite(CompositeNumber(4, [
               2,
             ]))),

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -137,7 +137,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -147,7 +147,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -172,7 +172,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -182,7 +182,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -201,7 +201,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -216,7 +216,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -234,7 +234,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -247,7 +247,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -260,7 +260,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -274,7 +274,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -293,7 +293,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -308,7 +308,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -328,7 +328,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -344,7 +344,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -365,7 +365,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -382,7 +382,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -404,7 +404,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -421,7 +421,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -438,7 +438,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -461,7 +461,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -486,7 +486,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -506,7 +506,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -524,7 +524,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(12)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -545,7 +545,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -566,7 +566,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -588,7 +588,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(4, [
               2,
@@ -705,7 +705,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -722,7 +722,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -741,7 +741,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -755,7 +755,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -769,7 +769,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -784,7 +784,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -804,7 +804,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -820,7 +820,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -841,7 +841,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -858,7 +858,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -880,7 +880,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -898,7 +898,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -921,7 +921,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(9)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -939,7 +939,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(9)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -957,7 +957,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -981,7 +981,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1008,7 +1008,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1030,7 +1030,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1049,7 +1049,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(12)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1071,7 +1071,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1093,7 +1093,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1116,7 +1116,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(13)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1218,7 +1218,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1232,7 +1232,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1276,7 +1276,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         )),
@@ -1286,7 +1286,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
           },
         ))),
@@ -1307,7 +1307,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1324,7 +1324,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1343,7 +1343,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1357,7 +1357,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1371,7 +1371,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1386,7 +1386,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1406,7 +1406,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1422,7 +1422,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(6)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1443,7 +1443,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1460,7 +1460,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(7)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1482,7 +1482,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1500,7 +1500,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(8)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1527,7 +1527,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1547,7 +1547,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1565,7 +1565,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(10)),
         content: YieldInto(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1591,7 +1591,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(10)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: None,
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1620,7 +1620,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1644,7 +1644,7 @@ TestInterpreterOutputTrace(
             2,
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1665,7 +1665,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(12)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1689,7 +1689,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(12)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1715,7 +1715,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1742,7 +1742,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1846,7 +1846,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1860,7 +1860,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(6, [
               2,
@@ -1898,7 +1898,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1913,7 +1913,7 @@ TestInterpreterOutputTrace(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1931,7 +1931,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,
@@ -1944,7 +1944,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
             Vid(2): Some(Composite(CompositeNumber(9, [
               3,

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -5,67 +5,67 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Composite", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Composite", Eid(2))),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(3), "Prime", "value")),
+        content: Call(ResolveProperty(Vid(3), "Prime", "value")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(3), "Prime", Eid(3))),
+        content: Call(ResolveNeighbors(Vid(3), "Prime", Eid(3))),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(4), "Number", Eid(4))),
+        content: Call(ResolveNeighbors(Vid(4), "Number", Eid(4))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(5), "Number", Eid(5))),
+        content: Call(ResolveNeighbors(Vid(5), "Number", Eid(5))),
       ),
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(6))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(6))),
       ),
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(7), "Number", "value")),
+        content: Call(ResolveProperty(Vid(7), "Number", "value")),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(6), "Number", "value")),
+        content: Call(ResolveProperty(Vid(6), "Number", "value")),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Composite", "value")),
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
       ),
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(7), "Number", "value")),
+        content: Call(ResolveProperty(Vid(7), "Number", "value")),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -130,7 +130,7 @@ TestInterpreterOutputTrace(
       Opid(26): TraceOp(
         opid: Opid(26),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(27): TraceOp(
         opid: Opid(27),
@@ -145,7 +145,7 @@ TestInterpreterOutputTrace(
       Opid(28): TraceOp(
         opid: Opid(28),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -165,7 +165,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(32): TraceOp(
         opid: Opid(32),
@@ -180,7 +180,7 @@ TestInterpreterOutputTrace(
       Opid(33): TraceOp(
         opid: Opid(33),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -190,7 +190,7 @@ TestInterpreterOutputTrace(
       Opid(34): TraceOp(
         opid: Opid(34),
         parent_opid: Some(Opid(33)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -212,7 +212,7 @@ TestInterpreterOutputTrace(
       Opid(36): TraceOp(
         opid: Opid(36),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -227,7 +227,7 @@ TestInterpreterOutputTrace(
       Opid(37): TraceOp(
         opid: Opid(37),
         parent_opid: Some(Opid(36)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(38): TraceOp(
         opid: Opid(38),
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
       Opid(39): TraceOp(
         opid: Opid(39),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -272,7 +272,7 @@ TestInterpreterOutputTrace(
       Opid(41): TraceOp(
         opid: Opid(41),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -286,7 +286,7 @@ TestInterpreterOutputTrace(
       Opid(42): TraceOp(
         opid: Opid(42),
         parent_opid: Some(Opid(41)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(43): TraceOp(
         opid: Opid(43),
@@ -306,7 +306,7 @@ TestInterpreterOutputTrace(
       Opid(44): TraceOp(
         opid: Opid(44),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -321,7 +321,7 @@ TestInterpreterOutputTrace(
       Opid(45): TraceOp(
         opid: Opid(45),
         parent_opid: Some(Opid(44)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(46): TraceOp(
         opid: Opid(46),
@@ -342,7 +342,7 @@ TestInterpreterOutputTrace(
       Opid(47): TraceOp(
         opid: Opid(47),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -380,7 +380,7 @@ TestInterpreterOutputTrace(
       Opid(50): TraceOp(
         opid: Opid(50),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -397,7 +397,7 @@ TestInterpreterOutputTrace(
       Opid(51): TraceOp(
         opid: Opid(51),
         parent_opid: Some(Opid(50)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(52): TraceOp(
         opid: Opid(52),
@@ -419,7 +419,7 @@ TestInterpreterOutputTrace(
       Opid(53): TraceOp(
         opid: Opid(53),
         parent_opid: Some(Opid(9)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -459,7 +459,7 @@ TestInterpreterOutputTrace(
       Opid(55): TraceOp(
         opid: Opid(55),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -502,7 +502,7 @@ TestInterpreterOutputTrace(
       Opid(57): TraceOp(
         opid: Opid(57),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -543,7 +543,7 @@ TestInterpreterOutputTrace(
       Opid(59): TraceOp(
         opid: Opid(59),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -586,7 +586,7 @@ TestInterpreterOutputTrace(
       Opid(61): TraceOp(
         opid: Opid(61),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -692,7 +692,7 @@ TestInterpreterOutputTrace(
       Opid(78): TraceOp(
         opid: Opid(78),
         parent_opid: Some(Opid(33)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -717,7 +717,7 @@ TestInterpreterOutputTrace(
       Opid(80): TraceOp(
         opid: Opid(80),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -734,7 +734,7 @@ TestInterpreterOutputTrace(
       Opid(81): TraceOp(
         opid: Opid(81),
         parent_opid: Some(Opid(80)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(82): TraceOp(
         opid: Opid(82),
@@ -753,7 +753,7 @@ TestInterpreterOutputTrace(
       Opid(83): TraceOp(
         opid: Opid(83),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -782,7 +782,7 @@ TestInterpreterOutputTrace(
       Opid(85): TraceOp(
         opid: Opid(85),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -797,7 +797,7 @@ TestInterpreterOutputTrace(
       Opid(86): TraceOp(
         opid: Opid(86),
         parent_opid: Some(Opid(85)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(87): TraceOp(
         opid: Opid(87),
@@ -818,7 +818,7 @@ TestInterpreterOutputTrace(
       Opid(88): TraceOp(
         opid: Opid(88),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -834,7 +834,7 @@ TestInterpreterOutputTrace(
       Opid(89): TraceOp(
         opid: Opid(89),
         parent_opid: Some(Opid(88)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(90): TraceOp(
         opid: Opid(90),
@@ -856,7 +856,7 @@ TestInterpreterOutputTrace(
       Opid(91): TraceOp(
         opid: Opid(91),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -896,7 +896,7 @@ TestInterpreterOutputTrace(
       Opid(94): TraceOp(
         opid: Opid(94),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -914,7 +914,7 @@ TestInterpreterOutputTrace(
       Opid(95): TraceOp(
         opid: Opid(95),
         parent_opid: Some(Opid(94)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(96): TraceOp(
         opid: Opid(96),
@@ -937,7 +937,7 @@ TestInterpreterOutputTrace(
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(9)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -979,7 +979,7 @@ TestInterpreterOutputTrace(
       Opid(99): TraceOp(
         opid: Opid(99),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1025,7 +1025,7 @@ TestInterpreterOutputTrace(
       Opid(101): TraceOp(
         opid: Opid(101),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1069,7 +1069,7 @@ TestInterpreterOutputTrace(
       Opid(103): TraceOp(
         opid: Opid(103),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1114,7 +1114,7 @@ TestInterpreterOutputTrace(
       Opid(105): TraceOp(
         opid: Opid(105),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1211,7 +1211,7 @@ TestInterpreterOutputTrace(
       Opid(120): TraceOp(
         opid: Opid(120),
         parent_opid: Some(Opid(80)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(121): TraceOp(
         opid: Opid(121),
@@ -1230,7 +1230,7 @@ TestInterpreterOutputTrace(
       Opid(122): TraceOp(
         opid: Opid(122),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -1269,7 +1269,7 @@ TestInterpreterOutputTrace(
       Opid(128): TraceOp(
         opid: Opid(128),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
       Opid(129): TraceOp(
         opid: Opid(129),
@@ -1284,7 +1284,7 @@ TestInterpreterOutputTrace(
       Opid(130): TraceOp(
         opid: Opid(130),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1294,7 +1294,7 @@ TestInterpreterOutputTrace(
       Opid(131): TraceOp(
         opid: Opid(131),
         parent_opid: Some(Opid(130)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(6, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
@@ -1319,7 +1319,7 @@ TestInterpreterOutputTrace(
       Opid(133): TraceOp(
         opid: Opid(133),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1336,7 +1336,7 @@ TestInterpreterOutputTrace(
       Opid(134): TraceOp(
         opid: Opid(134),
         parent_opid: Some(Opid(133)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(135): TraceOp(
         opid: Opid(135),
@@ -1355,7 +1355,7 @@ TestInterpreterOutputTrace(
       Opid(136): TraceOp(
         opid: Opid(136),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1384,7 +1384,7 @@ TestInterpreterOutputTrace(
       Opid(138): TraceOp(
         opid: Opid(138),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1399,7 +1399,7 @@ TestInterpreterOutputTrace(
       Opid(139): TraceOp(
         opid: Opid(139),
         parent_opid: Some(Opid(138)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
       Opid(140): TraceOp(
         opid: Opid(140),
@@ -1420,7 +1420,7 @@ TestInterpreterOutputTrace(
       Opid(141): TraceOp(
         opid: Opid(141),
         parent_opid: Some(Opid(6)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1436,7 +1436,7 @@ TestInterpreterOutputTrace(
       Opid(142): TraceOp(
         opid: Opid(142),
         parent_opid: Some(Opid(141)),
-        content: YieldFrom(ProjectNeighborsInner(0, Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
       ),
       Opid(143): TraceOp(
         opid: Opid(143),
@@ -1458,7 +1458,7 @@ TestInterpreterOutputTrace(
       Opid(144): TraceOp(
         opid: Opid(144),
         parent_opid: Some(Opid(7)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1498,7 +1498,7 @@ TestInterpreterOutputTrace(
       Opid(147): TraceOp(
         opid: Opid(147),
         parent_opid: Some(Opid(8)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1516,7 +1516,7 @@ TestInterpreterOutputTrace(
       Opid(148): TraceOp(
         opid: Opid(148),
         parent_opid: Some(Opid(147)),
-        content: YieldFrom(ProjectNeighborsInner(0, Composite(CompositeNumber(4, [
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
@@ -1543,7 +1543,7 @@ TestInterpreterOutputTrace(
       Opid(150): TraceOp(
         opid: Opid(150),
         parent_opid: Some(Opid(9)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1589,7 +1589,7 @@ TestInterpreterOutputTrace(
       Opid(152): TraceOp(
         opid: Opid(152),
         parent_opid: Some(Opid(10)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: None,
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1639,7 +1639,7 @@ TestInterpreterOutputTrace(
       Opid(154): TraceOp(
         opid: Opid(154),
         parent_opid: Some(Opid(11)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
             2,
             3,
@@ -1687,7 +1687,7 @@ TestInterpreterOutputTrace(
       Opid(156): TraceOp(
         opid: Opid(156),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1738,7 +1738,7 @@ TestInterpreterOutputTrace(
       Opid(158): TraceOp(
         opid: Opid(158),
         parent_opid: Some(Opid(13)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
             2,
           ]))),
@@ -1839,7 +1839,7 @@ TestInterpreterOutputTrace(
       Opid(173): TraceOp(
         opid: Opid(173),
         parent_opid: Some(Opid(133)),
-        content: YieldFrom(ProjectNeighborsInner(1, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(1, Prime(PrimeNumber(3)))),
       ),
       Opid(174): TraceOp(
         opid: Opid(174),
@@ -1858,7 +1858,7 @@ TestInterpreterOutputTrace(
       Opid(175): TraceOp(
         opid: Opid(175),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),
@@ -1887,7 +1887,7 @@ TestInterpreterOutputTrace(
       Opid(179): TraceOp(
         opid: Opid(179),
         parent_opid: Some(Opid(130)),
-        content: YieldFrom(ProjectNeighborsInner(1, Composite(CompositeNumber(9, [
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
           3,
         ])))),
       ),
@@ -1909,7 +1909,7 @@ TestInterpreterOutputTrace(
       Opid(181): TraceOp(
         opid: Opid(181),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(9, [
             3,
           ]))),
@@ -1924,7 +1924,7 @@ TestInterpreterOutputTrace(
       Opid(182): TraceOp(
         opid: Opid(182),
         parent_opid: Some(Opid(181)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(183): TraceOp(
         opid: Opid(183),
@@ -1942,7 +1942,7 @@ TestInterpreterOutputTrace(
       Opid(184): TraceOp(
         opid: Opid(184),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "__typename")),
+        content: Call(ResolveProperty(Vid(1), "Number", "__typename")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -43,7 +43,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {},
         ), String("Neither"))),
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -69,7 +69,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {},
         ), String("Prime"))),
@@ -87,7 +87,7 @@ TestInterpreterOutputTrace(
       Opid(14): TraceOp(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(8): TraceOp(
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {},
+          vertices: {},
         ), String("Neither"))),
       ),
       Opid(9): TraceOp(
@@ -63,7 +63,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         )),
       ),
       Opid(12): TraceOp(
@@ -71,7 +71,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {},
+          vertices: {},
         ), String("Prime"))),
       ),
       Opid(13): TraceOp(
@@ -79,7 +79,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -89,7 +89,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), Int64(2))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         )),
       ),
@@ -44,7 +44,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {},
         ), String("Neither"))),
       ),
@@ -62,7 +62,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         )),
       ),
@@ -70,7 +70,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {},
         ), String("Prime"))),
       ),
@@ -78,7 +78,7 @@ TestInterpreterOutputTrace(
         opid: Opid(13),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -88,7 +88,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
@@ -27,7 +27,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ), String("Neither"))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
@@ -5,12 +5,12 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "__typename")),
+        content: Call(ResolveProperty(Vid(1), "Number", "__typename")),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
@@ -20,7 +20,7 @@ TestInterpreterOutputTrace(
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
@@ -35,7 +35,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
@@ -26,7 +26,7 @@ TestInterpreterOutputTrace(
         opid: Opid(5),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(6),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -108,7 +108,7 @@ TestInterpreterOutputTrace(
           values: [
             String("Prime"),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         )),
@@ -124,7 +124,7 @@ TestInterpreterOutputTrace(
           values: [
             String("Prime"),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(2))),
           ],
         ), String("Neither"))),
@@ -210,7 +210,7 @@ TestInterpreterOutputTrace(
           values: [
             String("Prime"),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         )),
@@ -226,7 +226,7 @@ TestInterpreterOutputTrace(
           values: [
             String("Prime"),
           ],
-          suspended_tokens: [
+          suspended_vertices: [
             Some(Prime(PrimeNumber(3))),
           ],
         ), String("Prime"))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -57,7 +57,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -67,7 +67,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         )),
@@ -92,7 +92,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
         ), String("Prime"))),
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           values: [
@@ -118,7 +118,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
           values: [
@@ -159,7 +159,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -169,7 +169,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ))),
@@ -184,7 +184,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         )),
@@ -194,7 +194,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
         ), String("Prime"))),
@@ -204,7 +204,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           values: [
@@ -220,7 +220,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
           values: [
@@ -236,7 +236,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },
@@ -247,7 +247,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -56,7 +56,7 @@ TestInterpreterOutputTrace(
         opid: Opid(11),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -66,7 +66,7 @@ TestInterpreterOutputTrace(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -91,7 +91,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(16),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -117,7 +117,7 @@ TestInterpreterOutputTrace(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(1))),
+          active_vertex: Some(Neither(NeitherNumber(1))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(1))),
           },
@@ -158,7 +158,7 @@ TestInterpreterOutputTrace(
         opid: Opid(23),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -168,7 +168,7 @@ TestInterpreterOutputTrace(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -183,7 +183,7 @@ TestInterpreterOutputTrace(
         opid: Opid(26),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -193,7 +193,7 @@ TestInterpreterOutputTrace(
         opid: Opid(27),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(3))),
+          active_vertex: Some(Prime(PrimeNumber(3))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -203,7 +203,7 @@ TestInterpreterOutputTrace(
         opid: Opid(28),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -219,7 +219,7 @@ TestInterpreterOutputTrace(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
           },
@@ -235,7 +235,7 @@ TestInterpreterOutputTrace(
         opid: Opid(30),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),
@@ -246,7 +246,7 @@ TestInterpreterOutputTrace(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Prime(PrimeNumber(2))),
+          active_vertex: Some(Prime(PrimeNumber(2))),
           tokens: {
             Vid(1): Some(Prime(PrimeNumber(2))),
             Vid(2): Some(Prime(PrimeNumber(3))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -5,27 +5,27 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(2), "Number", "__typename")),
+        content: Call(ResolveProperty(Vid(2), "Number", "__typename")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "__typename")),
+        content: Call(ResolveProperty(Vid(1), "Number", "__typename")),
       ),
       Opid(5): TraceOp(
         opid: Opid(5),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(6): TraceOp(
         opid: Opid(6),
@@ -50,7 +50,7 @@ TestInterpreterOutputTrace(
       Opid(10): TraceOp(
         opid: Opid(10),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(1)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
       ),
       Opid(11): TraceOp(
         opid: Opid(11),
@@ -65,7 +65,7 @@ TestInterpreterOutputTrace(
       Opid(12): TraceOp(
         opid: Opid(12),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -75,7 +75,7 @@ TestInterpreterOutputTrace(
       Opid(13): TraceOp(
         opid: Opid(13),
         parent_opid: Some(Opid(12)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
       Opid(14): TraceOp(
         opid: Opid(14),
@@ -90,7 +90,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -116,7 +116,7 @@ TestInterpreterOutputTrace(
       Opid(17): TraceOp(
         opid: Opid(17),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(1))),
@@ -152,7 +152,7 @@ TestInterpreterOutputTrace(
       Opid(22): TraceOp(
         opid: Opid(22),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Prime(PrimeNumber(2)))),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
@@ -167,7 +167,7 @@ TestInterpreterOutputTrace(
       Opid(24): TraceOp(
         opid: Opid(24),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -177,7 +177,7 @@ TestInterpreterOutputTrace(
       Opid(25): TraceOp(
         opid: Opid(25),
         parent_opid: Some(Opid(24)),
-        content: YieldFrom(ProjectNeighborsInner(0, Prime(PrimeNumber(3)))),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
       Opid(26): TraceOp(
         opid: Opid(26),
@@ -192,7 +192,7 @@ TestInterpreterOutputTrace(
       Opid(27): TraceOp(
         opid: Opid(27),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -218,7 +218,7 @@ TestInterpreterOutputTrace(
       Opid(29): TraceOp(
         opid: Opid(29),
         parent_opid: Some(Opid(4)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),
@@ -245,7 +245,7 @@ TestInterpreterOutputTrace(
       Opid(31): TraceOp(
         opid: Opid(31),
         parent_opid: Some(Opid(5)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
           vertices: {
             Vid(1): Some(Prime(PrimeNumber(2))),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -101,7 +101,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -102,7 +102,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -99,7 +99,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -98,7 +98,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -99,7 +99,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -98,7 +98,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -100,7 +100,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
@@ -37,7 +37,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         )),
@@ -47,7 +47,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
         ))),
@@ -82,7 +82,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {
@@ -99,7 +99,7 @@ TestInterpreterOutputTrace(
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
-          tokens: {
+          vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
           folded_contexts: {

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
@@ -5,17 +5,17 @@ TestInterpreterOutputTrace(
       Opid(1): TraceOp(
         opid: Opid(1),
         parent_opid: None,
-        content: Call(GetStartingTokens(Vid(1))),
+        content: Call(ResolveStartingVertices(Vid(1))),
       ),
       Opid(2): TraceOp(
         opid: Opid(2),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(1), "Number", Eid(1))),
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
       ),
       Opid(3): TraceOp(
         opid: Opid(3),
         parent_opid: None,
-        content: Call(ProjectProperty(Vid(1), "Number", "value")),
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
       ),
       Opid(4): TraceOp(
         opid: Opid(4),
@@ -30,7 +30,7 @@ TestInterpreterOutputTrace(
       Opid(6): TraceOp(
         opid: Opid(6),
         parent_opid: Some(Opid(1)),
-        content: YieldFrom(GetStartingTokens(Neither(NeitherNumber(0)))),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
       ),
       Opid(7): TraceOp(
         opid: Opid(7),
@@ -45,7 +45,7 @@ TestInterpreterOutputTrace(
       Opid(8): TraceOp(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
-        content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),
@@ -55,7 +55,7 @@ TestInterpreterOutputTrace(
       Opid(9): TraceOp(
         opid: Opid(9),
         parent_opid: None,
-        content: Call(ProjectNeighbors(Vid(2), "Number", Eid(2))),
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
       ),
       Opid(10): TraceOp(
         opid: Opid(10),
@@ -97,7 +97,7 @@ TestInterpreterOutputTrace(
       Opid(15): TraceOp(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
-        content: YieldFrom(ProjectProperty(SerializableContext(
+        content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
             Vid(1): Some(Neither(NeitherNumber(0))),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
@@ -36,7 +36,7 @@ TestInterpreterOutputTrace(
         opid: Opid(7),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -46,7 +46,7 @@ TestInterpreterOutputTrace(
         opid: Opid(8),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ProjectNeighborsOuter(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -81,7 +81,7 @@ TestInterpreterOutputTrace(
         opid: Opid(14),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },
@@ -98,7 +98,7 @@ TestInterpreterOutputTrace(
         opid: Opid(15),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ProjectProperty(SerializableContext(
-          current_token: Some(Neither(NeitherNumber(0))),
+          active_vertex: Some(Neither(NeitherNumber(0))),
           tokens: {
             Vid(1): Some(Neither(NeitherNumber(0))),
           },

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -95,21 +95,21 @@ impl From<&trustfall_core::ir::EdgeParameters> for JsEdgeParameters {
 pub struct JsContext {
     #[wasm_bindgen(js_name = "localId")]
     pub local_id: u32,
-    current_token: Option<JsValue>,
+    active_vertex: Option<JsValue>,
 }
 
 #[wasm_bindgen]
 impl JsContext {
-    pub(super) fn new(local_id: u32, current_token: Option<JsValue>) -> Self {
+    pub(super) fn new(local_id: u32, active_vertex: Option<JsValue>) -> Self {
         Self {
             local_id,
-            current_token,
+            active_vertex,
         }
     }
 
     #[wasm_bindgen(getter, js_name = "currentToken")]
-    pub fn current_token(&self) -> JsValue {
-        match &self.current_token {
+    pub fn active_vertex(&self) -> JsValue {
+        match &self.active_vertex {
             Some(value) => value.clone(),
             None => JsValue::NULL,
         }


### PR DESCRIPTION
- Replace `DataContext`'s `current_token` field with `active_vertex`.
- Rename `suspended_tokens` to `suspended_vertices`.
- Rename `tokens` to `vertices`.
- Rename `token` to `vertex` in most places.
- Rename FilesystemInterpreter's vertex type.
- Rename `token` -> `vertex` in `demo-hackernews`.
- Change `token` -> `vertex` for `NumbersInterpreter`.
- Update trace and Python shim terminology to match new Adapter names.
- Replace `Token` -> `Vertex` in most places.
- Update `replay` struct names.
- Reformat.
