### PR TITLE
Single-dependency `#[derive(TrustfallEnumVertex)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
  "ron 0.7.1",
  "serde",
  "serde_json",
- "trustfall_core",
+ "trustfall",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,12 +3205,12 @@ dependencies = [
 
 [[package]]
 name = "trustfall_derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "trustfall_core",
+ "trustfall",
  "trybuild",
 ]
 

--- a/demo-feeds/Cargo.toml
+++ b/demo-feeds/Cargo.toml
@@ -14,4 +14,4 @@ reqwest = { version = "0.11.6", features = ["blocking"] }
 ron = "0.7.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.69"
-trustfall_core = { path = "../trustfall_core" }
+trustfall = { path = "../trustfall" }

--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -1,12 +1,11 @@
 use feed_rs::model::{Content, Entry, Feed, FeedType, Image, Link, Text};
-use trustfall_core::{
-    field_property,
-    interpreter::{
-        basic_adapter::BasicAdapter,
-        helpers::{resolve_neighbors_with as neighbors, resolve_property_with as property},
-        ContextIterator, ContextOutcomeIterator, Typename, VertexIterator,
+use trustfall::{
+    provider::{
+        field_property, resolve_neighbors_with as neighbors, resolve_property_with as property,
+        BasicAdapter, ContextIterator, ContextOutcomeIterator, EdgeParameters,
+        VertexIterator, TrustfallEnumVertex,
     },
-    ir::{EdgeParameters, FieldValue},
+    FieldValue,
 };
 
 #[derive(Debug)]
@@ -20,7 +19,7 @@ impl<'a> FeedAdapter<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TrustfallEnumVertex)]
 pub(crate) enum Vertex<'a> {
     Feed(&'a Feed),
     FeedText(&'a Text),
@@ -28,39 +27,6 @@ pub(crate) enum Vertex<'a> {
     FeedLink(&'a Link),
     FeedEntry(&'a Entry),
     FeedContent(&'a Content),
-}
-
-macro_rules! impl_downcast {
-    ($name:ident, $output:ident, $arm:path) => {
-        fn $name(&self) -> Option<&'a $output> {
-            match self {
-                $arm(x) => Some(*x),
-                _ => None,
-            }
-        }
-    };
-}
-
-impl<'a> Vertex<'a> {
-    impl_downcast!(as_feed, Feed, Self::Feed);
-    impl_downcast!(as_feed_text, Text, Self::FeedText);
-    impl_downcast!(as_channel_image, Image, Self::ChannelImage);
-    impl_downcast!(as_feed_link, Link, Self::FeedLink);
-    impl_downcast!(as_feed_entry, Entry, Self::FeedEntry);
-    impl_downcast!(as_feed_content, Content, Self::FeedContent);
-}
-
-impl<'a> Typename for Vertex<'a> {
-    fn typename(&self) -> &'static str {
-        match self {
-            Vertex::Feed(..) => "Feed",
-            Vertex::FeedText(..) => "FeedText",
-            Vertex::ChannelImage(..) => "ChannelImage",
-            Vertex::FeedLink(..) => "FeedLink",
-            Vertex::FeedEntry(..) => "FeedEntry",
-            Vertex::FeedContent(..) => "FeedContent",
-        }
-    }
 }
 
 macro_rules! iterable {

--- a/demo-feeds/src/adapter.rs
+++ b/demo-feeds/src/adapter.rs
@@ -2,8 +2,8 @@ use feed_rs::model::{Content, Entry, Feed, FeedType, Image, Link, Text};
 use trustfall::{
     provider::{
         field_property, resolve_neighbors_with as neighbors, resolve_property_with as property,
-        BasicAdapter, ContextIterator, ContextOutcomeIterator, EdgeParameters,
-        VertexIterator, TrustfallEnumVertex,
+        BasicAdapter, ContextIterator, ContextOutcomeIterator, EdgeParameters, TrustfallEnumVertex,
+        VertexIterator,
     },
     FieldValue,
 };

--- a/demo-feeds/src/main.rs
+++ b/demo-feeds/src/main.rs
@@ -10,9 +10,7 @@ use std::{
 
 use feed_rs::{model::Feed, parser};
 use serde::Deserialize;
-use trustfall::{
-    FieldValue, Schema, execute_query,
-};
+use trustfall::{execute_query, FieldValue, Schema};
 
 #[macro_use]
 extern crate lazy_static;

--- a/demo-feeds/src/main.rs
+++ b/demo-feeds/src/main.rs
@@ -36,7 +36,7 @@ lazy_static! {
 struct InputQuery<'a> {
     query: &'a str,
 
-    args: Arc<BTreeMap<Arc<str>, FieldValue>>,
+    args: BTreeMap<Arc<str>, FieldValue>,
 }
 
 fn refresh_data() {

--- a/trustfall/Cargo.toml
+++ b/trustfall/Cargo.toml
@@ -2,6 +2,11 @@
 name = "trustfall"
 version = "0.2.0"
 edition = "2021"
+authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
+license = "Apache-2.0"
+description = "The trustfall query engine, empowering you to query everything."
+repository = "https://github.com/obi1kenobi/trustfall"
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trustfall/Cargo.toml
+++ b/trustfall/Cargo.toml
@@ -13,4 +13,4 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1.0.69"
 trustfall_core = { version = "0.2.0", path = "../trustfall_core" }
-trustfall_derive = { version = "0.2.0", path = "../trustfall_derive" }
+trustfall_derive = { version = "0.2.1", path = "../trustfall_derive" }

--- a/trustfall_derive/Cargo.toml
+++ b/trustfall_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall_derive"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0"
@@ -14,10 +14,10 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-trustfall_core = { version = "0.2.0", path = "../trustfall_core" }
 quote = "1.0"
 syn = "1.0"
 proc-macro2 = "1.0.51"
 
 [dev-dependencies]
 trybuild = "1.0"
+trustfall = { version = "0.2.0", path = "../trustfall" }

--- a/trustfall_derive/Cargo.toml
+++ b/trustfall_derive/Cargo.toml
@@ -2,6 +2,11 @@
 name = "trustfall_derive"
 version = "0.2.0"
 edition = "2021"
+authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
+license = "Apache-2.0"
+description = "Derive macros for the trustfall query engine."
+repository = "https://github.com/obi1kenobi/trustfall"
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trustfall_derive/src/lib.rs
+++ b/trustfall_derive/src/lib.rs
@@ -104,7 +104,7 @@ const SKIP_CONVERSION_ATTRIBUTE: &str = "skip_conversion";
 /// To add only the [`Typename`] implementation without the `as_<variant>()` conversions,
 /// use the [`Typename`](self::Typename) derive macro instead.
 ///
-/// [`Typename`]: trustfall::provider::Typename
+/// [`Typename`]: https://docs.rs/trustfall/0.2.0/trustfall/provider/trait.Typename.html
 #[proc_macro_derive(TrustfallEnumVertex, attributes(trustfall))]
 pub fn trustfall_enum_vertex_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match syn::parse(input) {
@@ -152,8 +152,8 @@ pub fn trustfall_enum_vertex_derive(input: proc_macro::TokenStream) -> proc_macr
 ///     }
 /// }
 /// ```
-/// [`Typename`]: trustfall::provider::Typename
-/// [`typename()`]: trustfall::provider::Typename::typename
+/// [`Typename`]: https://docs.rs/trustfall/0.2.0/trustfall/provider/trait.Typename.html
+/// [`typename()`]: https://docs.rs/trustfall/0.2.0/trustfall/provider/trait.Typename.html#tymethod.typename
 #[proc_macro_derive(Typename)]
 pub fn typename_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match syn::parse(input) {

--- a/trustfall_derive/src/lib.rs
+++ b/trustfall_derive/src/lib.rs
@@ -42,7 +42,7 @@ const SKIP_CONVERSION_ATTRIBUTE: &str = "skip_conversion";
 /// ```
 /// will get the following implementations:
 /// ```rust
-/// # use trustfall_core::interpreter::Typename;
+/// # use trustfall::provider::Typename;
 /// #
 /// # #[derive(Debug, Clone)]
 /// # enum Vertex {
@@ -104,7 +104,7 @@ const SKIP_CONVERSION_ATTRIBUTE: &str = "skip_conversion";
 /// To add only the [`Typename`] implementation without the `as_<variant>()` conversions,
 /// use the [`Typename`](self::Typename) derive macro instead.
 ///
-/// [`Typename`]: trustfall_core::interpreter::Typename
+/// [`Typename`]: trustfall::provider::Typename
 #[proc_macro_derive(TrustfallEnumVertex, attributes(trustfall))]
 pub fn trustfall_enum_vertex_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match syn::parse(input) {
@@ -133,7 +133,7 @@ pub fn trustfall_enum_vertex_derive(input: proc_macro::TokenStream) -> proc_macr
 /// ```
 /// will get the following implementation:
 /// ```rust
-/// # use trustfall_core::interpreter::Typename;
+/// # use trustfall::provider::Typename;
 /// #
 /// # #[derive(Debug, Clone)]
 /// # enum Vertex {
@@ -152,8 +152,8 @@ pub fn trustfall_enum_vertex_derive(input: proc_macro::TokenStream) -> proc_macr
 ///     }
 /// }
 /// ```
-/// [`Typename`]: trustfall_core::interpreter::Typename
-/// [`typename()`]: trustfall_core::interpreter::Typename::typename
+/// [`Typename`]: trustfall::provider::Typename
+/// [`typename()`]: trustfall::provider::Typename::typename
 #[proc_macro_derive(Typename)]
 pub fn typename_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match syn::parse(input) {

--- a/trustfall_derive/src/lib.rs
+++ b/trustfall_derive/src/lib.rs
@@ -188,7 +188,7 @@ fn impl_typename_derive(ast: &syn::DeriveInput) -> syn::Result<proc_macro2::Toke
 
     let gen = quote! {
         #[automatically_derived]
-        impl #impl_generics ::trustfall_core::interpreter::Typename for #name #ty_generics #where_clause {
+        impl #impl_generics ::trustfall::provider::Typename for #name #ty_generics #where_clause {
             fn typename(&self) -> &'static str {
                 match self {
                     #arms

--- a/trustfall_derive/tests/ui/call_skipped_conversion.rs
+++ b/trustfall_derive/tests/ui/call_skipped_conversion.rs
@@ -1,4 +1,4 @@
-use trustfall_core::interpreter::Typename;
+use trustfall::provider::Typename;
 use trustfall_derive::TrustfallEnumVertex;
 
 #[derive(Debug, Clone, TrustfallEnumVertex)]

--- a/trustfall_derive/tests/uses.rs
+++ b/trustfall_derive/tests/uses.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use trustfall::provider::Typename;
-use trustfall_derive::{TrustfallEnumVertex};
+use trustfall_derive::TrustfallEnumVertex;
 
 #[test]
 fn empty_enum() {

--- a/trustfall_derive/tests/uses.rs
+++ b/trustfall_derive/tests/uses.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
-use trustfall_core::interpreter::Typename;
-use trustfall_derive::{TrustfallEnumVertex, Typename};
+use trustfall::provider::Typename;
+use trustfall_derive::{TrustfallEnumVertex};
 
 #[test]
 fn empty_enum() {


### PR DESCRIPTION
Fixes #176.

- Use `TrustfallEnumVertex` derive with single dependency.
- Refer to the `trustfall` crate in macro-generated code.
