### PR TITLE
feat: Bump monaco-graphql, update editor configs

### DIFF
--- a/experiments/browser_based_querying/package-lock.json
+++ b/experiments/browser_based_querying/package-lock.json
@@ -18,7 +18,7 @@
         "detect-browser": "^5.3.0",
         "graphiql": "^1.11.5",
         "monaco-editor": "^0.20.0",
-        "monaco-graphql": "^1.1.2",
+        "monaco-graphql": "^1.2.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-reverse-portal": "^2.1.1",
@@ -3811,12 +3811,12 @@
       }
     },
     "node_modules/graphql-language-service": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.0.6.tgz",
-      "integrity": "sha512-FjE23aTy45Lr5metxCv3ZgSKEZOzN7ERR+OFC1isV5mHxI0Ob8XxayLTYjQKrs8b3kOpvgTYmSmu6AyXOzYslg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.1.3.tgz",
+      "integrity": "sha512-01KZLExoF53i8a2Jhgt+nVGsm9O2+jmDdwms4THSxCY+gU9FukF6X4pPLO2Gk7qZ6CVcInM8+IQx/ph4AOTOLA==",
       "dependencies": {
         "nullthrows": "^1.0.0",
-        "vscode-languageserver-types": "^3.15.1"
+        "vscode-languageserver-types": "^3.17.1"
       },
       "bin": {
         "graphql": "dist/temp-bin.js"
@@ -4901,16 +4901,17 @@
       "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ=="
     },
     "node_modules/monaco-graphql": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/monaco-graphql/-/monaco-graphql-1.1.2.tgz",
-      "integrity": "sha512-3Z9+Zre3vSnJ41rI1jnxym3UlKyXYjRWw6Gk4j+9bU273VIe0G/EPxubctj23lAc3MxeOpe3zGzzYugriGdqlQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/monaco-graphql/-/monaco-graphql-1.2.0.tgz",
+      "integrity": "sha512-r4QhIp7Q35zo7/a8EqtWePQou/sV0JewUjuXZJFHXKq1wDaTmXg+6AsS/D5wU5iUpudKu1Zjv2sC9co+28ypQA==",
       "dependencies": {
-        "graphql-language-service": "^5.0.6",
+        "graphql-language-service": "^5.1.3",
         "picomatch-browser": "^2.2.6"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0",
-        "monaco-editor": "^0.20.0"
+        "monaco-editor": ">= 0.20.0 < 1",
+        "prettier": "^2.8.0 || ^3.0.0"
       }
     },
     "node_modules/ms": {
@@ -5475,9 +5476,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -9551,12 +9552,12 @@
       "peer": true
     },
     "graphql-language-service": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.0.6.tgz",
-      "integrity": "sha512-FjE23aTy45Lr5metxCv3ZgSKEZOzN7ERR+OFC1isV5mHxI0Ob8XxayLTYjQKrs8b3kOpvgTYmSmu6AyXOzYslg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.1.3.tgz",
+      "integrity": "sha512-01KZLExoF53i8a2Jhgt+nVGsm9O2+jmDdwms4THSxCY+gU9FukF6X4pPLO2Gk7qZ6CVcInM8+IQx/ph4AOTOLA==",
       "requires": {
         "nullthrows": "^1.0.0",
-        "vscode-languageserver-types": "^3.15.1"
+        "vscode-languageserver-types": "^3.17.1"
       }
     },
     "graphql-ws": {
@@ -10213,11 +10214,11 @@
       "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ=="
     },
     "monaco-graphql": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/monaco-graphql/-/monaco-graphql-1.1.2.tgz",
-      "integrity": "sha512-3Z9+Zre3vSnJ41rI1jnxym3UlKyXYjRWw6Gk4j+9bU273VIe0G/EPxubctj23lAc3MxeOpe3zGzzYugriGdqlQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/monaco-graphql/-/monaco-graphql-1.2.0.tgz",
+      "integrity": "sha512-r4QhIp7Q35zo7/a8EqtWePQou/sV0JewUjuXZJFHXKq1wDaTmXg+6AsS/D5wU5iUpudKu1Zjv2sC9co+28ypQA==",
       "requires": {
-        "graphql-language-service": "^5.0.6",
+        "graphql-language-service": "^5.1.3",
         "picomatch-browser": "^2.2.6"
       }
     },
@@ -10564,8 +10565,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "dev": true
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw=="
     },
     "pretty-error": {
       "version": "4.0.0",

--- a/experiments/browser_based_querying/package.json
+++ b/experiments/browser_based_querying/package.json
@@ -37,7 +37,7 @@
     "detect-browser": "^5.3.0",
     "graphiql": "^1.11.5",
     "monaco-editor": "^0.20.0",
-    "monaco-graphql": "^1.1.2",
+    "monaco-graphql": "^1.2.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-reverse-portal": "^2.1.1",

--- a/experiments/browser_based_querying/src/TrustfallPlayground.tsx
+++ b/experiments/browser_based_querying/src/TrustfallPlayground.tsx
@@ -82,6 +82,8 @@ const enableGutterConfig: monaco.editor.IStandaloneEditorConstructionOptions = {
   folding: true,
   lineDecorationsWidth: 5,
   lineNumbersMinChars: 2,
+  acceptSuggestionOnEnter: "off",
+  suggestOnTriggerCharacters: false,
 };
 
 window.MonacoEnvironment = {


### PR DESCRIPTION
* Bumps the `monaco-graphql` library
* Updates config to `disableSuggestionOnEnter`, so hitting Enter always creates a new line rather than selecting the current autocomplete option
* Updates config to disable `suggestOnTriggerCharacters`. Big deal! No longer will hitting space automatically bring up autocomplete, which has been very frustrating for users. Entering characters will still bring up the autocomplete, as well as ctrl-space.