### PR TITLE
Replace HRTBs with `DeserializeOwned`

### DIFF
--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use async_graphql_parser::types::Type;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     ir::{
@@ -125,11 +125,10 @@ impl From<ValueOrVec> for FieldValue {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize, for<'de2> Vertex: Deserialize<'de2>")]
+#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
 struct SerializableContext<Vertex>
 where
-    Vertex: Clone + Debug + Serialize,
-    for<'d> Vertex: Deserialize<'d>,
+    Vertex: Clone + Debug + Serialize + DeserializeOwned,
 {
     active_vertex: Option<Vertex>,
     vertices: BTreeMap<Vid, Option<Vertex>>,
@@ -156,8 +155,7 @@ where
 
 impl<Vertex> From<SerializableContext<Vertex>> for DataContext<Vertex>
 where
-    Vertex: Clone + Debug + Serialize,
-    for<'d> Vertex: Deserialize<'d>,
+    Vertex: Clone + Debug + Serialize + DeserializeOwned,
 {
     fn from(context: SerializableContext<Vertex>) -> Self {
         Self {
@@ -175,8 +173,7 @@ where
 
 impl<Vertex> From<DataContext<Vertex>> for SerializableContext<Vertex>
 where
-    Vertex: Clone + Debug + Serialize,
-    for<'d> Vertex: Deserialize<'d>,
+    Vertex: Clone + Debug + Serialize + DeserializeOwned,
 {
     fn from(context: DataContext<Vertex>) -> Self {
         Self {
@@ -305,8 +302,7 @@ impl<Vertex: Debug + Clone + PartialEq + Eq> Eq for DataContext<Vertex> {}
 
 impl<Vertex> Serialize for DataContext<Vertex>
 where
-    Vertex: Debug + Clone + Serialize,
-    for<'d> Vertex: Deserialize<'d>,
+    Vertex: Debug + Clone + Serialize + DeserializeOwned,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -319,8 +315,7 @@ where
 
 impl<'de, Vertex> Deserialize<'de> for DataContext<Vertex>
 where
-    Vertex: Debug + Clone + Serialize,
-    for<'d> Vertex: Deserialize<'d>,
+    Vertex: Debug + Clone + Serialize + DeserializeOwned,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     interpreter::VertexInfo,
@@ -25,8 +25,7 @@ use super::{
 #[derive(Clone, Debug)]
 struct TraceReaderAdapter<'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'trace,
 {
     next_op: Rc<RefCell<btree_map::Iter<'trace, Opid, TraceOp<Vertex>>>>,
 }
@@ -40,8 +39,7 @@ fn advance_ref_iter<T, Iter: Iterator<Item = T>>(iter: &RefCell<Iter>) -> Option
 #[derive(Debug)]
 struct TraceReaderStartingVerticesIter<'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'trace,
 {
     exhausted: bool,
     parent_opid: Opid,
@@ -51,8 +49,7 @@ where
 #[allow(unused_variables)]
 impl<'trace, Vertex> Iterator for TraceReaderStartingVerticesIter<'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'trace,
 {
     type Item = Vertex;
 
@@ -86,8 +83,7 @@ where
 
 struct TraceReaderResolvePropertiesIter<'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'trace,
 {
     exhausted: bool,
     parent_opid: Opid,
@@ -99,8 +95,7 @@ where
 #[allow(unused_variables)]
 impl<'trace, Vertex> Iterator for TraceReaderResolvePropertiesIter<'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'trace,
 {
     type Item = (DataContext<Vertex>, FieldValue);
 
@@ -166,8 +161,7 @@ where
 
 struct TraceReaderResolveCoercionIter<'query, 'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     exhausted: bool,
@@ -180,8 +174,7 @@ where
 #[allow(unused_variables)]
 impl<'query, 'trace, Vertex> Iterator for TraceReaderResolveCoercionIter<'query, 'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     type Item = (DataContext<Vertex>, bool);
@@ -249,8 +242,7 @@ where
 
 struct TraceReaderResolveNeighborsIter<'query, 'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     exhausted: bool,
@@ -262,8 +254,7 @@ where
 
 impl<'query, 'trace, Vertex> Iterator for TraceReaderResolveNeighborsIter<'query, 'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     type Item = (DataContext<Vertex>, VertexIterator<'query, Vertex>);
@@ -339,8 +330,7 @@ where
 
 struct TraceReaderNeighborIter<'query, 'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     exhausted: bool,
@@ -352,8 +342,7 @@ where
 
 impl<'query, 'trace, Vertex> Iterator for TraceReaderNeighborIter<'query, 'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     type Item = Vertex;
@@ -390,8 +379,7 @@ where
 #[allow(unused_variables)]
 impl<'trace, Vertex> Adapter<'trace> for TraceReaderAdapter<'trace, Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'trace,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'trace,
 {
     type Vertex = Vertex;
 
@@ -516,8 +504,7 @@ pub fn assert_interpreted_results<'query, 'trace, Vertex>(
     expected_results: &[BTreeMap<Arc<str>, FieldValue>],
     complete: bool,
 ) where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + 'query,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'query,
     'trace: 'query,
 {
     let next_op = Rc::new(RefCell::new(trace.ops.iter()));
@@ -577,7 +564,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use serde::{Deserialize, Serialize};
+    use serde::{de::DeserializeOwned, Serialize};
     use trustfall_filetests_macros::parameterize;
 
     use crate::{
@@ -594,8 +581,7 @@ mod tests {
         test_data: TestInterpreterOutputTrace<Vertex>,
         test_outputs: TestInterpreterOutputData,
     ) where
-        Vertex: Debug + Clone + PartialEq + Eq + Serialize,
-        for<'de> Vertex: Deserialize<'de>,
+        Vertex: Debug + Clone + PartialEq + Eq + Serialize + DeserializeOwned,
     {
         // Ensure that the trace file's IR hasn't drifted away from the IR file of the same name.
         assert_eq!(expected_ir.ir_query, test_data.trace.ir_query);

--- a/trustfall_core/src/serialization/mod.rs
+++ b/trustfall_core/src/serialization/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use serde::de;
+use serde::de::DeserializeOwned;
 
 use crate::ir::FieldValue;
 
@@ -51,13 +51,13 @@ mod tests;
 pub trait TryIntoStruct {
     type Error;
 
-    fn try_into_struct<S: for<'de> de::Deserialize<'de>>(self) -> Result<S, Self::Error>;
+    fn try_into_struct<S: DeserializeOwned>(self) -> Result<S, Self::Error>;
 }
 
 impl TryIntoStruct for BTreeMap<Arc<str>, FieldValue> {
     type Error = deserializers::Error;
 
-    fn try_into_struct<S: for<'de> de::Deserialize<'de>>(self) -> Result<S, deserializers::Error> {
+    fn try_into_struct<S: DeserializeOwned>(self) -> Result<S, deserializers::Error> {
         let deserializer = deserializers::QueryResultDeserializer::new(self);
         S::deserialize(deserializer)
     }

--- a/trustfall_core/src/test_types.rs
+++ b/trustfall_core/src/test_types.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     frontend::error::FrontendError,
@@ -44,11 +44,10 @@ pub struct TestIRQuery {
 pub type TestIRQueryResult = Result<TestIRQuery, FrontendError>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize, for<'de2> Vertex: Deserialize<'de2>")]
+#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
 pub struct TestInterpreterOutputTrace<Vertex>
 where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize,
-    for<'de2> Vertex: Deserialize<'de2>,
+    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
 {
     pub schema_name: String,
 

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 
 use async_graphql_parser::{parse_query, parse_schema};
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 
 use trustfall_core::{
     filesystem_interpreter::{FilesystemInterpreter, FilesystemVertex},
@@ -112,8 +112,7 @@ fn check_fuzzed(path: &str, schema_name: &str) {
 fn outputs_with_adapter<'a, AdapterT>(adapter: AdapterT, test_query: TestIRQuery)
 where
     AdapterT: Adapter<'a> + Clone + 'a,
-    AdapterT::Vertex: Clone + Debug + PartialEq + Eq + Serialize,
-    for<'de> AdapterT::Vertex: Deserialize<'de>,
+    AdapterT::Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
 {
     let query: Arc<IndexedQuery> = Arc::new(test_query.ir_query.clone().try_into().unwrap());
     let arguments: Arc<BTreeMap<_, _>> = Arc::new(
@@ -178,8 +177,7 @@ fn trace_with_adapter<'a, AdapterT>(
     expected_results: &Vec<BTreeMap<Arc<str>, FieldValue>>,
 ) where
     AdapterT: Adapter<'a> + Clone + 'a,
-    AdapterT::Vertex: Clone + Debug + PartialEq + Eq + Serialize,
-    for<'de> AdapterT::Vertex: Deserialize<'de>,
+    AdapterT::Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
 {
     let query = Arc::new(test_query.ir_query.clone().try_into().unwrap());
     let arguments: Arc<BTreeMap<_, _>> = Arc::new(


### PR DESCRIPTION
Replaces `for<'de> Deserialize<'de>` [higher-rank trait bounds (HRTBs)](https://doc.rust-lang.org/nomicon/hrtb.html) with the much simpler [`DeserializeOwned`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html) helper trait.

This change has no effect on semantics or compatibility.