### PR TITLE
Update terminology in WASM, TypeScript, and rustdoc components.

### DIFF
--- a/experiments/browser_based_querying/README.md
+++ b/experiments/browser_based_querying/README.md
@@ -1,22 +1,16 @@
 # Data Widgets
 
-A truly-serverless querying demo: query HackerNews entirely from your browser. No backend servers or lambdas involved! Your browser fetches data directly from HackerNews and executes queries using `trustfall_wasm`.
+A truly-serverless querying demo: query HackerNews and rustdoc entirely from your browser. No backend servers or lambdas involved!
 
-Only tested to work in Chrome. Known to not work in Firefox since [Firefox does not support modules in web workers](https://bugzilla.mozilla.org/show_bug.cgi?id=1247687).
+Your browser fetches data directly from HackerNews and executes queries using `trustfall_wasm`. For rustdoc, your browser downloads the rustdoc JSON file and queries it in-memory using `trustfall_wasm`.
 
 See the `example_queries` directory for some example queries to run. Live demo here: https://predr.ag/demo/trustfall/
-
-Contents:
-
-- `src` contains the TypeScript source code for the demo.
-- Those source files are built as JavaScript (currently, without a bundler) into the `www` directory (not checked in).
-- The `www2` directory contains the `trustfall_wasm` WASM bindings for the `trustfall` query engine. In principle, this shouldn't be checked in, but is checked in for convenience since this is a custom bundler-less build (unlike the regular version which assumes use with a bundler).
 
 ## Development
 
 - Install the version of node and `npm`.
 - `npm install` to install dependencies
-- `npm run build:trustfall` to build the `trustfall_wasm` crate to WASM
+- `npm run build:trustfall` to build the `trustfall_wasm` crate to WASM, saved in the git-ignored `www2` directory.
 - `npm run build:rustdoc` to build the `trustfall_rustdoc` crate to WASM
 - `npm start` to build and run the local server
-- Open a browser to `http://localhost:8000/hackernews` or `/rustdoc` and enjoy!
+- Open a browser to `http://localhost:8000/hackernews` or `http://localhost:8000/rustdoc` and enjoy!

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -179,7 +179,7 @@ export class MyAdapter implements Adapter<Vertex> {
     this.fetchPort = fetchPort;
   }
 
-  *getStartingTokens(edge: string, parameters: JsEdgeParameters): IterableIterator<Vertex> {
+  *resolveStartingVertices(edge: string, parameters: JsEdgeParameters): IterableIterator<Vertex> {
     if (edge === 'FrontPage') {
       return limitIterator(getTopItems(this.fetchPort), 30);
     } else if (
@@ -258,7 +258,7 @@ export class MyAdapter implements Adapter<Vertex> {
     }
   }
 
-  *projectProperty(
+  *resolveProperty(
     contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
     field_name: string
@@ -398,7 +398,7 @@ export class MyAdapter implements Adapter<Vertex> {
     }
   }
 
-  *projectNeighbors(
+  *resolveNeighbors(
     contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
     edge_name: string,
@@ -544,7 +544,7 @@ export class MyAdapter implements Adapter<Vertex> {
     }
   }
 
-  *canCoerceToType(
+  *resolveCoercion(
     contexts: IterableIterator<JsContext<Vertex>>,
     type_name: string,
     coerce_to_type: string

--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -267,7 +267,7 @@ export class MyAdapter implements Adapter<Vertex> {
       for (const ctx of contexts) {
         yield {
           localId: ctx.localId,
-          value: ctx.currentToken?.__typename || null,
+          value: ctx.activeVertex?.__typename || null,
         };
       }
       return;
@@ -282,7 +282,7 @@ export class MyAdapter implements Adapter<Vertex> {
       switch (field_name) {
         case 'url': {
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
 
             let value = null;
             if (vertex) {
@@ -300,7 +300,7 @@ export class MyAdapter implements Adapter<Vertex> {
           const fieldKey = HNItemFieldMappings.textHtml;
 
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
 
             let value = null;
             if (vertex) {
@@ -321,7 +321,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
 
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
 
             yield {
               localId: ctx.localId,
@@ -334,7 +334,7 @@ export class MyAdapter implements Adapter<Vertex> {
       switch (field_name) {
         case 'url': {
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
 
             let value = null;
             if (vertex) {
@@ -352,7 +352,7 @@ export class MyAdapter implements Adapter<Vertex> {
           const fieldKey = HNUserFieldMappings.aboutHtml;
 
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
 
             let value = null;
             if (vertex) {
@@ -373,7 +373,7 @@ export class MyAdapter implements Adapter<Vertex> {
           }
 
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
             yield {
               localId: ctx.localId,
               value: vertex?.[fieldKey] || null,
@@ -384,7 +384,7 @@ export class MyAdapter implements Adapter<Vertex> {
     } else if (type_name === 'Webpage') {
       if (field_name === 'url') {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           yield {
             localId: ctx.localId,
             value: vertex?.url || null,
@@ -414,7 +414,7 @@ export class MyAdapter implements Adapter<Vertex> {
           // Link submission stories have the submitted URL as a link.
           // Text submission stories can have multiple links in the text.
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
             let neighbors: IterableIterator<Vertex>;
             if (vertex) {
               if (vertex.url) {
@@ -440,7 +440,7 @@ export class MyAdapter implements Adapter<Vertex> {
         } else if (type_name === 'Comment') {
           // Comments can only have links in their text content.
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
             let neighbors: IterableIterator<Vertex>;
             if (vertex) {
               neighbors = linksInHnMarkup(this.fetchPort, vertex.text);
@@ -455,7 +455,7 @@ export class MyAdapter implements Adapter<Vertex> {
         } else if (type_name === 'Job') {
           // Jobs only have the submitted URL as a link.
           for (const ctx of contexts) {
-            const vertex = ctx.currentToken;
+            const vertex = ctx.activeVertex;
             let neighbors: IterableIterator<Vertex> = [][Symbol.iterator]();
             if (vertex) {
               const neighbor = materializeWebsite(this.fetchPort, vertex.url);
@@ -473,7 +473,7 @@ export class MyAdapter implements Adapter<Vertex> {
         }
       } else if (edge_name === 'byUser') {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           if (vertex) {
             yield {
               localId: ctx.localId,
@@ -488,7 +488,7 @@ export class MyAdapter implements Adapter<Vertex> {
         }
       } else if (edge_name === 'comment' || edge_name === 'reply') {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           yield {
             localId: ctx.localId,
             neighbors: lazyFetchMap(this.fetchPort, vertex?.kids, materializeItem),
@@ -496,7 +496,7 @@ export class MyAdapter implements Adapter<Vertex> {
         }
       } else if (edge_name === 'parent') {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           const parent = vertex?.parent;
           if (parent) {
             yield {
@@ -516,7 +516,7 @@ export class MyAdapter implements Adapter<Vertex> {
     } else if (type_name === 'User') {
       if (edge_name === 'submitted') {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           const submitted = vertex?.submitted;
           yield {
             localId: ctx.localId,
@@ -525,7 +525,7 @@ export class MyAdapter implements Adapter<Vertex> {
         }
       } else if (edge_name === 'link') {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           let neighbors: IterableIterator<Vertex> = [][Symbol.iterator]();
           const aboutHtml = vertex?.about;
           if (aboutHtml) {
@@ -553,7 +553,7 @@ export class MyAdapter implements Adapter<Vertex> {
       if (coerce_to_type === 'Item') {
         // The Item type is abstract, we need to check if the vertex is any of the Item subtypes.
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           const type = vertex?.__typename;
           yield {
             localId: ctx.localId,
@@ -562,7 +562,7 @@ export class MyAdapter implements Adapter<Vertex> {
         }
       } else {
         for (const ctx of contexts) {
-          const vertex = ctx.currentToken;
+          const vertex = ctx.activeVertex;
           yield {
             localId: ctx.localId,
             value: vertex?.__typename === coerce_to_type,

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -107,7 +107,7 @@ impl JsContext {
         }
     }
 
-    #[wasm_bindgen(getter, js_name = "currentToken")]
+    #[wasm_bindgen(getter, js_name = "activeVertex")]
     pub fn active_vertex(&self) -> JsValue {
         match &self.active_vertex {
             Some(value) => value.clone(),

--- a/trustfall_wasm/src/trustfall_wasm.d.ts
+++ b/trustfall_wasm/src/trustfall_wasm.d.ts
@@ -24,25 +24,25 @@ export interface ContextAndBool {
 }
 
 export interface Adapter<T> {
-    getStartingTokens(
+    resolveStartingVertices(
         edge: string,
         parameters: JsEdgeParameters,
     ): IterableIterator<T>;
 
-    projectProperty(
+    resolveProperty(
         contexts: IterableIterator<JsContext<T>>,
         type_name: string,
         field_name: string
     ): IterableIterator<ContextAndValue>;
 
-    projectNeighbors(
+    resolveNeighbors(
         contexts: IterableIterator<JsContext<T>>,
         type_name: string,
         edge_name: string,
         parameters: JsEdgeParameters,
     ): IterableIterator<ContextAndNeighborsIterator<T>>;
 
-    canCoerceToType(
+    resolveCoercion(
         contexts: IterableIterator<JsContext<T>>,
         type_name: string,
         coerce_to_type: string

--- a/trustfall_wasm/src/trustfall_wasm.d.ts
+++ b/trustfall_wasm/src/trustfall_wasm.d.ts
@@ -5,7 +5,7 @@ export interface JsContext<T> {
     free(): void;
 
     readonly localId: number;
-    readonly currentToken: T | null;
+    readonly activeVertex: T | null;
 }
 
 export interface ContextAndValue {

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -39,7 +39,7 @@ use wasm_bindgen::prelude::*;
                     for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
-                            value: ctx.currentToken,
+                            value: ctx.activeVertex,
                         };
                         yield val;
                     }
@@ -67,7 +67,7 @@ use wasm_bindgen::prelude::*;
                     for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
-                            neighbors: [ctx.currentToken + 1],
+                            neighbors: [ctx.activeVertex + 1],
                         };
                         yield val;
                     }
@@ -100,7 +100,7 @@ use wasm_bindgen::prelude::*;
                 if (coerce_to_type === "Prime") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
-                        if (ctx.currentToken in primes) {
+                        if (ctx.activeVertex in primes) {
                             can_coerce = true;
                         }
                         const val = {
@@ -112,7 +112,7 @@ use wasm_bindgen::prelude::*;
                 } else if (coerce_to_type === "Composite") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
-                        if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
+                        if (!(ctx.activeVertex in primes || ctx.activeVertex === 1)) {
                             can_coerce = true;
                         }
                         const val = {

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -10,10 +10,10 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(inline_js = r#"
     class JsNumbersAdapter {
         /*
-        #[wasm_bindgen(structural, method, js_name = "getStartingTokens")]
+        #[wasm_bindgen(structural, method, js_name = "resolveStartingVertices")]
         pub fn resolve_starting_vertices(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
         */
-        *getStartingTokens(edge, parameters) {
+        *resolveStartingVertices(edge, parameters) {
             if (edge === "Number") {
                 const maxValue = parameters["max"];
                 for (var i = 1; i <= maxValue; i++) {
@@ -25,7 +25,7 @@ use wasm_bindgen::prelude::*;
         }
 
         /*
-        #[wasm_bindgen(structural, method, js_name = "projectProperty")]
+        #[wasm_bindgen(structural, method, js_name = "resolveProperty")]
         pub fn resolve_property(
             this: &JsAdapter,
             contexts: ContextIterator,
@@ -33,7 +33,7 @@ use wasm_bindgen::prelude::*;
             field_name: &str,
         ) -> js_sys::Iterator;
         */
-        *projectProperty(contexts, type_name, field_name) {
+        *resolveProperty(contexts, type_name, field_name) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (field_name === "value") {
                     for (const ctx of contexts) {
@@ -52,7 +52,7 @@ use wasm_bindgen::prelude::*;
         }
 
         /*
-        #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
+        #[wasm_bindgen(structural, method, js_name = "resolveNeighbors")]
         pub fn resolve_neighbors(
             this: &JsAdapter,
             contexts: ContextIterator,
@@ -61,7 +61,7 @@ use wasm_bindgen::prelude::*;
             parameters: Option<EdgeParameters>,
         ) -> js_sys::Iterator;
         */
-        *projectNeighbors(contexts, type_name, edge_name, parameters) {
+        *resolveNeighbors(contexts, type_name, edge_name, parameters) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (edge_name === "successor") {
                     for (const ctx of contexts) {
@@ -80,7 +80,7 @@ use wasm_bindgen::prelude::*;
         }
 
         /*
-        #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
+        #[wasm_bindgen(structural, method, js_name = "resolveCoercion")]
         pub fn resolve_coercion(
             this: &JsAdapter,
             contexts: ContextIterator,
@@ -88,7 +88,7 @@ use wasm_bindgen::prelude::*;
             coerce_to_type: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(contexts, type_name, coerce_to_type) {
+        *resolveCoercion(contexts, type_name, coerce_to_type) {
             const primes = {
                 2: null,
                 3: null,

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -124,7 +124,7 @@ type Letter implements Named {
                     for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
-                            value: ctx.currentToken,
+                            value: ctx.activeVertex,
                         };
                         yield val;
                     }
@@ -152,7 +152,7 @@ type Letter implements Named {
                     for (const ctx of contexts) {
                         const val = {
                             localId: ctx.localId,
-                            neighbors: [ctx.currentToken + 1],
+                            neighbors: [ctx.activeVertex + 1],
                         };
                         yield val;
                     }
@@ -185,7 +185,7 @@ type Letter implements Named {
                 if (coerce_to_type === "Prime") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
-                        if (ctx.currentToken in primes) {
+                        if (ctx.activeVertex in primes) {
                             can_coerce = true;
                         }
                         const val = {
@@ -197,7 +197,7 @@ type Letter implements Named {
                 } else if (coerce_to_type === "Composite") {
                     for (const ctx of contexts) {
                         var can_coerce = false;
-                        if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
+                        if (!(ctx.activeVertex in primes || ctx.activeVertex === 1)) {
                             can_coerce = true;
                         }
                         const val = {

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -95,10 +95,10 @@ type Letter implements Named {
 
     class JsNumbersAdapter {
         /*
-        #[wasm_bindgen(structural, method, js_name = "getStartingTokens")]
+        #[wasm_bindgen(structural, method, js_name = "resolveStartingVertices")]
         pub fn resolve_starting_vertices(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
         */
-        *getStartingTokens(edge, parameters) {
+        *resolveStartingVertices(edge, parameters) {
             if (edge === "Number") {
                 const maxValue = parameters["max"];
                 for (var i = 1; i <= maxValue; i++) {
@@ -110,7 +110,7 @@ type Letter implements Named {
         }
 
         /*
-        #[wasm_bindgen(structural, method, js_name = "projectProperty")]
+        #[wasm_bindgen(structural, method, js_name = "resolveProperty")]
         pub fn resolve_property(
             this: &JsAdapter,
             contexts: ContextIterator,
@@ -118,7 +118,7 @@ type Letter implements Named {
             field_name: &str,
         ) -> js_sys::Iterator;
         */
-        *projectProperty(contexts, type_name, field_name) {
+        *resolveProperty(contexts, type_name, field_name) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (field_name === "value") {
                     for (const ctx of contexts) {
@@ -137,7 +137,7 @@ type Letter implements Named {
         }
 
         /*
-        #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
+        #[wasm_bindgen(structural, method, js_name = "resolveNeighbors")]
         pub fn resolve_neighbors(
             this: &JsAdapter,
             contexts: ContextIterator,
@@ -146,7 +146,7 @@ type Letter implements Named {
             parameters: Option<EdgeParameters>,
         ) -> js_sys::Iterator;
         */
-        *projectNeighbors(contexts, type_name, edge_name, parameters) {
+        *resolveNeighbors(contexts, type_name, edge_name, parameters) {
             if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
                 if (edge_name === "successor") {
                     for (const ctx of contexts) {
@@ -165,7 +165,7 @@ type Letter implements Named {
         }
 
         /*
-        #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
+        #[wasm_bindgen(structural, method, js_name = "resolveCoercion")]
         pub fn resolve_coercion(
             this: &JsAdapter,
             contexts: ContextIterator,
@@ -173,7 +173,7 @@ type Letter implements Named {
             coerce_to_type: &str,
         ) -> js_sys::Iterator;
         */
-        *canCoerceToType(contexts, type_name, coerce_to_type) {
+        *resolveCoercion(contexts, type_name, coerce_to_type) {
             const primes = {
                 2: null,
                 3: null,

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -62,10 +62,10 @@ type Letter implements Named {
 
 class JsNumbersAdapter {
   /*
-  #[wasm_bindgen(structural, method, js_name = "getStartingTokens")]
+  #[wasm_bindgen(structural, method, js_name = "resolveStartingVertices")]
   pub fn resolve_starting_vertices(this: &JsAdapter, edge: &str) -> js_sys::Iterator;
   */
-  *getStartingTokens(edge, parameters) {
+  *resolveStartingVertices(edge, parameters) {
     if (edge === "Number") {
       const maxValue = parameters["max"];
       for (var i = 1; i <= maxValue; i++) {
@@ -77,7 +77,7 @@ class JsNumbersAdapter {
   }
 
   /*
-  #[wasm_bindgen(structural, method, js_name = "projectProperty")]
+  #[wasm_bindgen(structural, method, js_name = "resolveProperty")]
   pub fn resolve_property(
       this: &JsAdapter,
       contexts: ContextIterator,
@@ -85,7 +85,7 @@ class JsNumbersAdapter {
       field_name: &str,
   ) -> js_sys::Iterator;
   */
-  *projectProperty(contexts, type_name, field_name) {
+  *resolveProperty(contexts, type_name, field_name) {
     if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
       if (field_name === "value") {
         for (const ctx of contexts) {
@@ -104,7 +104,7 @@ class JsNumbersAdapter {
   }
 
   /*
-  #[wasm_bindgen(structural, method, js_name = "projectNeighbors")]
+  #[wasm_bindgen(structural, method, js_name = "resolveNeighbors")]
   pub fn resolve_neighbors(
       this: &JsAdapter,
       contexts: ContextIterator,
@@ -113,7 +113,7 @@ class JsNumbersAdapter {
       parameters: Option<EdgeParameters>,
   ) -> js_sys::Iterator;
   */
-  *projectNeighbors(contexts, type_name, edge_name, parameters) {
+  *resolveNeighbors(contexts, type_name, edge_name, parameters) {
     if (type_name === "Number" || type_name === "Prime" || type_name === "Composite") {
       if (edge_name === "successor") {
         for (const ctx of contexts) {
@@ -132,7 +132,7 @@ class JsNumbersAdapter {
   }
 
   /*
-  #[wasm_bindgen(structural, method, js_name = "canCoerceToType")]
+  #[wasm_bindgen(structural, method, js_name = "resolveCoercion")]
   pub fn resolve_coercion(
       this: &JsAdapter,
       contexts: ContextIterator,
@@ -140,7 +140,7 @@ class JsNumbersAdapter {
       coerce_to_type: &str,
   ) -> js_sys::Iterator;
   */
-  *canCoerceToType(contexts, type_name, coerce_to_type) {
+  *resolveCoercion(contexts, type_name, coerce_to_type) {
     const primes = {
       2: null,
       3: null,

--- a/trustfall_wasm/www/index.js
+++ b/trustfall_wasm/www/index.js
@@ -91,7 +91,7 @@ class JsNumbersAdapter {
         for (const ctx of contexts) {
           const val = {
             localId: ctx.localId,
-            value: ctx.currentToken,
+            value: ctx.activeVertex,
           };
           yield val;
         }
@@ -119,7 +119,7 @@ class JsNumbersAdapter {
         for (const ctx of contexts) {
           const val = {
             localId: ctx.localId,
-            neighbors: [ctx.currentToken + 1],
+            neighbors: [ctx.activeVertex + 1],
           };
           yield val;
         }
@@ -152,7 +152,7 @@ class JsNumbersAdapter {
       if (coerce_to_type === "Prime") {
         for (const ctx of contexts) {
           var can_coerce = false;
-          if (ctx.currentToken in primes) {
+          if (ctx.activeVertex in primes) {
             can_coerce = true;
           }
           const val = {
@@ -164,7 +164,7 @@ class JsNumbersAdapter {
       } else if (coerce_to_type === "Composite") {
         for (const ctx of contexts) {
           var can_coerce = false;
-          if (!(ctx.currentToken in primes || ctx.currentToken === 1)) {
+          if (!(ctx.activeVertex in primes || ctx.activeVertex === 1)) {
             can_coerce = true;
           }
           const val = {


### PR DESCRIPTION
- Update adapter method names in WASM and TypeScript.
- Replace `token` -> `vertex` in WASM and TypeScript.
- Update rustdoc adapter naming.
