### PR TITLE
Use `Arc` of adapter to execute queries.

### DIFF
--- a/demo-hytradboi/src/main.rs
+++ b/demo-hytradboi/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -37,7 +36,7 @@ fn execute_query(path: &str) {
     let content = fs::read_to_string(path).unwrap();
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
-    let adapter = Rc::new(DemoAdapter::new());
+    let adapter = Arc::new(DemoAdapter::new());
 
     let query = parse(&SCHEMA, input_query.query).unwrap();
     let arguments = input_query.args;

--- a/experiments/trustfall_rustdoc/src/lib.rs
+++ b/experiments/trustfall_rustdoc/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod adapter;
 pub mod indexed_crate;
 
-use std::{collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use gloo_utils::format::JsValueSerdeExt;
 use ouroboros::self_referencing;
@@ -50,7 +50,7 @@ pub fn run_query(
     trustfall_wasm::util::initialize().expect("init failed");
 
     let schema = RustdocAdapter::schema();
-    let adapter = Rc::new(RustdocAdapter::new(
+    let adapter = Arc::new(RustdocAdapter::new(
         crate_info.inner.borrow_indexed_crate(),
         None,
     ));

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use pyo3::{exceptions::PyStopIteration, prelude::*, wrap_pyfunction};
 
@@ -79,7 +79,7 @@ pub fn interpret_query(
     query: &str,
     #[pyo3(from_py_with = "to_query_arguments")] arguments: Arc<BTreeMap<Arc<str>, FieldValue>>,
 ) -> PyResult<ResultIterator> {
-    let wrapped_adapter = Rc::new(adapter);
+    let wrapped_adapter = Arc::from(adapter);
 
     let indexed_query = parse(&schema.inner, query).map_err(|err| match err {
         FrontendError::ParseError(parse_err) => Python::with_gil(|py| {

--- a/trustfall/examples/feeds/main.rs
+++ b/trustfall/examples/feeds/main.rs
@@ -4,7 +4,6 @@ use std::{
     fs::{self, File},
     io::{BufWriter, Write},
     process,
-    rc::Rc,
     sync::Arc,
 };
 
@@ -65,7 +64,7 @@ fn run_query(path: &str) {
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
     let data = read_feed_data();
-    let adapter = Rc::new(FeedAdapter::new(&data));
+    let adapter = Arc::new(FeedAdapter::new(&data));
 
     let query = input_query.query;
     let arguments = input_query.args;

--- a/trustfall/examples/hackernews/main.rs
+++ b/trustfall/examples/hackernews/main.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::{env, process};
 
@@ -31,7 +30,7 @@ fn run_query(path: &str, max_results: Option<usize>) {
     let content = util::read_file(path);
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
-    let adapter = Rc::new(HackerNewsAdapter::new());
+    let adapter = Arc::new(HackerNewsAdapter::new());
 
     let query = input_query.query;
     let arguments = input_query.args;

--- a/trustfall/examples/weather/main.rs
+++ b/trustfall/examples/weather/main.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::rc::Rc;
 use std::sync::Arc;
 use std::{env, process};
 
@@ -93,7 +92,7 @@ fn run_query(path: &str) {
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
     let data = read_metar_data();
-    let adapter = Rc::new(MetarAdapter::new(&data));
+    let adapter = Arc::new(MetarAdapter::new(&data));
 
     let query = input_query.query;
     let arguments = input_query.args;

--- a/trustfall/src/lib.rs
+++ b/trustfall/src/lib.rs
@@ -33,7 +33,7 @@
 //! More details on the role Trustfall plays in that use case are available in
 //! [this blog post](https://predr.ag/blog/speeding-up-rust-semver-checking-by-over-2000x/).
 
-use std::{collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 /// Components needed to implement data providers.
 pub mod provider {
@@ -69,7 +69,7 @@ pub use trustfall_core::TryIntoStruct;
 /// Run a Trustfall query over the data provider specified by the given schema and adapter.
 pub fn execute_query<'vertex>(
     schema: &Schema,
-    adapter: Rc<impl provider::Adapter<'vertex> + 'vertex>,
+    adapter: Arc<impl provider::Adapter<'vertex> + 'vertex>,
     query: &str,
     variables: BTreeMap<impl Into<Arc<str>>, impl Into<FieldValue>>,
 ) -> anyhow::Result<Box<dyn Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex>> {

--- a/trustfall/tests/helper_macros.rs
+++ b/trustfall/tests/helper_macros.rs
@@ -80,7 +80,7 @@ impl trustfall::provider::BasicAdapter<'static> for Adapter {
 
 #[test]
 fn main() {
-    let adapter = std::rc::Rc::new(Adapter);
+    let adapter = std::sync::Arc::new(Adapter);
     let schema = trustfall::Schema::parse(
         "\
 schema {

--- a/trustfall_core/src/interpreter/execution.rs
+++ b/trustfall_core/src/interpreter/execution.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    rc::Rc,
     sync::Arc,
 };
 
@@ -27,7 +26,7 @@ pub(super) struct QueryCarrier {
 
 #[allow(clippy::type_complexity)]
 pub fn interpret_ir<'query, AdapterT: Adapter<'query> + 'query>(
-    adapter: Rc<AdapterT>,
+    adapter: Arc<AdapterT>,
     indexed_query: Arc<IndexedQuery>,
     arguments: Arc<BTreeMap<Arc<str>, FieldValue>>,
 ) -> Result<Box<dyn Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'query>, QueryArgumentsError>
@@ -100,7 +99,7 @@ fn perform_coercion<'query, AdapterT: Adapter<'query>>(
 }
 
 fn compute_component<'query, AdapterT: Adapter<'query> + 'query>(
-    adapter: Rc<AdapterT>,
+    adapter: Arc<AdapterT>,
     carrier: &mut QueryCarrier,
     component: &IRQueryComponent,
     mut iterator: ContextIterator<'query, AdapterT::Vertex>,
@@ -345,7 +344,7 @@ fn collect_fold_elements<'query, Vertex: Clone + Debug + 'query>(
 
 #[allow(unused_variables)]
 fn compute_fold<'query, AdapterT: Adapter<'query> + 'query>(
-    adapter: Rc<AdapterT>,
+    adapter: Arc<AdapterT>,
     carrier: &mut QueryCarrier,
     expanding_from: &IRVertex,
     parent_component: &IRQueryComponent,
@@ -1285,7 +1284,7 @@ mod tests {
     }
 
     mod batching_fuzzer_repro_cases {
-        use std::{cell::RefCell, collections::VecDeque, marker::PhantomData, rc::Rc, sync::Arc};
+        use std::{cell::RefCell, collections::VecDeque, marker::PhantomData, sync::Arc};
 
         use crate::{
             interpreter::{
@@ -1478,7 +1477,7 @@ mod tests {
                     .map(|(k, v)| (k.into(), v))
                     .collect(),
             );
-            let adapter = Rc::new(VariableBatchingAdapter::new(
+            let adapter = Arc::new(VariableBatchingAdapter::new(
                 NumbersAdapter::new(),
                 batch_sequences,
             ));

--- a/trustfall_core/src/interpreter/hints/tests/mod.rs
+++ b/trustfall_core/src/interpreter/hints/tests/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::RefCell, collections::BTreeMap, num::NonZeroUsize, path::PathBuf, rc::Rc, sync::Arc,
+    cell::RefCell, collections::BTreeMap, num::NonZeroUsize, path::PathBuf, sync::Arc,
 };
 
 use super::{ResolveEdgeInfo, ResolveInfo};
@@ -159,9 +159,9 @@ fn eid(n: usize) -> Eid {
     Eid::new(n.try_into().unwrap())
 }
 
-fn run_query<A: Adapter<'static> + 'static>(adapter: A, input_name: &str) -> Rc<A> {
+fn run_query<A: Adapter<'static> + 'static>(adapter: A, input_name: &str) -> Arc<A> {
     let input = get_ir_for_named_query(input_name);
-    let adapter = Rc::from(adapter);
+    let adapter = Arc::from(adapter);
     let _ = interpret_ir(
         adapter.clone(),
         Arc::new(input.ir_query.try_into().unwrap()),

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -521,7 +521,7 @@ pub fn assert_interpreted_results<'query, 'trace, Vertex>(
     'trace: 'query,
 {
     let next_op = Rc::new(RefCell::new(trace.ops.iter()));
-    let trace_reader_adapter = Rc::new(TraceReaderAdapter {
+    let trace_reader_adapter = Arc::new(TraceReaderAdapter {
         next_op: next_op.clone(),
     });
 

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -213,7 +213,7 @@ where
 }
 
 pub fn tap_results<'vertex, AdapterT>(
-    adapter_tap: Rc<AdapterTap<'vertex, AdapterT>>,
+    adapter_tap: Arc<AdapterTap<'vertex, AdapterT>>,
     result_iter: impl Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex,
 ) -> impl Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex
 where

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -127,7 +127,7 @@ where
     let outputs = query.outputs.clone();
     let output_names: BTreeSet<_> = outputs.keys().collect();
 
-    let execution_result = execution::interpret_ir(Rc::new(adapter), query, arguments);
+    let execution_result = execution::interpret_ir(Arc::new(adapter), query, arguments);
     match execution_result {
         Ok(results_iter) => {
             let results = results_iter.collect_vec();
@@ -194,7 +194,7 @@ fn trace_with_adapter<'a, AdapterT>(
         test_query.ir_query.clone(),
         test_query.arguments,
     )));
-    let mut adapter_tap = Rc::new(AdapterTap::new(adapter, tracer));
+    let mut adapter_tap = Arc::new(AdapterTap::new(adapter, tracer));
 
     let execution_result = execution::interpret_ir(adapter_tap.clone(), query, arguments);
     match execution_result {
@@ -205,7 +205,7 @@ fn trace_with_adapter<'a, AdapterT>(
                 "tracing execution produced different outputs from expected (untraced) outputs"
             );
 
-            let trace = Rc::make_mut(&mut adapter_tap).clone().finish();
+            let trace = Arc::make_mut(&mut adapter_tap).clone().finish();
             let data = TestInterpreterOutputTrace {
                 schema_name: test_query.schema_name,
                 trace,

--- a/trustfall_wasm/src/lib.rs
+++ b/trustfall_wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use gloo_utils::format::JsValueSerdeExt;
 use trustfall_core::ir::FieldValue;
@@ -76,7 +76,7 @@ pub fn execute_query(
 
     let query = trustfall_core::frontend::parse(schema, query).map_err(|e| format!("{e}"))?;
 
-    let wrapped_adapter = Rc::new(AdapterShim::new(adapter));
+    let wrapped_adapter = Arc::new(AdapterShim::new(adapter));
 
     let results_iter =
         trustfall_core::interpreter::execution::interpret_ir(wrapped_adapter, query, args)

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use trustfall_wasm::{
     adapter::{AdapterShim, JsAdapter},
@@ -153,7 +153,7 @@ pub fn run_numbers_query(
 
     let query = trustfall_core::frontend::parse(&schema, query).map_err(|e| e.to_string())?;
 
-    let wrapped_adapter = Rc::new(AdapterShim::new(adapter));
+    let wrapped_adapter = Arc::new(AdapterShim::new(adapter));
 
     let results: Vec<_> = trustfall_core::interpreter::execution::interpret_ir(
         wrapped_adapter,


### PR DESCRIPTION
Using `trustfall` in a web server was previously quite tricky because it required an `Rc<Adapter>` whereas servers tend to wrap everything inside `Arc`. The mismatch was even more striking since some of Trustfall's other input arguments were themselves wrapped in `Arc`.

In principle, Trustfall doesn't need to know whether it's passed an `Rc` or `Arc` of the adapter. There's a way to do this with generics, but it's a bit complex and the overhead is not worth it right now. Instead, we make evaluating queries always use an `Arc` to get a large usability and ergonomics win at a tiny perf cost. We can relatively easily win back more than enough performance by optimizing other things. Stay tuned!
