### PR TITLE
Actually put url property on all webpage objects

### DIFF
--- a/experiments/browser_based_querying/src/hackernews/adapter.ts
+++ b/experiments/browser_based_querying/src/hackernews/adapter.ts
@@ -72,22 +72,24 @@ const _userPattern = /^https:\/\/news\.ycombinator\.com\/user\?id=(.+)$/;
 
 function materializeWebsite(fetchPort: MessagePort, url: string): Vertex | null {
   const itemMatch = url.match(_itemPattern);
+  let ret: any
   if (itemMatch) {
     // This is an item.
-    return materializeItem(fetchPort, parseInt(itemMatch[1]));
+    ret = materializeItem(fetchPort, parseInt(itemMatch[1]));
   } else {
     const userMatch = url.match(_userPattern);
     if (userMatch) {
       // This is a user.
-      return materializeUser(fetchPort, userMatch[1]);
+      ret = materializeUser(fetchPort, userMatch[1]);
     } else {
       // This is some other type of webpage that we don't have a more specific type for.
-      return {
-        __typename: 'Website',
-        url,
+      ret = {
+        __typename: 'Website'
       };
     }
   }
+  ret.url = url
+  return ret
 }
 
 function* linksInHnMarkup(fetchPort: MessagePort, hnText: string | null): IterableIterator<Vertex> {


### PR DESCRIPTION
this fixes the problem described in: https://github.com/obi1kenobi/trustfall/discussions/277

The problem is that `materializeItem()` and `materializeUser()` don't put the `url` property on the objects they return. Open to solutions that don't use `any` if that's a problem.