### PR TITLE
Require `BasicAdapter::Vertex` type to implement `Typename`.

### DIFF
--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -4,7 +4,7 @@ use trustfall_core::{
     interpreter::{
         basic_adapter::BasicAdapter,
         helpers::{resolve_neighbors_with as neighbors, resolve_property_with as property},
-        ContextIterator, ContextOutcomeIterator, VertexIterator,
+        ContextIterator, ContextOutcomeIterator, Typename, VertexIterator,
     },
     ir::{EdgeParameters, FieldValue},
 };
@@ -48,6 +48,19 @@ impl<'a> Vertex<'a> {
     impl_downcast!(as_feed_link, Link, Self::FeedLink);
     impl_downcast!(as_feed_entry, Entry, Self::FeedEntry);
     impl_downcast!(as_feed_content, Content, Self::FeedContent);
+}
+
+impl<'a> Typename for Vertex<'a> {
+    fn typename(&self) -> &'static str {
+        match self {
+            Vertex::Feed(..) => "Feed",
+            Vertex::FeedText(..) => "FeedText",
+            Vertex::ChannelImage(..) => "ChannelImage",
+            Vertex::FeedLink(..) => "FeedLink",
+            Vertex::FeedEntry(..) => "FeedEntry",
+            Vertex::FeedContent(..) => "FeedContent",
+        }
+    }
 }
 
 macro_rules! iterable {

--- a/demo-hackernews/src/vertex.rs
+++ b/demo-hackernews/src/vertex.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use hn_api::types::{Comment, Item, Job, Story, User};
+use trustfall_core::interpreter::Typename;
 
 #[derive(Debug, Clone)]
 pub enum Vertex {
@@ -11,8 +12,8 @@ pub enum Vertex {
     User(Rc<User>),
 }
 
-impl Vertex {
-    pub fn typename(&self) -> &'static str {
+impl Typename for Vertex {
+    fn typename(&self) -> &'static str {
         match self {
             Vertex::Item(..) => "Item",
             Vertex::Story(..) => "Story",
@@ -21,7 +22,9 @@ impl Vertex {
             Vertex::User(..) => "User",
         }
     }
+}
 
+impl Vertex {
     pub fn as_story(&self) -> Option<&Story> {
         match self {
             Vertex::Story(s) => Some(s.as_ref()),

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -2,7 +2,10 @@ use std::fmt::Debug;
 
 use crate::ir::{EdgeParameters, FieldValue};
 
-use super::{hints::QueryInfo, Adapter, ContextIterator, ContextOutcomeIterator, VertexIterator};
+use super::{
+    helpers::resolve_property_with, hints::QueryInfo, Adapter, ContextIterator,
+    ContextOutcomeIterator, Typename, VertexIterator,
+};
 
 /// A simplified variant of the [`Adapter`] trait.
 ///
@@ -14,7 +17,7 @@ use super::{hints::QueryInfo, Adapter, ContextIterator, ContextOutcomeIterator, 
 pub trait BasicAdapter<'vertex> {
     /// The type of vertices in the dataset this adapter queries.
     /// It's frequently a good idea to use an Rc<...> type for cheaper cloning here.
-    type Vertex: Clone + Debug + 'vertex;
+    type Vertex: Typename + Clone + Debug + 'vertex;
 
     /// Produce an iterator of vertices for the specified starting edge.
     ///
@@ -40,16 +43,20 @@ pub trait BasicAdapter<'vertex> {
 
     /// Resolve the value of a vertex property over an iterator of query contexts.
     ///
-    /// Each [`DataContext`](super::DataContext) in the `contexts` argument has an active vertex,
+    /// Each [`DataContext`] in the `contexts` argument has an active vertex,
     /// which is either `None`, or a `Some(Self::Vertex)` value representing a vertex
     /// of type `type_name` defined in the schema.
     ///
-    /// This function resolves the property value on that active vertex.
+    /// This method resolves the property value on that active vertex.
+    ///
+    /// Unlike the [`Adapter::resolve_property`] method, this method does not
+    /// handle the special `__typename` property. Instead, that property is resolved
+    /// by the [`BasicAdapter::resolve_typename`] method, which has a default implementation
+    /// using the [`Typename`] trait implemented by `Self::Vertex`.
     ///
     /// The caller guarantees that:
     /// - `type_name` is a type or interface defined in the schema.
-    /// - `property_name` is either a property field on `type_name` defined in the schema,
-    ///   or the special value `"__typename"` requesting the name of the vertex's type.
+    /// - `property_name` is a property field on `type_name` defined in the schema.
     /// - When the active vertex is `Some(...)`, it's a vertex of type `type_name`:
     ///   either its type is exactly `type_name`, or `type_name` is an interface that
     ///   the vertex's type implements.
@@ -60,7 +67,7 @@ pub trait BasicAdapter<'vertex> {
     /// - Produce property values whose type matches the property's type defined in the schema.
     /// - When a context's active vertex is `None`, its property value is `FieldValue::Null`.
     ///
-    /// [`DataContext`](super::DataContext)
+    /// [`DataContext`]: super::DataContext
     fn resolve_property(
         &mut self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
@@ -74,7 +81,7 @@ pub trait BasicAdapter<'vertex> {
     /// which is either `None`, or a `Some(Self::Vertex)` value representing a vertex
     /// of type `type_name` defined in the schema.
     ///
-    /// This function resolves the neighboring vertices for that active vertex.
+    /// This method resolves the neighboring vertices for that active vertex.
     ///
     /// If the schema this adapter covers has no edges aside from starting edges,
     /// then this method will never be called and may be implemented as `unreachable!()`.
@@ -119,7 +126,7 @@ pub trait BasicAdapter<'vertex> {
     /// which is either `None`, or a `Some(Self::Vertex)` value representing a vertex
     /// of type `type_name` defined in the schema.
     ///
-    /// This function checks whether the active vertex is of the specified subtype.
+    /// This method checks whether the active vertex is of the specified subtype.
     ///
     /// If this adapter's schema contains no subtyping, then no type coercions are possible:
     /// this method will never be called and may be implemented as `unreachable!()`.
@@ -142,6 +149,48 @@ pub trait BasicAdapter<'vertex> {
         type_name: &str,
         coerce_to_type: &str,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, bool>;
+
+    /// Resolve the `__typename` special property over an iterator of query contexts.
+    ///
+    /// Each [`DataContext`] in the `contexts` argument has an active vertex,
+    /// which is either `None`, or a `Some(Self::Vertex)` value representing a vertex
+    /// of type `type_name` defined in the schema.
+    ///
+    /// This method resolves the name of the type of that active vertex.
+    ///
+    /// The default implementation uses the [`Typename`] trait implemented by `Self::Vertex`
+    /// to get each vertex's type name.
+    ///
+    /// The caller guarantees that:
+    /// - `type_name` is a type or interface defined in the schema.
+    /// - When the active vertex is `Some(...)`, it's a vertex of type `type_name`:
+    ///   either its type is exactly `type_name`, or `type_name` is an interface that
+    ///   the vertex's type implements.
+    ///
+    /// The returned iterator must satisfy these properties:
+    /// - Produce `(context, property_value)` tuples with the property's value for that context.
+    /// - Produce contexts in the same order as the input `contexts` iterator produced them.
+    /// - Produce property values whose type matches the property's type defined in the schema.
+    /// - When a context's active vertex is `None`, its property value is `FieldValue::Null`.
+    ///
+    /// # Overriding the default implementation
+    ///
+    /// Some adapters may be able to implement this method more efficiently than the provided
+    /// default implementation.
+    ///
+    /// For example: adapters having access to a [`Schema`] can use
+    /// the [`interpreter::helpers::resolve_typename`](super::helpers::resolve_typename) method,
+    /// which implements a "fast path" for types that don't have any subtypes per the schema.
+    ///
+    /// [`DataContext`]: super::DataContext
+    /// [`Schema`]: crate::schema::Schema
+    fn resolve_typename(
+        &mut self,
+        contexts: ContextIterator<'vertex, Self::Vertex>,
+        _type_name: &str,
+    ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
+        resolve_property_with(contexts, |vertex| vertex.typename().into())
+    }
 }
 
 impl<'vertex, T> Adapter<'vertex> for T
@@ -166,6 +215,10 @@ where
         property_name: &std::sync::Arc<str>,
         _query_info: &QueryInfo,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
+        if property_name.as_ref() == "__typename" {
+            return self.resolve_typename(contexts, type_name);
+        }
+
         <Self as BasicAdapter>::resolve_property(
             self,
             contexts,


### PR DESCRIPTION
`BasicAdapter` now requires its `Vertex` type to implement `Typename`. In exchange, it automatically handles the type name property while still allowing implementers to override that logic. Default implementations of trait methods for the win!