### PR TITLE
Simplify definitions and impls of `Vertex`-containing types

### DIFF
--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -72,7 +72,7 @@ pub(crate) enum TaggedValue {
 
 /// A partial result of a Trustfall query within the interpreter defined in this module.
 #[derive(Debug, Clone)]
-pub struct DataContext<Vertex: Clone + Debug> {
+pub struct DataContext<Vertex> {
     active_vertex: Option<Vertex>,
     vertices: BTreeMap<Vid, Option<Vertex>>,
     values: Vec<FieldValue>,
@@ -83,7 +83,7 @@ pub struct DataContext<Vertex: Clone + Debug> {
     imported_tags: BTreeMap<FieldRef, TaggedValue>,
 }
 
-impl<Vertex: Clone + Debug> DataContext<Vertex> {
+impl<Vertex> DataContext<Vertex> {
     /// The vertex currently being processed.
     ///
     /// For contexts passed to an [`Adapter`] resolver method,
@@ -125,11 +125,8 @@ impl From<ValueOrVec> for FieldValue {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
-struct SerializableContext<Vertex>
-where
-    Vertex: Clone + Debug + Serialize + DeserializeOwned,
-{
+#[serde(bound = "Vertex: Debug + Clone + Serialize + DeserializeOwned")]
+struct SerializableContext<Vertex> {
     active_vertex: Option<Vertex>,
     vertices: BTreeMap<Vid, Option<Vertex>>,
 
@@ -153,10 +150,7 @@ where
     imported_tags: BTreeMap<FieldRef, TaggedValue>,
 }
 
-impl<Vertex> From<SerializableContext<Vertex>> for DataContext<Vertex>
-where
-    Vertex: Clone + Debug + Serialize + DeserializeOwned,
-{
+impl<Vertex> From<SerializableContext<Vertex>> for DataContext<Vertex> {
     fn from(context: SerializableContext<Vertex>) -> Self {
         Self {
             active_vertex: context.active_vertex,
@@ -171,10 +165,7 @@ where
     }
 }
 
-impl<Vertex> From<DataContext<Vertex>> for SerializableContext<Vertex>
-where
-    Vertex: Clone + Debug + Serialize + DeserializeOwned,
-{
+impl<Vertex> From<DataContext<Vertex>> for SerializableContext<Vertex> {
     fn from(context: DataContext<Vertex>) -> Self {
         Self {
             active_vertex: context.active_vertex,
@@ -286,7 +277,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     }
 }
 
-impl<Vertex: Debug + Clone + PartialEq> PartialEq for DataContext<Vertex> {
+impl<Vertex: PartialEq> PartialEq for DataContext<Vertex> {
     fn eq(&self, other: &Self) -> bool {
         self.active_vertex == other.active_vertex
             && self.vertices == other.vertices
@@ -298,7 +289,7 @@ impl<Vertex: Debug + Clone + PartialEq> PartialEq for DataContext<Vertex> {
     }
 }
 
-impl<Vertex: Debug + Clone + PartialEq + Eq> Eq for DataContext<Vertex> {}
+impl<Vertex: Eq> Eq for DataContext<Vertex> {}
 
 impl<Vertex> Serialize for DataContext<Vertex>
 where

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -20,11 +20,8 @@ use super::{
 pub struct Opid(pub NonZeroUsize); // operation ID
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
-pub struct Trace<Vertex>
-where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-{
+#[serde(bound = "Vertex: Debug + Clone + Serialize + DeserializeOwned")]
+pub struct Trace<Vertex> {
     pub ops: BTreeMap<Opid, TraceOp<Vertex>>,
 
     pub ir_query: IRQuery,
@@ -60,11 +57,8 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
-pub struct TraceOp<Vertex>
-where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-{
+#[serde(bound = "Vertex: Debug + Clone + Serialize + DeserializeOwned")]
+pub struct TraceOp<Vertex> {
     pub opid: Opid,
     pub parent_opid: Option<Opid>, // None parent_opid means this is a top-level operation
 
@@ -72,11 +66,8 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
-pub enum TraceOpContent<Vertex>
-where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-{
+#[serde(bound = "Vertex: Debug + Clone + Serialize + DeserializeOwned")]
+pub enum TraceOpContent<Vertex> {
     // TODO: make a way to differentiate between different queries recorded in the same trace
     Call(FunctionCall),
 
@@ -101,11 +92,8 @@ pub enum FunctionCall {
 
 #[allow(clippy::enum_variant_names)] // the variant names match the functions they represent
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
-pub enum YieldValue<Vertex>
-where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-{
+#[serde(bound = "Vertex: Debug + Clone + Serialize + DeserializeOwned")]
+pub enum YieldValue<Vertex> {
     ResolveStartingVertices(Vertex),
     ResolveProperty(DataContext<Vertex>, FieldValue),
     ResolveNeighborsOuter(DataContext<Vertex>),

--- a/trustfall_core/src/test_types.rs
+++ b/trustfall_core/src/test_types.rs
@@ -44,11 +44,8 @@ pub struct TestIRQuery {
 pub type TestIRQueryResult = Result<TestIRQuery, FrontendError>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "Vertex: Serialize + DeserializeOwned")]
-pub struct TestInterpreterOutputTrace<Vertex>
-where
-    Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-{
+#[serde(bound = "Vertex: Debug + Clone + Serialize + DeserializeOwned")]
+pub struct TestInterpreterOutputTrace<Vertex> {
     pub schema_name: String,
 
     pub trace: Trace<Vertex>,


### PR DESCRIPTION
By not requiring so many bounds on `Vertex` at type definition time, it becomes easier to modify this code.