### PR TITLE
Enable trusted publishing for Python packages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,5 +442,3 @@ jobs:
       - pre-publish-checks
       - attempt-publish-trustfall-core
     uses: ./.github/workflows/publish-python.yml
-    secrets:
-      PYPI_TOKEN: ${{ secrets.MATURIN_PYPI_TOKEN }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -2,9 +2,6 @@ name: Publish Python bindings
 
 on:
   workflow_call:
-    secrets:
-      PYPI_TOKEN:
-        required: true
 
 concurrency:
   group: publish-python
@@ -14,8 +11,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  publish:
-    name: publish python trustfall
+  tag:
+    name: tag the version
     runs-on: ubuntu-latest
     needs:
       - should-publish
@@ -25,20 +22,6 @@ jobs:
       # - musllinux
     if: needs.should-publish.outputs.is_new_version == 'yes' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Publish to PyPi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          set -euxo pipefail
-          pip install --upgrade twine
-          twine upload --skip-existing *
       - uses: actions/checkout@v3
         with:
           persist-credentials: true
@@ -48,6 +31,33 @@ jobs:
           export CURRENT_VERSION="$(.github/workflows/get_current_crate_version.sh trustfall)"
           git tag "pytrustfall-v$CURRENT_VERSION"
           git push origin "pytrustfall-v$CURRENT_VERSION"
+
+  publish:
+    name: publish python trustfall
+    runs-on: ubuntu-latest
+    needs:
+      - should-publish
+      - tag
+      - macos
+      - windows
+      - linux
+      # - musllinux
+    if: needs.should-publish.outputs.is_new_version == 'yes' && github.ref == 'refs/heads/main'
+    permissions:
+      # This permission is used for trusted publishing:
+      # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+      #
+      # Trusted publishing is configured on PyPI for the `trustfall` Python package.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true
 
   macos:
     runs-on: macos-latest

--- a/pytrustfall/pyproject.toml
+++ b/pytrustfall/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustfall"
-description = "If GraphQL were more like SQL: a query language for any combination of data sources."
+description = "A query engine for any combination of data sources. Query your files and APIs as if they were databases!"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
For more info, see: https://docs.pypi.org/trusted-publishers/
