### PR TITLE
Allow using `*_property` helper macros without importing `FieldValue`

### DIFF
--- a/trustfall/tests/helper_macros.rs
+++ b/trustfall/tests/helper_macros.rs
@@ -1,0 +1,130 @@
+// Do NOT import FieldValue, we want to check that accessor macros does what
+// we want
+
+struct Adapter;
+
+#[derive(Debug, Clone, trustfall::provider::TrustfallEnumVertex)]
+enum V {
+    Variant(Value),
+}
+
+#[derive(Debug, Clone)]
+struct Value {
+    name: String,
+}
+impl Value {
+    fn initial(&self) -> String {
+        self.name
+            .chars()
+            .next()
+            .map(String::from)
+            .unwrap_or_default()
+    }
+}
+
+impl trustfall::provider::BasicAdapter<'static> for Adapter {
+    type Vertex = V;
+    fn resolve_starting_vertices(
+        &mut self,
+        _edge_name: &str,
+        _parameters: &trustfall::provider::EdgeParameters,
+    ) -> trustfall::provider::VertexIterator<'static, Self::Vertex> {
+        Box::new(std::iter::once(V::Variant(Value {
+            name: String::from("Berit"),
+        })))
+    }
+    fn resolve_property(
+        &mut self,
+        contexts: trustfall::provider::ContextIterator<'static, Self::Vertex>,
+        type_name: &str,
+        property_name: &str,
+    ) -> trustfall::provider::ContextOutcomeIterator<'static, Self::Vertex, trustfall::FieldValue>
+    {
+        match (type_name, property_name) {
+            ("Vertex", "name") => trustfall::provider::resolve_property_with(
+                contexts,
+                trustfall::provider::field_property!(as_variant, name),
+            ),
+            ("Vertex", "initial") => trustfall::provider::resolve_property_with(
+                contexts,
+                trustfall::provider::accessor_property!(as_variant, initial),
+            ),
+            (t, p) => unreachable!("tried to resolve ({t}, {p})"),
+        }
+    }
+
+    fn resolve_neighbors(
+        &mut self,
+        _contexts: trustfall::provider::ContextIterator<'static, Self::Vertex>,
+        _type_name: &str,
+        _edge_name: &str,
+        _parameters: &trustfall::provider::EdgeParameters,
+    ) -> trustfall::provider::ContextOutcomeIterator<
+        'static,
+        Self::Vertex,
+        trustfall::provider::VertexIterator<'static, Self::Vertex>,
+    > {
+        todo!("schema should not contain neighbors: Berit likes it that way")
+    }
+
+    fn resolve_coercion(
+        &mut self,
+        _contexts: trustfall::provider::ContextIterator<'static, Self::Vertex>,
+        _type_name: &str,
+        _coerce_to_type: &str,
+    ) -> trustfall::provider::ContextOutcomeIterator<'static, Self::Vertex, bool> {
+        todo!("there is only ever one Berit")
+    }
+}
+
+#[test]
+fn main() {
+    let adapter = std::rc::Rc::new(std::cell::RefCell::new(Adapter));
+    let schema = trustfall::Schema::parse(
+        "\
+schema {
+    query: RootSchemaQuery
+}
+directive @filter(op: String!, value: [String!]) on FIELD | INLINE_FRAGMENT
+directive @tag(name: String) on FIELD
+directive @output(name: String) on FIELD
+directive @optional on FIELD
+directive @recurse(depth: Int!) on FIELD
+directive @fold on FIELD
+directive @transform(op: String!) on FIELD
+
+type RootSchemaQuery {
+    Person: Vertex!
+}
+
+type Vertex {
+    name: String!
+    initial: String!
+}",
+    )
+    .unwrap();
+
+    let query = "\
+{
+    Person {
+        name @output
+        initial @output
+    }
+}";
+    let variables: std::collections::BTreeMap<std::sync::Arc<str>, trustfall::FieldValue> =
+        std::collections::BTreeMap::new();
+    let res = trustfall::execute_query(&schema, adapter, query, variables)
+        .expect("query should resolve")
+        .collect::<Vec<_>>();
+
+    assert_eq!(res.len(), 1);
+
+    assert_eq!(
+        res[0].get("name").unwrap().to_owned(),
+        trustfall::FieldValue::String(String::from("Berit"))
+    );
+    assert_eq!(
+        res[0].get("initial").unwrap().to_owned(),
+        trustfall::FieldValue::String(String::from("B"))
+    );
+}

--- a/trustfall_core/src/interpreter/helpers.rs
+++ b/trustfall_core/src/interpreter/helpers.rs
@@ -184,12 +184,12 @@ pub fn resolve_coercion_with<'vertex, Vertex: Debug + Clone + 'vertex>(
 macro_rules! field_property {
     // If the data is a field directly on the vertex type.
     ($field:ident) => {
-        |vertex| -> FieldValue { vertex.$field.clone().into() }
+        |vertex| -> $crate::ir::value::FieldValue { vertex.$field.clone().into() }
     };
     // If we need to call a fallible conversion method
     // (such as `fn as_foo() -> Option<&Foo>`) before getting the field.
     ($conversion:ident, $field:ident) => {
-        |vertex| -> FieldValue {
+        |vertex| -> $crate::ir::value::FieldValue {
             let vertex = vertex.$conversion().expect("conversion failed");
             vertex.$field.clone().into()
         }
@@ -197,7 +197,7 @@ macro_rules! field_property {
     // Supply a block to post-process the field's value.
     // Use the field's name inside the block.
     ($conversion:ident, $field:ident, $b:block) => {
-        |vertex| -> FieldValue {
+        |vertex| -> $crate::ir::value::FieldValue {
             let $field = &vertex.$conversion().expect("conversion failed").$field;
             $b
         }
@@ -263,12 +263,12 @@ macro_rules! field_property {
 macro_rules! accessor_property {
     // If the data is available as an accessor method on the vertex type.
     ($accessor:ident) => {
-        |vertex| -> FieldValue { vertex.$accessor().clone().into() }
+        |vertex| -> $crate::ir::value::FieldValue { vertex.$accessor().clone().into() }
     };
     // If we need to call a fallible conversion method
     // (such as `fn as_foo() -> Option<&Foo>`) before using the accessor.
     ($conversion:ident, $accessor:ident) => {
-        |vertex| -> FieldValue {
+        |vertex| -> $crate::ir::value::FieldValue {
             let vertex = vertex.$conversion().expect("conversion failed");
             vertex.$accessor().clone().into()
         }
@@ -277,7 +277,7 @@ macro_rules! accessor_property {
     // The accessor's value is assigned to a variable with the same name as the accessor,
     // and is available as such inside the block.
     ($conversion:ident, $accessor:ident, $b:block) => {
-        |vertex| -> FieldValue {
+        |vertex| -> $crate::ir::value::FieldValue {
             let $accessor = vertex.$conversion().expect("conversion failed").$accessor();
             $b
         }


### PR DESCRIPTION
Fixes #203 

Before, the macro would not compile without `use ...::FieldValue` in the same scope. This uses the special `$crate` metavariable to fix this.

Haven't tested this properly, do we have anywhere nice to put the tests?