### PR TITLE
Add `From<&Vec<T>>` and `From<&&[T]>` for `FieldValue`.

### DIFF
--- a/trustfall_core/src/ir/value.rs
+++ b/trustfall_core/src/ir/value.rs
@@ -335,6 +335,12 @@ impl<T: Into<FieldValue>> From<Vec<T>> for FieldValue {
     }
 }
 
+impl<T: Clone + Into<FieldValue>> From<&Vec<T>> for FieldValue {
+    fn from(v: &Vec<T>) -> FieldValue {
+        FieldValue::List(v.iter().map(|x| x.clone().into()).collect())
+    }
+}
+
 impl<T: Clone + Into<FieldValue>> From<&[T]> for FieldValue {
     fn from(v: &[T]) -> FieldValue {
         FieldValue::List(v.iter().map(|x| x.clone().into()).collect())


### PR DESCRIPTION
Type inference doesn't always realize that it can use the `From<&[T]>`
implementation for `&Vec`, so let's help it out.
