### PR TITLE
Broaden lifetimes in Hackernews example

### DIFF
--- a/trustfall/examples/hackernews/adapter.rs
+++ b/trustfall/examples/hackernews/adapter.rs
@@ -212,22 +212,21 @@ impl<'a> BasicAdapter<'a> for HackerNewsAdapter {
     ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match (type_name, edge_name) {
             ("Story", "byUser") => {
-                let edge_resolver =
-                    |vertex: &Self::Vertex| -> VertexIterator<'a, Self::Vertex> {
-                        let story = vertex.as_story().unwrap();
-                        let author = story.by.as_str();
-                        match CLIENT.get_user(author) {
-                            Ok(None) => Box::new(std::iter::empty()), // no known author
-                            Ok(Some(user)) => Box::new(std::iter::once(user.into())),
-                            Err(e) => {
-                                eprintln!(
-                                    "API error while fetching story {} author \"{}\": {}",
-                                    story.id, author, e
-                                );
-                                Box::new(std::iter::empty())
-                            }
+                let edge_resolver = |vertex: &Self::Vertex| -> VertexIterator<'a, Self::Vertex> {
+                    let story = vertex.as_story().unwrap();
+                    let author = story.by.as_str();
+                    match CLIENT.get_user(author) {
+                        Ok(None) => Box::new(std::iter::empty()), // no known author
+                        Ok(Some(user)) => Box::new(std::iter::once(user.into())),
+                        Err(e) => {
+                            eprintln!(
+                                "API error while fetching story {} author \"{}\": {}",
+                                story.id, author, e
+                            );
+                            Box::new(std::iter::empty())
                         }
-                    };
+                    }
+                };
                 resolve_neighbors_with(contexts, edge_resolver)
             }
             ("Story", "comment") => {
@@ -264,18 +263,18 @@ impl<'a> BasicAdapter<'a> for HackerNewsAdapter {
                 let edge_resolver = |vertex: &Self::Vertex| {
                     let comment = vertex.as_comment().unwrap();
                     let author = comment.by.as_str();
-                    let neighbors: VertexIterator<'a, Self::Vertex> =
-                        match CLIENT.get_user(author) {
-                            Ok(None) => Box::new(std::iter::empty()), // no known author
-                            Ok(Some(user)) => Box::new(std::iter::once(user.into())),
-                            Err(e) => {
-                                eprintln!(
-                                    "API error while fetching comment {} author \"{}\": {}",
-                                    comment.id, author, e
-                                );
-                                Box::new(std::iter::empty())
-                            }
-                        };
+                    let neighbors: VertexIterator<'a, Self::Vertex> = match CLIENT.get_user(author)
+                    {
+                        Ok(None) => Box::new(std::iter::empty()), // no known author
+                        Ok(Some(user)) => Box::new(std::iter::once(user.into())),
+                        Err(e) => {
+                            eprintln!(
+                                "API error while fetching comment {} author \"{}\": {}",
+                                comment.id, author, e
+                            );
+                            Box::new(std::iter::empty())
+                        }
+                    };
                     neighbors
                 };
                 resolve_neighbors_with(contexts, edge_resolver)

--- a/trustfall/examples/hackernews/adapter.rs
+++ b/trustfall/examples/hackernews/adapter.rs
@@ -119,7 +119,7 @@ macro_rules! item_property_resolver {
     };
 }
 
-impl BasicAdapter<'static> for HackerNewsAdapter {
+impl<'a> BasicAdapter<'a> for HackerNewsAdapter {
     type Vertex = Vertex;
 
     fn resolve_starting_vertices(
@@ -147,10 +147,10 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
 
     fn resolve_property(
         &self,
-        contexts: ContextIterator<'static, Self::Vertex>,
+        contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         property_name: &str,
-    ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         match (type_name, property_name) {
             // properties on Item and its implementers
             (type_name, "id") if self.item_subtypes.contains(type_name) => {
@@ -205,11 +205,11 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
 
     fn resolve_neighbors(
         &self,
-        contexts: ContextIterator<'static, Self::Vertex>,
+        contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &str,
         edge_name: &str,
         _parameters: &EdgeParameters,
-    ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match (type_name, edge_name) {
             ("Story", "byUser") => {
                 let edge_resolver =
@@ -358,10 +358,12 @@ impl BasicAdapter<'static> for HackerNewsAdapter {
 
     fn resolve_coercion(
         &self,
-        contexts: ContextIterator<'static, Self::Vertex>,
+        contexts: ContextIterator<'a, Self::Vertex>,
         _type_name: &str,
         coerce_to_type: &str,
-    ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         resolve_coercion_using_schema(contexts, &SCHEMA, coerce_to_type)
     }
 }
+
+

--- a/trustfall/examples/hackernews/adapter.rs
+++ b/trustfall/examples/hackernews/adapter.rs
@@ -365,5 +365,3 @@ impl<'a> BasicAdapter<'a> for HackerNewsAdapter {
         resolve_coercion_using_schema(contexts, &SCHEMA, coerce_to_type)
     }
 }
-
-


### PR DESCRIPTION
Switch the lifetimesi n the hackernews example from 'static to non static, giving a bit more flexibility. Also, because Predrag said so.