### PR TITLE
Make the `Adapter` trait methods take `&self` instead of `&mut self`.

### DIFF
--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -177,7 +177,7 @@ impl Adapter<'static> for DemoAdapter {
     type Vertex = Vertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         _resolve_info: &ResolveInfo,
@@ -202,7 +202,7 @@ impl Adapter<'static> for DemoAdapter {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -331,7 +331,7 @@ impl Adapter<'static> for DemoAdapter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -650,7 +650,7 @@ impl Adapter<'static> for DemoAdapter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/demo-hytradboi/src/main.rs
+++ b/demo-hytradboi/src/main.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::fs;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{cell::RefCell, fs};
 
 use adapter::DemoAdapter;
 use serde::Deserialize;
@@ -37,7 +37,7 @@ fn execute_query(path: &str) {
     let content = fs::read_to_string(path).unwrap();
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
-    let adapter = Rc::new(RefCell::new(DemoAdapter::new()));
+    let adapter = Rc::new(DemoAdapter::new());
 
     let query = parse(&SCHEMA, input_query.query).unwrap();
     let arguments = input_query.args;

--- a/experiments/trustfall_rustdoc/src/adapter.rs
+++ b/experiments/trustfall_rustdoc/src/adapter.rs
@@ -471,7 +471,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     type Vertex = Vertex<'a>;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         _parameters: &EdgeParameters,
         _resolve_info: &ResolveInfo,
@@ -493,7 +493,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -573,7 +573,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -1081,7 +1081,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/experiments/trustfall_rustdoc/src/lib.rs
+++ b/experiments/trustfall_rustdoc/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod adapter;
 pub mod indexed_crate;
 
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use gloo_utils::format::JsValueSerdeExt;
 use ouroboros::self_referencing;
@@ -50,10 +50,10 @@ pub fn run_query(
     trustfall_wasm::util::initialize().expect("init failed");
 
     let schema = RustdocAdapter::schema();
-    let adapter = Rc::new(RefCell::new(RustdocAdapter::new(
+    let adapter = Rc::new(RustdocAdapter::new(
         crate_info.inner.borrow_indexed_crate(),
         None,
-    )));
+    ));
 
     let query = trustfall_core::frontend::parse(&schema, query).map_err(|e| e.to_string())?;
     let args = from_js_args(args)?;

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use pyo3::{exceptions::PyStopIteration, prelude::*, wrap_pyfunction};
 
@@ -79,7 +79,7 @@ pub fn interpret_query(
     query: &str,
     #[pyo3(from_py_with = "to_query_arguments")] arguments: Arc<BTreeMap<Arc<str>, FieldValue>>,
 ) -> PyResult<ResultIterator> {
-    let wrapped_adapter = Rc::new(RefCell::new(adapter));
+    let wrapped_adapter = Rc::new(adapter);
 
     let indexed_query = parse(&schema.inner, query).map_err(|err| match err {
         FrontendError::ParseError(parse_err) => Python::with_gil(|py| {
@@ -236,7 +236,7 @@ impl Adapter<'static> for AdapterShim {
     type Vertex = Arc<Py<PyAny>>;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         _resolve_info: &ResolveInfo,
@@ -262,7 +262,7 @@ impl Adapter<'static> for AdapterShim {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -286,7 +286,7 @@ impl Adapter<'static> for AdapterShim {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -321,7 +321,7 @@ impl Adapter<'static> for AdapterShim {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: BaseContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall/examples/feeds/adapter.rs
+++ b/trustfall/examples/feeds/adapter.rs
@@ -43,7 +43,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
     type Vertex = Vertex<'a>;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &str,
         _parameters: &EdgeParameters,
     ) -> VertexIterator<'a, Self::Vertex> {
@@ -57,7 +57,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         property_name: &str,
@@ -135,7 +135,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
@@ -183,7 +183,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         _contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         coerce_to_type: &str,

--- a/trustfall/examples/feeds/main.rs
+++ b/trustfall/examples/feeds/main.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::RefCell,
     collections::BTreeMap,
     env,
     fs::{self, File},
@@ -66,7 +65,7 @@ fn run_query(path: &str) {
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
     let data = read_feed_data();
-    let adapter = Rc::new(RefCell::new(FeedAdapter::new(&data)));
+    let adapter = Rc::new(FeedAdapter::new(&data));
 
     let query = input_query.query;
     let arguments = input_query.args;

--- a/trustfall/examples/hackernews/adapter.rs
+++ b/trustfall/examples/hackernews/adapter.rs
@@ -124,7 +124,7 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
     type Vertex = Vertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &str,
         parameters: &EdgeParameters,
     ) -> VertexIterator<'static, Self::Vertex> {
@@ -147,7 +147,7 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &str,
         property_name: &str,
@@ -205,7 +205,7 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
@@ -358,7 +358,7 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &str,
         coerce_to_type: &str,

--- a/trustfall/examples/hackernews/main.rs
+++ b/trustfall/examples/hackernews/main.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -32,7 +31,7 @@ fn run_query(path: &str, max_results: Option<usize>) {
     let content = util::read_file(path);
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
-    let adapter = Rc::new(RefCell::new(HackerNewsAdapter::new()));
+    let adapter = Rc::new(HackerNewsAdapter::new());
 
     let query = input_query.query;
     let arguments = input_query.args;

--- a/trustfall/examples/weather/adapter.rs
+++ b/trustfall/examples/weather/adapter.rs
@@ -57,7 +57,7 @@ impl<'a> BasicAdapter<'a> for MetarAdapter<'a> {
     type Vertex = Vertex<'a>;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &str,
         parameters: &EdgeParameters,
     ) -> VertexIterator<'a, Self::Vertex> {
@@ -77,7 +77,7 @@ impl<'a> BasicAdapter<'a> for MetarAdapter<'a> {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         property_name: &str,
@@ -139,7 +139,7 @@ impl<'a> BasicAdapter<'a> for MetarAdapter<'a> {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
@@ -164,7 +164,7 @@ impl<'a> BasicAdapter<'a> for MetarAdapter<'a> {
 
     #[allow(unused_variables)]
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         coerce_to_type: &str,

--- a/trustfall/examples/weather/main.rs
+++ b/trustfall/examples/weather/main.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
+use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::rc::Rc;
 use std::sync::Arc;
-use std::{cell::RefCell, fs};
 use std::{env, process};
 
 use serde::Deserialize;
@@ -93,7 +93,7 @@ fn run_query(path: &str) {
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
     let data = read_metar_data();
-    let adapter = Rc::new(RefCell::new(MetarAdapter::new(&data)));
+    let adapter = Rc::new(MetarAdapter::new(&data));
 
     let query = input_query.query;
     let arguments = input_query.args;

--- a/trustfall/src/lib.rs
+++ b/trustfall/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 /// Components needed to implement data providers.
 pub mod provider {
@@ -30,7 +30,7 @@ pub use trustfall_core::schema::Schema;
 /// Run a Trustfall query over the data provider specified by the given schema and adapter.
 pub fn execute_query<'vertex>(
     schema: &Schema,
-    adapter: Rc<RefCell<impl provider::Adapter<'vertex> + 'vertex>>,
+    adapter: Rc<impl provider::Adapter<'vertex> + 'vertex>,
     query: &str,
     variables: BTreeMap<impl Into<Arc<str>>, impl Into<FieldValue>>,
 ) -> anyhow::Result<Box<dyn Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex>> {

--- a/trustfall/tests/helper_macros.rs
+++ b/trustfall/tests/helper_macros.rs
@@ -24,8 +24,9 @@ impl Value {
 
 impl trustfall::provider::BasicAdapter<'static> for Adapter {
     type Vertex = V;
+
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         _edge_name: &str,
         _parameters: &trustfall::provider::EdgeParameters,
     ) -> trustfall::provider::VertexIterator<'static, Self::Vertex> {
@@ -34,7 +35,7 @@ impl trustfall::provider::BasicAdapter<'static> for Adapter {
         })))
     }
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: trustfall::provider::ContextIterator<'static, Self::Vertex>,
         type_name: &str,
         property_name: &str,
@@ -54,7 +55,7 @@ impl trustfall::provider::BasicAdapter<'static> for Adapter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         _contexts: trustfall::provider::ContextIterator<'static, Self::Vertex>,
         _type_name: &str,
         _edge_name: &str,
@@ -68,7 +69,7 @@ impl trustfall::provider::BasicAdapter<'static> for Adapter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         _contexts: trustfall::provider::ContextIterator<'static, Self::Vertex>,
         _type_name: &str,
         _coerce_to_type: &str,
@@ -79,7 +80,7 @@ impl trustfall::provider::BasicAdapter<'static> for Adapter {
 
 #[test]
 fn main() {
-    let adapter = std::rc::Rc::new(std::cell::RefCell::new(Adapter));
+    let adapter = std::rc::Rc::new(Adapter);
     let schema = trustfall::Schema::parse(
         "\
 schema {

--- a/trustfall_core/fuzz/fuzz_targets/adapter_batching/numbers_adapter.rs
+++ b/trustfall_core/fuzz/fuzz_targets/adapter_batching/numbers_adapter.rs
@@ -187,7 +187,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
     type Vertex = NumbersVertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -218,7 +218,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -245,7 +245,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -360,7 +360,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -260,7 +260,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     type Vertex = FilesystemVertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -275,7 +275,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -345,7 +345,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -374,7 +374,7 @@ impl Adapter<'static> for FilesystemInterpreter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_core/src/interpreter/basic_adapter.rs
+++ b/trustfall_core/src/interpreter/basic_adapter.rs
@@ -40,7 +40,7 @@ pub trait BasicAdapter<'vertex> {
     /// - The specified edge is a starting edge in the schema being queried.
     /// - Any parameters the edge requires per the schema have values provided.
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &str,
         parameters: &EdgeParameters,
     ) -> VertexIterator<'vertex, Self::Vertex>;
@@ -73,7 +73,7 @@ pub trait BasicAdapter<'vertex> {
     ///
     /// [`DataContext`]: super::DataContext
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &str,
         property_name: &str,
@@ -104,7 +104,7 @@ pub trait BasicAdapter<'vertex> {
     /// - Each neighboring vertex is of the type specified for that edge in the schema.
     /// - When a context's active vertex is None, it has an empty neighbors iterator.
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
@@ -148,7 +148,7 @@ pub trait BasicAdapter<'vertex> {
     /// - Each neighboring vertex is of the type specified for that edge in the schema.
     /// - When a context's active vertex is `None`, its coercion outcome is `false`.
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &str,
         coerce_to_type: &str,
@@ -202,7 +202,7 @@ pub trait BasicAdapter<'vertex> {
     /// [`DataContext`]: super::DataContext
     /// [`Schema`]: crate::schema::Schema
     fn resolve_typename(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         _type_name: &str,
     ) -> ContextOutcomeIterator<'vertex, Self::Vertex, FieldValue> {
@@ -217,7 +217,7 @@ where
     type Vertex = T::Vertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &std::sync::Arc<str>,
         parameters: &EdgeParameters,
         _resolve_info: &ResolveInfo,
@@ -226,7 +226,7 @@ where
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &std::sync::Arc<str>,
         property_name: &std::sync::Arc<str>,
@@ -245,7 +245,7 @@ where
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &std::sync::Arc<str>,
         edge_name: &std::sync::Arc<str>,
@@ -262,7 +262,7 @@ where
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &std::sync::Arc<str>,
         coerce_to_type: &std::sync::Arc<str>,

--- a/trustfall_core/src/interpreter/hints/dynamic.rs
+++ b/trustfall_core/src/interpreter/hints/dynamic.rs
@@ -68,7 +68,7 @@ impl<'a> DynamicallyResolvedValue<'a> {
     #[allow(dead_code)] // false-positive: dead in the bin target, not dead in the lib
     pub fn resolve<'vertex, AdapterT: Adapter<'vertex>>(
         self,
-        adapter: &mut AdapterT,
+        adapter: &AdapterT,
         contexts: ContextIterator<'vertex, AdapterT::Vertex>,
     ) -> ContextOutcomeIterator<'vertex, AdapterT::Vertex, CandidateValue<FieldValue>> {
         match &self.field {
@@ -102,7 +102,7 @@ impl<'a> DynamicallyResolvedValue<'a> {
     fn resolve_context_field<'vertex, AdapterT: Adapter<'vertex>>(
         self,
         context_field: &'a ContextField,
-        adapter: &mut AdapterT,
+        adapter: &AdapterT,
         contexts: ContextIterator<'vertex, AdapterT::Vertex>,
     ) -> ContextOutcomeIterator<'vertex, AdapterT::Vertex, CandidateValue<FieldValue>> {
         let mut carrier = QueryCarrier {

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -428,7 +428,7 @@ pub trait Adapter<'vertex> {
     /// - The specified edge is a starting edge in the schema being queried.
     /// - Any parameters the edge requires per the schema have values provided.
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -456,7 +456,7 @@ pub trait Adapter<'vertex> {
     /// - Produce property values whose type matches the property's type defined in the schema.
     /// - When a context's active vertex is `None`, its property value is [`FieldValue::Null`].
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -488,7 +488,7 @@ pub trait Adapter<'vertex> {
     /// - Each neighboring vertex is of the type specified for that edge in the schema.
     /// - When a context's active vertex is None, it has an empty neighbors iterator.
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -533,7 +533,7 @@ pub trait Adapter<'vertex> {
     /// - Each neighboring vertex is of the type specified for that edge in the schema.
     /// - When a context's active vertex is `None`, its coercion outcome is `false`.
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -396,7 +396,7 @@ where
     type Vertex = Vertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -419,7 +419,7 @@ where
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'trace, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -449,7 +449,7 @@ where
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'trace, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -480,7 +480,7 @@ where
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'trace, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
@@ -521,9 +521,9 @@ pub fn assert_interpreted_results<'query, 'trace, Vertex>(
     'trace: 'query,
 {
     let next_op = Rc::new(RefCell::new(trace.ops.iter()));
-    let trace_reader_adapter = Rc::new(RefCell::new(TraceReaderAdapter {
+    let trace_reader_adapter = Rc::new(TraceReaderAdapter {
         next_op: next_op.clone(),
-    }));
+    });
 
     let query: Arc<IndexedQuery> = Arc::new(trace.ir_query.clone().try_into().unwrap());
     let arguments = Arc::new(

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -214,7 +214,7 @@ where
 
 #[allow(dead_code)]
 pub(crate) fn tap_results<'vertex, AdapterT>(
-    adapter_tap: Rc<RefCell<AdapterTap<'vertex, AdapterT>>>,
+    adapter_tap: Rc<AdapterTap<'vertex, AdapterT>>,
     result_iter: impl Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex,
 ) -> impl Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex
 where
@@ -223,8 +223,7 @@ where
     for<'de2> AdapterT::Vertex: Deserialize<'de2>,
 {
     result_iter.map(move |result| {
-        let adapter_ref = adapter_tap.borrow_mut();
-        adapter_ref
+        adapter_tap
             .tracer
             .borrow_mut()
             .record(TraceOpContent::ProduceQueryResult(result.clone()), None);
@@ -242,7 +241,7 @@ where
     type Vertex = AdapterT::Vertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -277,7 +276,7 @@ where
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -344,7 +343,7 @@ where
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -437,7 +436,7 @@ where
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'vertex, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_core/src/main.rs
+++ b/trustfall_core/src/main.rs
@@ -133,16 +133,14 @@ where
         test_query.ir_query.clone(),
         test_query.arguments,
     )));
-    let cloned_adapter = adapter.clone();
-    let adapter_tap = Rc::new(RefCell::new(AdapterTap::new(adapter, tracer.clone())));
+    let mut adapter_tap = Rc::new(AdapterTap::new(adapter, tracer));
 
     let execution_result = execution::interpret_ir(adapter_tap.clone(), query, arguments);
     match execution_result {
         Ok(results_iter) => {
             let results = tap_results(adapter_tap.clone(), results_iter).collect_vec();
 
-            let empty_tap = AdapterTap::new(cloned_adapter, tracer);
-            let trace = adapter_tap.replace(empty_tap).finish();
+            let trace = Rc::make_mut(&mut adapter_tap).clone().finish();
             let data = TestInterpreterOutputTrace {
                 schema_name: test_query.schema_name,
                 trace,

--- a/trustfall_core/src/nullables_interpreter.rs
+++ b/trustfall_core/src/nullables_interpreter.rs
@@ -21,7 +21,7 @@ impl Adapter<'static> for NullablesAdapter {
     type Vertex = NullablesVertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -30,7 +30,7 @@ impl Adapter<'static> for NullablesAdapter {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -40,7 +40,7 @@ impl Adapter<'static> for NullablesAdapter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -51,7 +51,7 @@ impl Adapter<'static> for NullablesAdapter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -201,7 +201,7 @@ impl Adapter<'static> for NumbersAdapter {
     type Vertex = NumbersVertex;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         resolve_info: &ResolveInfo,
@@ -232,7 +232,7 @@ impl Adapter<'static> for NumbersAdapter {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -259,7 +259,7 @@ impl Adapter<'static> for NumbersAdapter {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -374,7 +374,7 @@ impl Adapter<'static> for NumbersAdapter {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -259,7 +259,7 @@ impl Adapter<'static> for AdapterShim {
     type Vertex = JsValue;
 
     fn resolve_starting_vertices(
-        &mut self,
+        &self,
         edge_name: &Arc<str>,
         parameters: &CoreEdgeParameters,
         _resolve_info: &ResolveInfo,
@@ -272,7 +272,7 @@ impl Adapter<'static> for AdapterShim {
     }
 
     fn resolve_property(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
@@ -287,7 +287,7 @@ impl Adapter<'static> for AdapterShim {
     }
 
     fn resolve_neighbors(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
@@ -312,7 +312,7 @@ impl Adapter<'static> for AdapterShim {
     }
 
     fn resolve_coercion(
-        &mut self,
+        &self,
         contexts: ContextIterator<'static, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,

--- a/trustfall_wasm/src/lib.rs
+++ b/trustfall_wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use gloo_utils::format::JsValueSerdeExt;
 use trustfall_core::ir::FieldValue;
@@ -76,7 +76,7 @@ pub fn execute_query(
 
     let query = trustfall_core::frontend::parse(schema, query).map_err(|e| format!("{e}"))?;
 
-    let wrapped_adapter = Rc::new(RefCell::new(AdapterShim::new(adapter)));
+    let wrapped_adapter = Rc::new(AdapterShim::new(adapter));
 
     let results_iter =
         trustfall_core::interpreter::execution::interpret_ir(wrapped_adapter, query, args)

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use trustfall_wasm::{
     adapter::{AdapterShim, JsAdapter},
@@ -153,7 +153,7 @@ pub fn run_numbers_query(
 
     let query = trustfall_core::frontend::parse(&schema, query).map_err(|e| e.to_string())?;
 
-    let wrapped_adapter = Rc::new(RefCell::new(AdapterShim::new(adapter)));
+    let wrapped_adapter = Rc::new(AdapterShim::new(adapter));
 
     let results: Vec<_> = trustfall_core::interpreter::execution::interpret_ir(
         wrapped_adapter,


### PR DESCRIPTION
- Make the `Adapter` trait methods take `&self` instead of `&mut self`.
- Update `trustfall, pytrustfall, trustfall_wasm` and Rust examples.
- Fix experiments and hytradboi demo.
- Update fuzz target.

Fixes #205.
