### PR TITLE
Add From<&bool> for FieldValue

### DIFF
--- a/trustfall_core/src/ir/value.rs
+++ b/trustfall_core/src/ir/value.rs
@@ -198,6 +198,12 @@ impl From<bool> for FieldValue {
     }
 }
 
+impl From<&bool> for FieldValue {
+    fn from(v: &bool) -> Self {
+        Self::Boolean(*v)
+    }
+}
+
 /// Represents a finite (non-infinite, not-NaN) [f64] value
 pub struct FiniteF64(f64);
 impl From<FiniteF64> for FieldValue {


### PR DESCRIPTION
The way helpers are created now, the following will throw an error as an arm to `resolve_property`:

```rust
("type", "bool_field") => resolve_property_with(contexts, field_property!(as_type, bool_field)),
```

throws

```
--> /adapter.rs:159:17
    |
159 |                 field_property!(type, bool_field),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&bool>` is not implemented for `FieldValue`
    |
    = note: required for `&bool` to implement `Into<FieldValue>`
    = note: this error originates in the macro `field_property` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider dereferencing here
   --> /XXX/trustfall_core/src/interpreter/helpers.rs:194:13
    |
194 |             (*(&vertex.$field)).into()
    |             ++                +
```

where `has_issues` is a bool field, and the content (i.e. we have something like `Vertex::Type(Rc<TypeWithBoolField>>`) of the vertex enum is some form of reference (I think).

I guess we could change the macro, but I am unsure if that will create unforeseen consequences.

Edit: Another workaround is to do the following, however it feels like a lot of work for little gains

```rust
("type", "bool_field") => resolve_property_with(contexts, field_property!(as_type, bool_field), { (*bool_field).into() }),
```