### PR TITLE
`FilterTypeError` should display the inner error's message.

### DIFF
--- a/trustfall_core/src/frontend/error.rs
+++ b/trustfall_core/src/frontend/error.rs
@@ -49,7 +49,7 @@ pub enum FrontendError {
     )]
     ExplicitTagNameRequired(String),
 
-    #[error("Incompatible types encountered in @filter.")]
+    #[error("Incompatible types encountered in @filter: {0}")]
     FilterTypeError(#[from] FilterTypeError),
 
     #[error("Found an edge with an @output directive, this is not supported: {0}")]


### PR DESCRIPTION
Resolves UX problem flagged in https://github.com/obi1kenobi/trustfall/discussions/277