### PR TITLE
Navigating past an `@optional` edge should disable many hints.

### DIFF
--- a/trustfall_core/src/interpreter/hints/vertex_info.rs
+++ b/trustfall_core/src/interpreter/hints/vertex_info.rs
@@ -281,8 +281,12 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
     }
 
     fn first_mandatory_edge(&self, name: &str) -> Option<EdgeInfo> {
-        self.edges_with_name(name)
-            .find(|edge| !edge.folded && !edge.optional && edge.recursive.is_none())
+        if self.non_binding_filters() {
+            None
+        } else {
+            self.edges_with_name(name)
+                .find(|edge| !edge.folded && !edge.optional && edge.recursive.is_none())
+        }
     }
 
     fn first_edge(&self, name: &str) -> Option<EdgeInfo> {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.graphql-parsed.ron
@@ -1,0 +1,85 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          recurse: Some(RecurseDirective(
+            depth: 2,
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          connections: [
+            (FieldConnection(
+              position: Pos(
+                line: 5,
+                column: 13,
+              ),
+              name: "predecessor",
+            ), FieldNode(
+              position: Pos(
+                line: 5,
+                column: 13,
+              ),
+              name: "predecessor",
+              connections: [
+                (FieldConnection(
+                  position: Pos(
+                    line: 6,
+                    column: 17,
+                  ),
+                  name: "predecessor",
+                ), FieldNode(
+                  position: Pos(
+                    line: 6,
+                    column: 17,
+                  ),
+                  name: "predecessor",
+                  connections: [
+                    (FieldConnection(
+                      position: Pos(
+                        line: 7,
+                        column: 21,
+                      ),
+                      name: "value",
+                    ), FieldNode(
+                      position: Pos(
+                        line: 7,
+                        column: 21,
+                      ),
+                      name: "value",
+                      output: [
+                        OutputDirective(),
+                      ],
+                    )),
+                  ],
+                )),
+              ],
+            )),
+          ],
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.graphql.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.graphql.ron
@@ -1,0 +1,16 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        successor @recurse(depth: 2) {
+            predecessor {
+                predecessor {
+                    value @output
+                }
+            }
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.ir.ron
@@ -1,0 +1,57 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Two",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Prime",
+        ),
+        Vid(2): IRVertex(
+          vid: Vid(2),
+          type_name: "Number",
+        ),
+        Vid(3): IRVertex(
+          vid: Vid(3),
+          type_name: "Number",
+        ),
+        Vid(4): IRVertex(
+          vid: Vid(4),
+          type_name: "Number",
+        ),
+      },
+      edges: {
+        Eid(1): IREdge(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "successor",
+          recursive: Some(Recursive(
+            depth: 2,
+          )),
+        ),
+        Eid(2): IREdge(
+          eid: Eid(2),
+          from_vid: Vid(2),
+          to_vid: Vid(3),
+          edge_name: "predecessor",
+        ),
+        Eid(3): IREdge(
+          eid: Eid(3),
+          from_vid: Vid(3),
+          to_vid: Vid(4),
+          edge_name: "predecessor",
+        ),
+      },
+      outputs: {
+        "value": ContextField(
+          vertex_id: Vid(4),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.trace.ron
@@ -1,0 +1,639 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(ResolveStartingVertices(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(3), "Number", Eid(3))),
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(4), "Number", "value")),
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(6)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(14)),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          piggyback: Some([
+            SerializableContext(
+              active_vertex: None,
+              vertices: {
+                Vid(1): Some(Prime(PrimeNumber(2))),
+              },
+              suspended_vertices: [
+                Some(Prime(PrimeNumber(2))),
+              ],
+            ),
+          ]),
+        )),
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+          piggyback: Some([
+            SerializableContext(
+              active_vertex: None,
+              vertices: {
+                Vid(1): Some(Prime(PrimeNumber(2))),
+              },
+              suspended_vertices: [
+                Some(Prime(PrimeNumber(2))),
+              ],
+            ),
+          ]),
+        ))),
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(17)),
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(23)),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(6)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+            Vid(4): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(6)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+            Vid(4): Some(Neither(NeitherNumber(0))),
+          },
+        ), Int64(0))),
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "value": Int64(0),
+        }),
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(6)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(23)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(20)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(34)),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(36): TraceOp(
+        opid: Opid(36),
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+            Vid(3): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+            Vid(3): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(38): TraceOp(
+        opid: Opid(38),
+        parent_opid: Some(Opid(37)),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(39): TraceOp(
+        opid: Opid(39),
+        parent_opid: Some(Opid(6)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+            Vid(3): Some(Prime(PrimeNumber(2))),
+            Vid(4): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(6)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+            Vid(3): Some(Prime(PrimeNumber(2))),
+            Vid(4): Some(Neither(NeitherNumber(1))),
+          },
+        ), Int64(1))),
+      ),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "value": Int64(1),
+        }),
+      ),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: Some(Opid(6)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(37)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(44): TraceOp(
+        opid: Opid(44),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(45): TraceOp(
+        opid: Opid(45),
+        parent_opid: Some(Opid(34)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(47): TraceOp(
+        opid: Opid(47),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(48): TraceOp(
+        opid: Opid(48),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(49): TraceOp(
+        opid: Opid(49),
+        parent_opid: Some(Opid(48)),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(50): TraceOp(
+        opid: Opid(50),
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(3): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(51): TraceOp(
+        opid: Opid(51),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(3): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(52): TraceOp(
+        opid: Opid(52),
+        parent_opid: Some(Opid(51)),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(53): TraceOp(
+        opid: Opid(53),
+        parent_opid: Some(Opid(6)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(3): Some(Prime(PrimeNumber(3))),
+            Vid(4): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: Some(Opid(6)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(3): Some(Prime(PrimeNumber(3))),
+            Vid(4): Some(Prime(PrimeNumber(2))),
+          },
+        ), Int64(2))),
+      ),
+      Opid(55): TraceOp(
+        opid: Opid(55),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "value": Int64(2),
+        }),
+      ),
+      Opid(56): TraceOp(
+        opid: Opid(56),
+        parent_opid: Some(Opid(6)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(51)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(58): TraceOp(
+        opid: Opid(58),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(59): TraceOp(
+        opid: Opid(59),
+        parent_opid: Some(Opid(48)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(60): TraceOp(
+        opid: Opid(60),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(17)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(63): TraceOp(
+        opid: Opid(63),
+        parent_opid: Some(Opid(14)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(64): TraceOp(
+        opid: Opid(64),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(65): TraceOp(
+        opid: Opid(65),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(66): TraceOp(
+        opid: Opid(66),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(67): TraceOp(
+        opid: Opid(67),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(68): TraceOp(
+        opid: Opid(68),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(69): TraceOp(
+        opid: Opid(69),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(70): TraceOp(
+        opid: Opid(70),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(71): TraceOp(
+        opid: Opid(71),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(72): TraceOp(
+        opid: Opid(72),
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(5)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(74): TraceOp(
+        opid: Opid(74),
+        parent_opid: Some(Opid(6)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(75): TraceOp(
+        opid: Opid(75),
+        parent_opid: Some(Opid(6)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Two",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Prime",
+          ),
+          Vid(2): IRVertex(
+            vid: Vid(2),
+            type_name: "Number",
+          ),
+          Vid(3): IRVertex(
+            vid: Vid(3),
+            type_name: "Number",
+          ),
+          Vid(4): IRVertex(
+            vid: Vid(4),
+            type_name: "Number",
+          ),
+        },
+        edges: {
+          Eid(1): IREdge(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "successor",
+            recursive: Some(Recursive(
+              depth: 2,
+            )),
+          ),
+          Eid(2): IREdge(
+            eid: Eid(2),
+            from_vid: Vid(2),
+            to_vid: Vid(3),
+            edge_name: "predecessor",
+          ),
+          Eid(3): IREdge(
+            eid: Eid(3),
+            from_vid: Vid(3),
+            to_vid: Vid(4),
+            edge_name: "predecessor",
+          ),
+        },
+        outputs: {
+          "value": ContextField(
+            vertex_id: Vid(4),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+  results: [
+    {
+      "value": Int64(0),
+    },
+    {
+      "value": Int64(1),
+    },
+    {
+      "value": Int64(2),
+    },
+  ],
+)

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.graphql-parsed.ron
@@ -1,0 +1,70 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          recurse: Some(RecurseDirective(
+            depth: 1,
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "successor",
+          connections: [
+            (FieldConnection(
+              position: Pos(
+                line: 5,
+                column: 13,
+              ),
+              name: "predecessor",
+            ), FieldNode(
+              position: Pos(
+                line: 5,
+                column: 13,
+              ),
+              name: "predecessor",
+              connections: [
+                (FieldConnection(
+                  position: Pos(
+                    line: 6,
+                    column: 17,
+                  ),
+                  name: "value",
+                ), FieldNode(
+                  position: Pos(
+                    line: 6,
+                    column: 17,
+                  ),
+                  name: "value",
+                  output: [
+                    OutputDirective(),
+                  ],
+                )),
+              ],
+            )),
+          ],
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.graphql.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.graphql.ron
@@ -1,0 +1,14 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        successor @recurse(depth: 1) {
+            predecessor {
+                value @output
+            }
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.ir.ron
@@ -1,0 +1,47 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Two",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Prime",
+        ),
+        Vid(2): IRVertex(
+          vid: Vid(2),
+          type_name: "Number",
+        ),
+        Vid(3): IRVertex(
+          vid: Vid(3),
+          type_name: "Number",
+        ),
+      },
+      edges: {
+        Eid(1): IREdge(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "successor",
+          recursive: Some(Recursive(
+            depth: 1,
+          )),
+        ),
+        Eid(2): IREdge(
+          eid: Eid(2),
+          from_vid: Vid(2),
+          to_vid: Vid(3),
+          edge_name: "predecessor",
+        ),
+      },
+      outputs: {
+        "value": ContextField(
+          vertex_id: Vid(3),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.trace.ron
@@ -1,0 +1,315 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(ResolveStartingVertices(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(1), "Prime", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(2), "Number", Eid(2))),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(3), "Number", "value")),
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(10)),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+          },
+        ))),
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(13)),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(2))),
+            Vid(3): Some(Neither(NeitherNumber(1))),
+          },
+        ), Int64(1))),
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "value": Int64(1),
+        }),
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(13)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+        )),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(3))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+          },
+        ))),
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(22)),
+        content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+            Vid(3): Some(Prime(PrimeNumber(2))),
+          },
+        )),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Prime(PrimeNumber(2))),
+          vertices: {
+            Vid(1): Some(Prime(PrimeNumber(2))),
+            Vid(2): Some(Prime(PrimeNumber(3))),
+            Vid(3): Some(Prime(PrimeNumber(2))),
+          },
+        ), Int64(2))),
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "value": Int64(2),
+        }),
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(22)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(10)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(36): TraceOp(
+        opid: Opid(36),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(38): TraceOp(
+        opid: Opid(38),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Two",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Prime",
+          ),
+          Vid(2): IRVertex(
+            vid: Vid(2),
+            type_name: "Number",
+          ),
+          Vid(3): IRVertex(
+            vid: Vid(3),
+            type_name: "Number",
+          ),
+        },
+        edges: {
+          Eid(1): IREdge(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "successor",
+            recursive: Some(Recursive(
+              depth: 1,
+            )),
+          ),
+          Eid(2): IREdge(
+            eid: Eid(2),
+            from_vid: Vid(2),
+            to_vid: Vid(3),
+            edge_name: "predecessor",
+          ),
+        },
+        outputs: {
+          "value": ContextField(
+            vertex_id: Vid(3),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+  results: [
+    {
+      "value": Int64(1),
+    },
+    {
+      "value": Int64(2),
+    },
+  ],
+)


### PR DESCRIPTION
Or else it's a footgun that adapters are pretty much guaranteed to fall for.

Also uses the test data added in #252 and #253.