### PR TITLE
Add another test case to the suite.

### DIFF
--- a/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.graphql-parsed.ron
@@ -1,0 +1,80 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Number",
+      arguments: {
+        "max": Int64(3),
+        "min": Int64(1),
+      },
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Number",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          output: [
+            OutputDirective(),
+          ],
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "multiple",
+          arguments: {
+            "max": Int64(3),
+          },
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "multiple",
+          connections: [
+            (FieldConnection(
+              position: Pos(
+                line: 7,
+                column: 13,
+              ),
+              name: "value",
+              alias: Some("multiple"),
+            ), FieldNode(
+              position: Pos(
+                line: 7,
+                column: 13,
+              ),
+              name: "value",
+              alias: Some("multiple"),
+              output: [
+                OutputDirective(),
+              ],
+            )),
+          ],
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.graphql.ron
+++ b/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.graphql.ron
@@ -1,0 +1,16 @@
+// Query analogous to the one that triggers:
+// https://github.com/obi1kenobi/trustfall/issues/205
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Number(min: 1, max: 3) {
+        value @output
+
+        multiple(max: 3) @fold {
+            multiple: value @output
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.ir.ron
@@ -1,0 +1,57 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Number",
+    root_parameters: EdgeParameters(
+      contents: {
+        "max": Int64(3),
+        "min": Int64(1),
+      },
+    ),
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Number",
+        ),
+      },
+      folds: {
+        Eid(1): IRFold(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "multiple",
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(3),
+            },
+          ),
+          component: IRQueryComponent(
+            root: Vid(2),
+            vertices: {
+              Vid(2): IRVertex(
+                vid: Vid(2),
+                type_name: "Composite",
+              ),
+            },
+            outputs: {
+              "multiple": ContextField(
+                vertex_id: Vid(2),
+                field_name: "value",
+                field_type: "Int",
+              ),
+            },
+          ),
+        ),
+      },
+      outputs: {
+        "value": ContextField(
+          vertex_id: Vid(1),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.trace.ron
@@ -1,0 +1,691 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(ResolveStartingVertices(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(8)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+          folded_contexts: {
+            Eid(1): [],
+          },
+          folded_values: {
+            (Eid(1), "multiple"): Some(Vec([])),
+          },
+        )),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+          folded_contexts: {
+            Eid(1): [],
+          },
+          folded_values: {
+            (Eid(1), "multiple"): Some(Vec([])),
+          },
+        ), Int64(1))),
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "multiple": List([]),
+          "value": Int64(1),
+        }),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(17)),
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(17)),
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(17)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(21)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(21)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(21)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(21)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(21)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        )),
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(21)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        ), Int64(6))),
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(21)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(21)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(21)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
+          folded_values: {
+            (Eid(1), "multiple"): Some(Vec([
+              Value(Int64(4)),
+              Value(Int64(6)),
+            ])),
+          },
+        )),
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(4, [
+                  2,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(4, [
+                    2,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
+          folded_values: {
+            (Eid(1), "multiple"): Some(Vec([
+              Value(Int64(4)),
+              Value(Int64(6)),
+            ])),
+          },
+        ), Int64(2))),
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "multiple": List([
+            Int64(4),
+            Int64(6),
+          ]),
+          "value": Int64(2),
+        }),
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(36): TraceOp(
+        opid: Opid(36),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
+      ),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(38): TraceOp(
+        opid: Opid(38),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(39): TraceOp(
+        opid: Opid(39),
+        parent_opid: Some(Opid(38)),
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(6, [
+          2,
+          3,
+        ])))),
+      ),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(38)),
+        content: YieldFrom(ResolveNeighborsInner(1, Composite(CompositeNumber(9, [
+          3,
+        ])))),
+      ),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(38)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
+      ),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(42)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(44): TraceOp(
+        opid: Opid(44),
+        parent_opid: Some(Opid(42)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        )),
+      ),
+      Opid(45): TraceOp(
+        opid: Opid(45),
+        parent_opid: Some(Opid(42)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(6, [
+            2,
+            3,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(6, [
+              2,
+              3,
+            ]))),
+          },
+        ), Int64(6))),
+      ),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(42)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(47): TraceOp(
+        opid: Opid(47),
+        parent_opid: Some(Opid(42)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(9, [
+            3,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(9, [
+              3,
+            ]))),
+          },
+        )),
+      ),
+      Opid(48): TraceOp(
+        opid: Opid(48),
+        parent_opid: Some(Opid(42)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(9, [
+            3,
+          ]))),
+          vertices: {
+            Vid(2): Some(Composite(CompositeNumber(9, [
+              3,
+            ]))),
+          },
+        ), Int64(9))),
+      ),
+      Opid(49): TraceOp(
+        opid: Opid(49),
+        parent_opid: Some(Opid(42)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(50): TraceOp(
+        opid: Opid(50),
+        parent_opid: Some(Opid(42)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(51): TraceOp(
+        opid: Opid(51),
+        parent_opid: Some(Opid(42)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(52): TraceOp(
+        opid: Opid(52),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(9, [
+                  3,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(9, [
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
+          folded_values: {
+            (Eid(1), "multiple"): Some(Vec([
+              Value(Int64(6)),
+              Value(Int64(9)),
+            ])),
+          },
+        )),
+      ),
+      Opid(53): TraceOp(
+        opid: Opid(53),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(3))),
+          },
+          folded_contexts: {
+            Eid(1): [
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(6, [
+                  2,
+                  3,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(6, [
+                    2,
+                    3,
+                  ]))),
+                },
+              ),
+              SerializableContext(
+                active_vertex: Some(Composite(CompositeNumber(9, [
+                  3,
+                ]))),
+                vertices: {
+                  Vid(2): Some(Composite(CompositeNumber(9, [
+                    3,
+                  ]))),
+                },
+              ),
+            ],
+          },
+          folded_values: {
+            (Eid(1), "multiple"): Some(Vec([
+              Value(Int64(6)),
+              Value(Int64(9)),
+            ])),
+          },
+        ), Int64(3))),
+      ),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "multiple": List([
+            Int64(6),
+            Int64(9),
+          ]),
+          "value": Int64(3),
+        }),
+      ),
+      Opid(55): TraceOp(
+        opid: Opid(55),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(56): TraceOp(
+        opid: Opid(56),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(58): TraceOp(
+        opid: Opid(58),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(59): TraceOp(
+        opid: Opid(59),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(60): TraceOp(
+        opid: Opid(60),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Number",
+      root_parameters: EdgeParameters(
+        contents: {
+          "max": Int64(3),
+          "min": Int64(1),
+        },
+      ),
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Number",
+          ),
+        },
+        folds: {
+          Eid(1): IRFold(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "multiple",
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(3),
+              },
+            ),
+            component: IRQueryComponent(
+              root: Vid(2),
+              vertices: {
+                Vid(2): IRVertex(
+                  vid: Vid(2),
+                  type_name: "Composite",
+                ),
+              },
+              outputs: {
+                "multiple": ContextField(
+                  vertex_id: Vid(2),
+                  field_name: "value",
+                  field_type: "Int",
+                ),
+              },
+            ),
+          ),
+        },
+        outputs: {
+          "value": ContextField(
+            vertex_id: Vid(1),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+  results: [
+    {
+      "multiple": List([]),
+      "value": Int64(1),
+    },
+    {
+      "multiple": List([
+        Int64(4),
+        Int64(6),
+      ]),
+      "value": Int64(2),
+    },
+    {
+      "multiple": List([
+        Int64(6),
+        Int64(9),
+      ]),
+      "value": Int64(3),
+    },
+  ],
+)


### PR DESCRIPTION
Test case topologically similar to the problem in #205.

This doesn't reproduce the problem from #205 because the adapter doesn't do `.collect()` inside a resolver. I'll extend the test suite with more adapter implementations to trigger the same bug as #205 and go from there.