### PR TITLE
Crate for generating adapter stubs given a schema.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,17 @@ dependencies = [
 
 [[package]]
 name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
+name = "bstr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
@@ -369,6 +380,18 @@ dependencies = [
  "http_req",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -606,6 +629,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -918,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick 0.7.20",
- "bstr",
+ "bstr 1.5.0",
  "fnv",
  "log",
  "regex",
@@ -1791,7 +1820,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec 1.10.0",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1904,6 +1933,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.22",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2208,6 +2247,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -2735,6 +2780,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+dependencies = [
+ "bstr 0.2.17",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
+dependencies = [
+ "console",
+ "similar",
 ]
 
 [[package]]
@@ -3338,6 +3403,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall_stubgen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "glob",
+ "maplit",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "similar-asserts",
+ "syn 2.0.22",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_testbin"
 version = "0.1.0"
 dependencies = [
@@ -3439,6 +3524,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-xid"
@@ -3752,7 +3843,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3772,11 +3863,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "trustfall_testbin",
     "trustfall_filetests_macros",
     "trustfall_derive",
+    "trustfall_stubgen",
     "trustfall_wasm",
     "pytrustfall",
     "demo-hytradboi",

--- a/trustfall_stubgen/Cargo.toml
+++ b/trustfall_stubgen/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "trustfall_stubgen"
+version = "0.1.0"
+rust-version = "1.70"
+license = "Apache-2.0"
+description = "Generate a Trustfall adapter stub for a given schema."
+repository = "https://github.com/obi1kenobi/trustfall"
+readme = "../README.md"
+edition.workspace = true
+authors.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+quote = "1.0"
+syn = "2.0"
+proc-macro2 = "1.0.51"
+trustfall = { path = "../trustfall" }
+maplit = "1.0.2"
+async-graphql-parser = "^2.11.3"
+async-graphql-value = "^2.11.3"
+anyhow = "1.0.71"
+serde = { version = "1.0.164", features = ["derive"] }
+prettyplease = "0.2.6"
+regex = "1.8.4"
+
+[dev-dependencies]
+glob = "0.3.1"
+serde_json = "1.0.96"
+similar-asserts = "1.4.2"

--- a/trustfall_stubgen/src/adapter_creator.rs
+++ b/trustfall_stubgen/src/adapter_creator.rs
@@ -1,0 +1,272 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use maplit::btreemap;
+use quote::quote;
+use trustfall::{Schema, SchemaAdapter, TryIntoStruct};
+
+use super::{
+    root::RustFile,
+    util::{parse_import, property_resolver_fn_name, type_edge_resolver_fn_name},
+};
+
+pub(super) fn make_adapter_file(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    adapter_file: &mut RustFile,
+    entrypoint_match_arms: proc_macro2::TokenStream,
+) {
+    let static_defn = quote! {
+        static SCHEMA: OnceLock<Schema> = OnceLock::new();
+    };
+
+    let adapter_defn = quote! {
+        #[derive(Debug)]
+        pub struct Adapter {}
+    };
+
+    adapter_file
+        .builtin_imports
+        .insert(parse_import("std::sync::OnceLock"));
+    adapter_file
+        .external_imports
+        .insert(parse_import("trustfall::Schema"));
+
+    adapter_file
+        .internal_imports
+        .insert(parse_import("super::vertex::Vertex"));
+
+    let adapter_impl = quote! {
+        impl Adapter {
+            pub const SCHEMA_TEXT: &'static str = include_str!("./schema.graphql");
+
+            pub fn schema() -> &'static Schema {
+                SCHEMA.get_or_init(|| Schema::parse(Self::SCHEMA_TEXT).expect("not a valid schema"))
+            }
+        }
+    };
+
+    let entrypoint_resolver_fn = emit_entrypoint_handling(
+        entrypoint_match_arms,
+        &mut adapter_file.builtin_imports,
+        &mut adapter_file.external_imports,
+    );
+    let property_resolver_fn = emit_property_handling(
+        querying_schema,
+        adapter.clone(),
+        &mut adapter_file.builtin_imports,
+        &mut adapter_file.external_imports,
+    );
+    let edge_resolver_fn = emit_edge_handling(
+        querying_schema,
+        adapter.clone(),
+        &mut adapter_file.builtin_imports,
+        &mut adapter_file.external_imports,
+    );
+    let coercion_resolver_fn = emit_coercion_handling(
+        &mut adapter_file.builtin_imports,
+        &mut adapter_file.external_imports,
+    );
+
+    let trustfall_adapter_impl = quote! {
+        impl<'a> trustfall::provider::Adapter<'a> for Adapter {
+            type Vertex = Vertex;
+
+            #entrypoint_resolver_fn
+
+            #property_resolver_fn
+
+            #edge_resolver_fn
+
+            #coercion_resolver_fn
+        }
+    };
+
+    adapter_file.top_level_items.extend([
+        static_defn,
+        adapter_defn,
+        adapter_impl,
+        trustfall_adapter_impl,
+    ]);
+}
+
+fn emit_entrypoint_handling(
+    entrypoint_match_arms: proc_macro2::TokenStream,
+    builtin_imports: &mut BTreeSet<Vec<String>>,
+    external_imports: &mut BTreeSet<Vec<String>>,
+) -> proc_macro2::TokenStream {
+    builtin_imports.insert(parse_import("std::sync::Arc"));
+    external_imports.insert(parse_import("trustfall::provider::VertexIterator"));
+    external_imports.insert(parse_import("trustfall::provider::EdgeParameters"));
+    external_imports.insert(parse_import("trustfall::provider::ResolveEdgeInfo"));
+
+    quote! {
+        fn resolve_starting_vertices(
+            &self,
+            edge_name: &Arc<str>,
+            parameters: &EdgeParameters,
+            resolve_info: &ResolveInfo,
+        ) -> VertexIterator<'a, Self::Vertex> {
+            match edge_name.as_ref() {
+                #entrypoint_match_arms
+                _ => unreachable!("attempted to resolve starting vertices for unexpected edge name: {edge_name}"),
+            }
+        }
+    }
+}
+
+fn emit_property_handling(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    builtin_imports: &mut BTreeSet<Vec<String>>,
+    external_imports: &mut BTreeSet<Vec<String>>,
+) -> proc_macro2::TokenStream {
+    let query = r#"
+{
+    VertexType {
+        name @output
+
+        property @fold @transform(op: "count") @filter(op: ">", value: ["$zero"])
+    }
+}"#;
+    let variables: BTreeMap<Arc<str>, i64> = btreemap! {
+        "zero".into() => 0,
+    };
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ResultRow {
+        name: String,
+    }
+
+    let mut arms = proc_macro2::TokenStream::new();
+    let rows = trustfall::execute_query(querying_schema, adapter, query, variables)
+        .expect("invalid query")
+        .map(|x| {
+            x.try_into_struct::<ResultRow>()
+                .expect("invalid conversion")
+        });
+    for row in rows {
+        let name = &row.name;
+        let ident = syn::Ident::new(
+            &property_resolver_fn_name(name),
+            proc_macro2::Span::call_site(),
+        );
+        arms.extend(quote! {
+            #name => super::properties::#ident(contexts, property_name.as_ref(), resolve_info),
+        });
+    }
+
+    builtin_imports.insert(parse_import("std::sync::Arc"));
+    external_imports.insert(parse_import("trustfall::provider::ContextIterator"));
+    external_imports.insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
+    external_imports.insert(parse_import("trustfall::provider::ResolveInfo"));
+    external_imports.insert(parse_import("trustfall::FieldValue"));
+
+    quote! {
+        fn resolve_property(
+            &self,
+            contexts: ContextIterator<'a, Self::Vertex>,
+            type_name: &Arc<str>,
+            property_name: &Arc<str>,
+            resolve_info: &ResolveInfo,
+        ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
+            match type_name.as_ref() {
+                #arms
+                _ => unreachable!("attempted to read property '{property_name}' on unexpected type: {type_name}"),
+            }
+        }
+    }
+}
+
+fn emit_edge_handling(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    builtin_imports: &mut BTreeSet<Vec<String>>,
+    external_imports: &mut BTreeSet<Vec<String>>,
+) -> proc_macro2::TokenStream {
+    let query = r#"
+{
+    VertexType {
+        name @output
+
+        edge @fold @transform(op: "count") @filter(op: ">", value: ["$zero"])
+    }
+}"#;
+    let variables: BTreeMap<Arc<str>, i64> = btreemap! {
+        "zero".into() => 0,
+    };
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ResultRow {
+        name: String,
+    }
+
+    let mut arms = proc_macro2::TokenStream::new();
+    let rows = trustfall::execute_query(querying_schema, adapter, query, variables)
+        .expect("invalid query")
+        .map(|x| {
+            x.try_into_struct::<ResultRow>()
+                .expect("invalid conversion")
+        });
+    for row in rows {
+        let name = &row.name;
+        let ident = syn::Ident::new(
+            &type_edge_resolver_fn_name(name),
+            proc_macro2::Span::call_site(),
+        );
+        arms.extend(quote! {
+            #name => super::edges::#ident(contexts, edge_name.as_ref(), parameters, resolve_info),
+        });
+    }
+
+    builtin_imports.insert(parse_import("std::sync::Arc"));
+    external_imports.insert(parse_import("trustfall::provider::ContextIterator"));
+    external_imports.insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
+    external_imports.insert(parse_import("trustfall::provider::EdgeParameters"));
+    external_imports.insert(parse_import("trustfall::provider::ResolveEdgeInfo"));
+    external_imports.insert(parse_import("trustfall::provider::VertexIterator"));
+    external_imports.insert(parse_import("trustfall::FieldValue"));
+
+    quote! {
+        fn resolve_neighbors(
+            &self,
+            contexts: ContextIterator<'a, Self::Vertex>,
+            type_name: &Arc<str>,
+            edge_name: &Arc<str>,
+            parameters: &EdgeParameters,
+            resolve_info: &ResolveEdgeInfo,
+        ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
+            match type_name.as_ref() {
+                #arms
+                _ => unreachable!("attempted to resolve edge '{edge_name}' on unexpected type: {type_name}"),
+            }
+        }
+    }
+}
+
+fn emit_coercion_handling(
+    builtin_imports: &mut BTreeSet<Vec<String>>,
+    external_imports: &mut BTreeSet<Vec<String>>,
+) -> proc_macro2::TokenStream {
+    builtin_imports.insert(parse_import("std::sync::Arc"));
+    external_imports.insert(parse_import("trustfall::provider::ContextIterator"));
+    external_imports.insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
+    external_imports.insert(parse_import("trustfall::provider::ResolveInfo"));
+    external_imports.insert(parse_import(
+        "trustfall::provider::resolve_coercion_using_schema",
+    ));
+
+    quote! {
+        fn resolve_coercion(
+            &self,
+            contexts: ContextIterator<'a, Self::Vertex>,
+            _type_name: &Arc<str>,
+            coerce_to_type: &Arc<str>,
+            _resolve_info: &ResolveInfo,
+        ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
+            resolve_coercion_using_schema(contexts, Self::schema(), coerce_to_type.as_ref())
+        }
+    }
+}

--- a/trustfall_stubgen/src/edges_creator.rs
+++ b/trustfall_stubgen/src/edges_creator.rs
@@ -1,0 +1,221 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use maplit::btreemap;
+use quote::quote;
+use trustfall::{Schema, SchemaAdapter, TryIntoStruct};
+
+use super::{
+    root::RustFile,
+    util::{
+        field_value_to_rust_type, parse_import, to_lower_snake_case, trustfall_type_to_rust_type,
+        type_edge_resolver_fn_name,
+    },
+};
+
+pub(super) fn make_edges_file(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    edges_file: &mut RustFile,
+) {
+    let query = r#"
+{
+    VertexType {
+        name @output
+
+        edge @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+            edge_name: name @output
+
+            parameter_: parameter @fold {
+                name @output
+                type @output
+            }
+        }
+    }
+}"#;
+    let variables: BTreeMap<Arc<str>, i64> = btreemap! {
+        "zero".into() => 0,
+    };
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ResultRow {
+        name: String,
+        edge_name: Vec<String>,
+        parameter_name: Vec<Vec<String>>,
+        parameter_type: Vec<Vec<String>>,
+    }
+
+    let rows = trustfall::execute_query(querying_schema, adapter, query, variables)
+        .expect("invalid query")
+        .map(|x| {
+            x.try_into_struct::<ResultRow>()
+                .expect("invalid conversion")
+        });
+    for row in rows {
+        let edges: Vec<(String, Vec<(String, String)>)> = row
+            .edge_name
+            .into_iter()
+            .zip(
+                row.parameter_name
+                    .into_iter()
+                    .zip(row.parameter_type.into_iter()),
+            )
+            .map(|(edge, (param, ty))| (edge, param.into_iter().zip(ty.into_iter()).collect()))
+            .collect();
+
+        let (type_edge_resolver_fn, type_edge_mod) = make_type_edge_resolver(&row.name, edges);
+        edges_file.top_level_items.push(type_edge_resolver_fn);
+        edges_file.top_level_items.push(type_edge_mod);
+    }
+
+    edges_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ContextIterator"));
+    edges_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
+    edges_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::EdgeParameters"));
+    edges_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ResolveEdgeInfo"));
+    edges_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::VertexIterator"));
+
+    edges_file
+        .internal_imports
+        .insert(parse_import("super::vertex::Vertex"));
+}
+
+fn make_type_edge_resolver(
+    type_name: &str,
+    edges: Vec<(String, Vec<(String, String)>)>,
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    let lower_type_name = to_lower_snake_case(type_name);
+    let mod_name = syn::Ident::new(&lower_type_name, proc_macro2::Span::call_site());
+
+    let mut arms = proc_macro2::TokenStream::new();
+    let mut edge_resolvers = proc_macro2::TokenStream::new();
+    for (edge_name, params) in edges {
+        let (arm, resolver) =
+            make_edge_resolver_and_call(type_name, &edge_name, &params, &mod_name);
+        arms.extend(arm);
+        edge_resolvers.extend(resolver);
+    }
+
+    let type_edge_resolver_fn = type_edge_resolver_fn_name(&lower_type_name);
+    let ident = syn::Ident::new(&type_edge_resolver_fn, proc_macro2::Span::call_site());
+    let unreachable_msg =
+        format!("attempted to resolve unexpected edge '{{edge_name}}' on type '{type_name}'");
+    let type_edge_resolver = quote! {
+        pub(super) fn #ident<'a>(
+            contexts: ContextIterator<'a, Vertex>,
+            edge_name: &str,
+            parameters: &EdgeParameters,
+            resolve_info: &ResolveEdgeInfo,
+        ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+            match edge_name {
+                #arms
+                _ => unreachable!(#unreachable_msg),
+            }
+        }
+    };
+
+    let type_edge_mod = quote! {
+        mod #mod_name {
+            use trustfall::provider::{ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator};
+
+            use super::super::vertex::Vertex;
+
+            #edge_resolvers
+        }
+    };
+
+    (type_edge_resolver, type_edge_mod)
+}
+
+fn make_edge_resolver_and_call(
+    type_name: &str,
+    edge_name: &str,
+    parameters: &[(String, String)],
+    mod_name: &proc_macro2::Ident,
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    let FnCall {
+        fn_params,
+        fn_args,
+        fn_arg_prep,
+    } = prepare_call_parameters(parameters, |parameter_name| {
+        format!("failed to find parameter '{parameter_name}' for edge '{edge_name}' on type '{type_name}'")
+    });
+
+    let resolver_fn_name = to_lower_snake_case(edge_name);
+    let resolver_fn_ident = syn::Ident::new(&resolver_fn_name, proc_macro2::Span::call_site());
+    let todo_msg = format!("implement edge '{edge_name}' for type '{type_name}'");
+    let resolver = quote! {
+        pub(super) fn #resolver_fn_ident<'a>(
+            contexts: ContextIterator<'a, Vertex>,
+            #fn_params
+            _resolve_info: &ResolveEdgeInfo,
+        ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+            todo!(#todo_msg)
+        }
+    };
+
+    let match_arm = if parameters.is_empty() {
+        quote! {
+            #edge_name => #mod_name::#resolver_fn_ident(contexts, resolve_info),
+        }
+    } else {
+        quote! {
+            #edge_name => {
+                #fn_arg_prep
+                #mod_name::#resolver_fn_ident(contexts, #fn_args resolve_info)
+            }
+        }
+    };
+
+    (match_arm, resolver)
+}
+
+pub(super) struct FnCall {
+    pub(super) fn_params: proc_macro2::TokenStream,
+    pub(super) fn_args: proc_macro2::TokenStream,
+    pub(super) fn_arg_prep: proc_macro2::TokenStream,
+}
+
+pub(super) fn prepare_call_parameters(
+    parameters: &[(String, String)],
+    expect_msg_fn: impl Fn(&str) -> String,
+) -> FnCall {
+    let mut fn_params: proc_macro2::TokenStream = proc_macro2::TokenStream::new();
+    let mut fn_args: proc_macro2::TokenStream = proc_macro2::TokenStream::new();
+    let mut fn_arg_prep: proc_macro2::TokenStream = proc_macro2::TokenStream::new();
+
+    for (parameter_name, parameter_type) in parameters {
+        let ident = syn::Ident::new(parameter_name, proc_macro2::Span::call_site());
+        let ty = trustfall_type_to_rust_type(parameter_type);
+        fn_params.extend(quote! {
+            #ident: #ty,
+        });
+        fn_args.extend(quote! {
+            #ident,
+        });
+
+        let expect_msg = expect_msg_fn(parameter_name);
+        let parameter_get = quote! {
+            parameters.get(#parameter_name).expect(#expect_msg)
+        };
+        let parameter_expr = field_value_to_rust_type(parameter_type, parameter_get);
+
+        fn_arg_prep.extend(quote! {
+            let #ident: #ty = #parameter_expr;
+        });
+    }
+
+    FnCall {
+        fn_params,
+        fn_args,
+        fn_arg_prep,
+    }
+}

--- a/trustfall_stubgen/src/entrypoints_creator.rs
+++ b/trustfall_stubgen/src/entrypoints_creator.rs
@@ -1,0 +1,112 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use maplit::btreemap;
+use quote::quote;
+use trustfall::{Schema, SchemaAdapter, TryIntoStruct};
+
+use crate::edges_creator::{prepare_call_parameters, FnCall};
+
+use super::{
+    root::RustFile,
+    util::{parse_import, to_lower_snake_case},
+};
+
+pub(super) fn make_entrypoints_file(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    entrypoints_file: &mut RustFile,
+    entrypoints_match_arms: &mut proc_macro2::TokenStream,
+) {
+    assert!(entrypoints_match_arms.is_empty());
+
+    let query = r#"
+{
+    Entrypoint {
+        name @output
+
+        parameter_: parameter @fold {
+            name @output
+            type @output
+        }
+    }
+}"#;
+    let variables: BTreeMap<Arc<str>, String> = btreemap! {};
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ResultRow {
+        name: String,
+        parameter_name: Vec<String>,
+        parameter_type: Vec<String>,
+    }
+
+    let rows = trustfall::execute_query(querying_schema, adapter, query, variables)
+        .expect("invalid query")
+        .map(|x| {
+            x.try_into_struct::<ResultRow>()
+                .expect("invalid conversion")
+        });
+    for row in rows {
+        let parameters: Vec<_> = row
+            .parameter_name
+            .into_iter()
+            .zip(row.parameter_type.into_iter())
+            .collect();
+
+        let (match_arm, entrypoint_fn) = make_entrypoint_fn(&row.name, &parameters);
+        entrypoints_file.top_level_items.push(entrypoint_fn);
+        entrypoints_match_arms.extend(match_arm);
+    }
+
+    entrypoints_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::VertexIterator"));
+    entrypoints_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ResolveInfo"));
+
+    entrypoints_file
+        .internal_imports
+        .insert(parse_import("super::vertex::Vertex"));
+}
+
+fn make_entrypoint_fn(
+    entrypoint: &str,
+    parameters: &[(String, String)],
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    let FnCall {
+        fn_params,
+        fn_args,
+        fn_arg_prep,
+    } = prepare_call_parameters(parameters, |parameter_name| {
+        format!("failed to find parameter '{parameter_name}' when resolving '{entrypoint}' starting vertices")
+    });
+
+    let entrypoint_fn_name = to_lower_snake_case(entrypoint);
+    let ident = syn::Ident::new(&entrypoint_fn_name, proc_macro2::Span::call_site());
+    let todo_msg =
+        format!("implement resolving starting vertices for entrypoint edge '{entrypoint}'");
+
+    let match_arm = if parameters.is_empty() {
+        quote! {
+            #entrypoint => super::entrypoints::#ident(resolve_info),
+        }
+    } else {
+        quote! {
+            #entrypoint => {
+                #fn_arg_prep
+                super::entrypoints::#ident(#fn_args resolve_info)
+            }
+        }
+    };
+
+    let resolver = quote! {
+        pub(super) fn #ident<'a>(
+            #fn_params
+            _resolve_info: &ResolveInfo,
+        ) -> VertexIterator<'a, Vertex> {
+            todo!(#todo_msg)
+        }
+    };
+
+    (match_arm, resolver)
+}

--- a/trustfall_stubgen/src/lib.rs
+++ b/trustfall_stubgen/src/lib.rs
@@ -1,0 +1,18 @@
+//! # trustfall_stubgen
+//!
+//! Given a Trustfall schema, autogenerate a Rust adapter stub fully wired up with
+//! all types, properties, and edges referenced in the schema.
+
+#![forbid(unsafe_code)]
+
+mod adapter_creator;
+mod edges_creator;
+mod entrypoints_creator;
+mod properties_creator;
+mod root;
+mod util;
+
+#[cfg(test)]
+mod tests;
+
+pub use root::generate_rust_stub;

--- a/trustfall_stubgen/src/properties_creator.rs
+++ b/trustfall_stubgen/src/properties_creator.rs
@@ -1,0 +1,92 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use maplit::btreemap;
+use quote::quote;
+use trustfall::{Schema, SchemaAdapter, TryIntoStruct};
+
+use super::{
+    root::RustFile,
+    util::{parse_import, property_resolver_fn_name},
+};
+
+pub(super) fn make_properties_file(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    properties_file: &mut RustFile,
+) {
+    let query = r#"
+{
+    VertexType {
+        name @output
+
+        property @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+            properties: name @output
+        }
+    }
+}"#;
+    let variables: BTreeMap<Arc<str>, i64> = btreemap! {
+        "zero".into() => 0,
+    };
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ResultRow {
+        name: String,
+        properties: Vec<String>,
+    }
+
+    let rows = trustfall::execute_query(querying_schema, adapter, query, variables)
+        .expect("invalid query")
+        .map(|x| {
+            x.try_into_struct::<ResultRow>()
+                .expect("invalid conversion")
+        });
+    for row in rows {
+        let resolver = make_resolver_fn(&row.name, &row.properties);
+        properties_file.top_level_items.push(resolver);
+    }
+
+    properties_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ContextIterator"));
+    properties_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
+    properties_file
+        .external_imports
+        .insert(parse_import("trustfall::provider::ResolveInfo"));
+    properties_file
+        .external_imports
+        .insert(parse_import("trustfall::FieldValue"));
+
+    properties_file
+        .internal_imports
+        .insert(parse_import("super::vertex::Vertex"));
+}
+
+fn make_resolver_fn(type_name: &str, properties: &[String]) -> proc_macro2::TokenStream {
+    let resolver_name = property_resolver_fn_name(type_name);
+    let ident = syn::Ident::new(&resolver_name, proc_macro2::Span::call_site());
+    let mut arms: proc_macro2::TokenStream = proc_macro2::TokenStream::new();
+
+    for property_name in properties {
+        let todo_msg = format!("implement property '{property_name}' in fn `{resolver_name}()`");
+        arms.extend(quote! {
+            #property_name => todo!(#todo_msg),
+        });
+    }
+
+    let unreachable_msg =
+        format!("attempted to read unexpected property '{{property_name}}' on type '{type_name}'");
+    quote! {
+        pub(super) fn #ident<'a>(
+            contexts: ContextIterator<'a, Vertex>,
+            property_name: &str,
+            _resolve_info: &ResolveInfo,
+        ) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+            match property_name {
+                #arms
+                _ => unreachable!(#unreachable_msg),
+            }
+        }
+    }
+}

--- a/trustfall_stubgen/src/root.rs
+++ b/trustfall_stubgen/src/root.rs
@@ -1,0 +1,372 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::Write,
+    path::Path,
+    sync::{Arc, OnceLock},
+};
+
+use maplit::btreemap;
+use quote::quote;
+use regex::Regex;
+use trustfall::{Schema, SchemaAdapter, TryIntoStruct};
+
+use super::{
+    adapter_creator::make_adapter_file, edges_creator::make_edges_file,
+    entrypoints_creator::make_entrypoints_file, properties_creator::make_properties_file,
+};
+
+/// Given a schema, make a Rust adapter stub for it in the given directory.
+///
+/// Generated code structure:
+/// - adapter/mod.rs         connects everything together
+/// - adapter/schema.graphql contains the schema for the adapter
+/// - adapter/adapter.rs     contains the adapter implementation
+/// - adapter/vertex.rs      contains the vertex type definition
+/// - adapter/entrypoints.rs contains the entry points where all queries must start
+/// - adapter/properties.rs  contains the property implementations
+/// - adapter/edges.rs       contains the edge implementations
+///
+/// # Example
+/// ```no_run
+/// # fn main() {
+/// let schema_text = include_str!("./schema.graphql");
+/// generate_rust_stub(schema_text, Path::new("crate/with/generated/stubs/src"))
+///     .expect("stub generation failed");
+/// # }
+/// ```
+pub fn generate_rust_stub(schema: &str, target: &Path) -> anyhow::Result<()> {
+    let target_schema = Schema::parse(schema)?;
+
+    let querying_schema =
+        Schema::parse(SchemaAdapter::schema_text()).expect("schema querying schema was not valid");
+    let schema_adapter = Arc::new(SchemaAdapter::new(&target_schema));
+
+    let mut stub = AdapterStub::with_standard_mod(schema);
+
+    let mut entrypoint_match_arms = proc_macro2::TokenStream::new();
+
+    make_vertex_file(&querying_schema, schema_adapter.clone(), &mut stub.vertex);
+    make_entrypoints_file(
+        &querying_schema,
+        schema_adapter.clone(),
+        &mut stub.entrypoints,
+        &mut entrypoint_match_arms,
+    );
+    make_properties_file(
+        &querying_schema,
+        schema_adapter.clone(),
+        &mut stub.properties,
+    );
+    make_edges_file(&querying_schema, schema_adapter.clone(), &mut stub.edges);
+
+    make_adapter_file(
+        &querying_schema,
+        schema_adapter.clone(),
+        &mut stub.adapter,
+        entrypoint_match_arms,
+    );
+
+    stub.write_to_directory(target)
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RustFile {
+    pub(crate) builtin_imports: BTreeSet<Vec<String>>,
+    pub(crate) internal_imports: BTreeSet<Vec<String>>,
+    pub(crate) external_imports: BTreeSet<Vec<String>>,
+    pub(crate) top_level_items: Vec<proc_macro2::TokenStream>,
+}
+
+impl RustFile {
+    fn write_to_file(self, target: &Path) -> anyhow::Result<()> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(8192);
+
+        write_import_tree(&mut buffer, &self.builtin_imports)?;
+        if !self.builtin_imports.is_empty() {
+            buffer.write_all("\n".as_bytes())?;
+        }
+
+        write_import_tree(&mut buffer, &self.external_imports)?;
+        if !self.external_imports.is_empty() {
+            buffer.write_all("\n".as_bytes())?;
+        }
+
+        write_import_tree(&mut buffer, &self.internal_imports)?;
+        if !self.internal_imports.is_empty() {
+            buffer.write_all("\n".as_bytes())?;
+        }
+
+        let mut item_iter = self.top_level_items.into_iter();
+        let first_item = item_iter.next().expect("no items found");
+        Self::pretty_print_item(&mut buffer, first_item)?;
+
+        for item in item_iter {
+            buffer.write_all("\n".as_bytes())?;
+            Self::pretty_print_item(&mut buffer, item)?;
+        }
+
+        std::fs::write(target, buffer)?;
+
+        Ok(())
+    }
+
+    /// Pretty-print an item into the buffer.
+    ///
+    /// First use `prettyplease`, then postprocess with a regex to further improve quality.
+    /// `prettyplease` does not add blank lines between sibling items, so we add them via regex.
+    fn pretty_print_item(
+        buffer: &mut impl std::io::Write,
+        item: proc_macro2::TokenStream,
+    ) -> anyhow::Result<()> {
+        static PATTERN: OnceLock<Regex> = OnceLock::new();
+        let pattern =
+            PATTERN.get_or_init(|| Regex::new("([^{])\n    (pub|fn|use)").expect("invalid regex"));
+
+        let pretty_item =
+            prettyplease::unparse(&syn::parse_str(&item.to_string()).expect("not valid Rust"));
+        let postprocessed = pattern.replace_all(&pretty_item, "$1\n\n    $2");
+
+        buffer.write_all(postprocessed.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum NodeOrLeaf<'a> {
+    Leaf,
+    Node(BTreeMap<&'a str, NodeOrLeaf<'a>>),
+}
+
+impl<'a> NodeOrLeaf<'a> {
+    fn insert(&mut self, path: &'a [String]) {
+        if let Some(first) = path.first() {
+            let rest = &path[1..];
+            match self {
+                Self::Leaf => {
+                    *self = Self::Node(btreemap! {
+                        "self" => Self::Leaf,
+                        first.as_str() => Self::from_path(rest),
+                    })
+                }
+                Self::Node(ref mut map) => match map.entry(first) {
+                    std::collections::btree_map::Entry::Vacant(e) => {
+                        e.insert(Self::from_path(rest));
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut e) => {
+                        e.get_mut().insert(rest);
+                    }
+                },
+            }
+        } else {
+            match self {
+                Self::Leaf => {} // self is already here
+                Self::Node(ref mut map) => {
+                    map.insert("self", Self::Leaf);
+                }
+            }
+        }
+    }
+
+    fn from_path(path: &[String]) -> NodeOrLeaf<'_> {
+        if let Some(first) = path.first() {
+            let rest = &path[1..];
+            NodeOrLeaf::Node(btreemap! {
+                first.as_str() => Self::from_path(rest)
+            })
+        } else {
+            NodeOrLeaf::Leaf
+        }
+    }
+}
+
+fn make_import_forest(imports: &BTreeSet<Vec<String>>) -> BTreeMap<&str, NodeOrLeaf<'_>> {
+    let first_import = imports.first().expect("no imports").as_slice();
+    let mut node = NodeOrLeaf::from_path(first_import);
+
+    for import in imports.iter().skip(1) {
+        node.insert(import.as_slice());
+    }
+
+    match node {
+        NodeOrLeaf::Node(map) => map,
+        NodeOrLeaf::Leaf => {
+            unreachable!("unexpectedly got a leaf node for the top level of the import forest")
+        }
+    }
+}
+
+fn write_import_tree<W: std::io::Write>(
+    writer: &mut W,
+    imports: &BTreeSet<Vec<String>>,
+) -> anyhow::Result<()> {
+    if imports.is_empty() {
+        return Ok(());
+    }
+
+    let forest = make_import_forest(imports);
+
+    for (root, nodes) in forest {
+        writer.write_all("use ".as_bytes())?;
+        writer.write_all(root.as_bytes())?;
+
+        write_import_subtree(writer, nodes)?;
+        writer.write_all(";\n".as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn write_import_subtree<W: std::io::Write>(
+    writer: &mut W,
+    nodes: NodeOrLeaf<'_>,
+) -> anyhow::Result<()> {
+    match nodes {
+        NodeOrLeaf::Leaf => {}
+        NodeOrLeaf::Node(map) => {
+            writer.write_all("::".as_bytes())?;
+
+            if map.len() == 1 {
+                for (root, inner) in map {
+                    writer.write_all(root.as_bytes())?;
+                    write_import_subtree(writer, inner)?;
+                }
+            } else {
+                writer.write_all("{".as_bytes())?;
+
+                let mut map_iter = map.into_iter();
+                let (root, inner) = map_iter.next().expect("empty map found");
+                writer.write_all(root.as_bytes())?;
+                write_import_subtree(writer, inner)?;
+
+                for (root, inner) in map_iter {
+                    writer.write_all(", ".as_bytes())?;
+                    writer.write_all(root.as_bytes())?;
+                    write_import_subtree(writer, inner)?;
+                }
+
+                writer.write_all("}".as_bytes())?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct AdapterStub<'a> {
+    mod_: RustFile,
+    schema: &'a str,
+    adapter: RustFile,
+    vertex: RustFile,
+    entrypoints: RustFile,
+    properties: RustFile,
+    edges: RustFile,
+}
+
+impl<'a> AdapterStub<'a> {
+    fn with_standard_mod(schema: &'a str) -> Self {
+        let mut mod_ = RustFile::default();
+
+        mod_.top_level_items.push(quote! {
+            mod adapter;
+            mod vertex;
+            mod entrypoints;
+            mod properties;
+            mod edges;
+        });
+        mod_.top_level_items.push(quote! {
+            pub use adapter::Adapter;
+            pub use vertex::Vertex;
+        });
+
+        Self {
+            mod_,
+            schema,
+            adapter: Default::default(),
+            vertex: Default::default(),
+            entrypoints: Default::default(),
+            properties: Default::default(),
+            edges: Default::default(),
+        }
+    }
+
+    fn write_to_directory(self, target: &Path) -> anyhow::Result<()> {
+        let mut path_buf = target.to_path_buf();
+        path_buf.push("adapter");
+        std::fs::create_dir_all(&path_buf)?;
+
+        path_buf.push("schema.graphql");
+        std::fs::write(path_buf.as_path(), self.schema)?;
+        path_buf.pop();
+
+        path_buf.push("mod.rs");
+        self.mod_.write_to_file(path_buf.as_path())?;
+        path_buf.pop();
+
+        path_buf.push("adapter.rs");
+        self.adapter.write_to_file(path_buf.as_path())?;
+        path_buf.pop();
+
+        path_buf.push("vertex.rs");
+        self.vertex.write_to_file(path_buf.as_path())?;
+        path_buf.pop();
+
+        path_buf.push("entrypoints.rs");
+        self.entrypoints.write_to_file(path_buf.as_path())?;
+        path_buf.pop();
+
+        path_buf.push("properties.rs");
+        self.properties.write_to_file(path_buf.as_path())?;
+        path_buf.pop();
+
+        path_buf.push("edges.rs");
+        self.edges.write_to_file(path_buf.as_path())?;
+        path_buf.pop();
+
+        Ok(())
+    }
+}
+
+fn make_vertex_file(
+    querying_schema: &Schema,
+    adapter: Arc<SchemaAdapter<'_>>,
+    vertex_file: &mut RustFile,
+) {
+    let query = r#"
+{
+    VertexType {
+        name @output
+    }
+}"#;
+    let variables: BTreeMap<String, String> = Default::default();
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ResultRow {
+        name: String,
+    }
+
+    let mut variants = proc_macro2::TokenStream::new();
+    let rows = trustfall::execute_query(querying_schema, adapter, query, variables)
+        .expect("invalid query")
+        .map(|x| {
+            x.try_into_struct::<ResultRow>()
+                .expect("invalid conversion")
+        });
+    for row in rows {
+        let name = &row.name;
+        let ident = syn::Ident::new(name.as_str(), proc_macro2::Span::call_site());
+        variants.extend(quote! {
+            #ident(()),
+        });
+    }
+
+    let vertex = quote! {
+        #[derive(Debug, Clone, trustfall::provider::TrustfallEnumVertex)]
+        pub enum Vertex {
+            #variants
+        }
+    };
+
+    vertex_file.top_level_items.push(vertex);
+}

--- a/trustfall_stubgen/src/tests.rs
+++ b/trustfall_stubgen/src/tests.rs
@@ -1,0 +1,154 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use super::generate_rust_stub;
+
+/// Write the given contents to a file, asserting that the file did not previously exist.
+fn write_new_file(path: &Path, contents: &str) {
+    match path.try_exists() {
+        Ok(true) => panic!(
+            "file at path unexpectedly already exists: {}",
+            path.display()
+        ),
+        Ok(false) => std::fs::write(path, contents).expect("failed to write file"),
+        Err(e) => panic!("{e}"),
+    }
+}
+
+fn assert_generated_code_compiles(path: &Path) {
+    let mut pathbuf = PathBuf::from(path);
+
+    let cargo_toml = r#"
+[package]
+name = "tests"
+publish = false
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+[dependencies]
+trustfall = "0.5.0"
+
+[workspace]
+"#;
+    pathbuf.push("Cargo.toml");
+    write_new_file(pathbuf.as_path(), cargo_toml);
+    pathbuf.pop();
+
+    let lib_rs = "\
+mod adapter;
+";
+    pathbuf.push("src");
+    pathbuf.push("lib.rs");
+    write_new_file(pathbuf.as_path(), lib_rs);
+    pathbuf.pop();
+
+    let output = Command::new("cargo")
+        .current_dir(pathbuf.as_path())
+        .arg("check")
+        .output()
+        .expect("failed to execute process");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        std::str::from_utf8(&output.stdout).expect("invalid utf-8"),
+        std::str::from_utf8(&output.stderr).expect("invalid utf-8"),
+    );
+}
+
+fn get_relevant_files_from_dir(path: &Path) -> BTreeMap<PathBuf, PathBuf> {
+    let mut base = path.to_str().expect("failed to make input path");
+    base = base.strip_prefix("./").unwrap_or(base);
+    let base = format!("{base}/");
+
+    let mut dir_glob = path.to_path_buf();
+    dir_glob.push("*");
+    glob::glob(dir_glob.to_str().expect("failed to convert path to &str"))
+        .expect("failed to list dir")
+        .filter_map(|res| {
+            let pathbuf = res.expect("failed to check file");
+            if !pathbuf.is_file() {
+                return None;
+            }
+
+            let extension = pathbuf
+                .extension()
+                .and_then(|x| x.to_str())
+                .unwrap_or_default();
+            if matches!(extension, "rs" | "graphql") {
+                let mut matched_filepath = pathbuf.to_str().expect("failed to make str");
+                matched_filepath = matched_filepath
+                    .strip_prefix("./")
+                    .unwrap_or(matched_filepath);
+
+                let key = matched_filepath
+                    .strip_prefix(&base)
+                    .expect("base path was not present as prefix");
+                Some((Path::new(key).to_path_buf(), pathbuf))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn assert_generated_code_is_unchanged(test_dir: &Path, expected_dir: &Path) {
+    let test_files = get_relevant_files_from_dir(test_dir);
+    let expected_files = get_relevant_files_from_dir(expected_dir);
+
+    let mut unexpected_files = test_files.clone();
+    unexpected_files.retain(|k, _| !expected_files.contains_key(k));
+
+    let mut missing_expected_files = expected_files.clone();
+    missing_expected_files.retain(|k, _| !test_files.contains_key(k));
+
+    for key in test_files
+        .keys()
+        .filter(|k| expected_files.contains_key(*k))
+    {
+        let expected_filepath = &expected_files[key];
+        let test_filepath = &test_files[key];
+
+        let expected = std::fs::read_to_string(expected_filepath).expect("failed to read file");
+        let actual = std::fs::read_to_string(test_filepath).expect("failed to read file");
+
+        similar_asserts::assert_eq!(expected, actual);
+    }
+
+    assert!(
+        unexpected_files.is_empty(),
+        "unexpected files found: {unexpected_files:?}"
+    );
+    assert!(
+        missing_expected_files.is_empty(),
+        "expected files were missing: {missing_expected_files:?}"
+    );
+}
+
+fn test_schema(name: &str) {
+    let mut test_dir = Path::new("/tmp/trustfall_stubgen/tests").to_path_buf();
+    test_dir.push(name);
+    let _ = std::fs::remove_dir_all(&test_dir); // it's fine if the dir didn't exist
+
+    let mut schema_path = Path::new("./test_data").to_path_buf();
+    schema_path.push(format!("{name}.graphql"));
+    let schema = std::fs::read_to_string(&schema_path).expect("failed to read schema file");
+
+    test_dir.push("src");
+    generate_rust_stub(&schema, &test_dir).expect("failed to generate stub");
+    test_dir.pop();
+
+    let mut expected_dir = Path::new("./test_data/expected_outputs").to_path_buf();
+    expected_dir.push(name);
+    assert_generated_code_compiles(&test_dir);
+    assert_generated_code_is_unchanged(&test_dir, &expected_dir);
+}
+
+#[test]
+fn test_hackernews_schema() {
+    test_schema("hackernews")
+}

--- a/trustfall_stubgen/src/util.rs
+++ b/trustfall_stubgen/src/util.rs
@@ -1,0 +1,140 @@
+use quote::quote;
+
+pub(crate) fn to_lower_snake_case(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    let mut last = '_';
+    for c in value.chars() {
+        if c.is_uppercase() {
+            if last != '_' && !last.is_uppercase() {
+                result.push('_');
+            }
+            result.extend(c.to_lowercase());
+        } else {
+            result.push(c);
+        }
+        last = c;
+    }
+    result
+}
+
+pub(crate) fn property_resolver_fn_name(type_name: &str) -> String {
+    let normalized_name = to_lower_snake_case(type_name);
+    format!("resolve_{normalized_name}_property")
+}
+
+pub(crate) fn type_edge_resolver_fn_name(type_name: &str) -> String {
+    let normalized_name = to_lower_snake_case(type_name);
+    format!("resolve_{normalized_name}_edge")
+}
+
+pub(crate) fn parse_import(import: &str) -> Vec<String> {
+    import.split("::").map(|x| x.to_string()).collect()
+}
+
+pub(crate) fn trustfall_type_to_rust_type(trustfall_type: &str) -> proc_macro2::TokenStream {
+    let mut processed_type = trustfall_type;
+
+    let mut nullable = true;
+    if let Some(inner) = processed_type.strip_suffix('!') {
+        processed_type = inner;
+        nullable = false;
+    }
+
+    let ty = {
+        if let Some(partial) = processed_type.strip_prefix('[') {
+            let inner = partial
+                .strip_suffix(']')
+                .unwrap_or_else(|| panic!("invalid Trustfall type started with `[` without matching `]`: {trustfall_type}"));
+            let inner_ty = trustfall_type_to_rust_type(inner);
+
+            quote! {
+                Vec<#inner_ty>
+            }
+        } else {
+            match processed_type {
+                "Int" => quote! { i64 }, // TODO: this is technically incorrect, it might be u64 too
+                "String" => quote! { &str },
+                "Float" => quote! { f64 },
+                "Boolean" => quote! { bool },
+                _ => unimplemented!(
+                    "type {processed_type} is not yet supported when autogenerating stubs"
+                ),
+            }
+        }
+    };
+
+    if nullable {
+        quote! {
+            Option<#ty>
+        }
+    } else {
+        ty
+    }
+}
+
+pub(crate) fn field_value_to_rust_type(
+    trustfall_type: &str,
+    base: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let mut processed_type = trustfall_type;
+
+    let mut nullable = true;
+    if let Some(inner) = processed_type.strip_suffix('!') {
+        processed_type = inner;
+        nullable = false;
+    }
+
+    let suffix = if let Some(partial) = processed_type.strip_prefix('[') {
+        let inner = partial.strip_suffix(']').unwrap_or_else(|| {
+            panic!("invalid Trustfall type started with `[` without matching `]`: {trustfall_type}")
+        });
+        let base = quote! {
+            |value| value
+        };
+        let inner_tokens = field_value_to_rust_type(inner, base);
+
+        if nullable {
+            quote! {
+                as_slice()
+                    .map(|slice| {
+                        slice
+                            .iter()
+                            .map(#inner_tokens)
+                            .collect()
+                    })
+            }
+        } else {
+            quote! {
+                as_slice()
+                    .expect("expected a list-typed value but did not get a list")
+                    .iter()
+                    .map(#inner_tokens)
+                    .collect()
+            }
+        }
+    } else {
+        let mut conv_fn = match processed_type {
+            "Int" => quote! { as_i64() }, // TODO: this is technically incorrect, it might be u64 too
+            "String" => quote! { as_str() },
+            "Float" => quote! { as_f64() },
+            "Boolean" => quote! { as_bool() },
+            _ => unimplemented!(
+                "type {processed_type} is not yet supported when autogenerating stubs"
+            ),
+        };
+        if !nullable {
+            let expect_msg = format!(
+                "unexpected null or other incorrect datatype for Trustfall type '{trustfall_type}'"
+            );
+            conv_fn = quote! {
+                #conv_fn.expect(#expect_msg)
+            };
+        }
+
+        conv_fn
+    };
+
+    quote! {
+        #base.#suffix
+    }
+}

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/adapter.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/adapter.rs
@@ -1,0 +1,278 @@
+use std::sync::{Arc, OnceLock};
+
+use trustfall::{FieldValue, Schema, provider::{ContextIterator, ContextOutcomeIterator, EdgeParameters, ResolveEdgeInfo, ResolveInfo, VertexIterator, resolve_coercion_using_schema}};
+
+use super::vertex::Vertex;
+
+static SCHEMA: OnceLock<Schema> = OnceLock::new();
+
+#[derive(Debug)]
+pub struct Adapter {}
+
+impl Adapter {
+    pub const SCHEMA_TEXT: &'static str = include_str!("./schema.graphql");
+
+    pub fn schema() -> &'static Schema {
+        SCHEMA
+            .get_or_init(|| {
+                Schema::parse(Self::SCHEMA_TEXT).expect("not a valid schema")
+            })
+    }
+}
+
+impl<'a> trustfall::provider::Adapter<'a> for Adapter {
+    type Vertex = Vertex;
+
+    fn resolve_starting_vertices(
+        &self,
+        edge_name: &Arc<str>,
+        parameters: &EdgeParameters,
+        resolve_info: &ResolveInfo,
+    ) -> VertexIterator<'a, Self::Vertex> {
+        match edge_name.as_ref() {
+            "FrontPage" => super::entrypoints::front_page(resolve_info),
+            "Top" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'Top' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::top(max, resolve_info)
+            }
+            "Latest" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'Latest' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::latest(max, resolve_info)
+            }
+            "Best" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'Best' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::best(max, resolve_info)
+            }
+            "AskHN" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'AskHN' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::ask_hn(max, resolve_info)
+            }
+            "ShowHN" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'ShowHN' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::show_hn(max, resolve_info)
+            }
+            "RecentJob" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'RecentJob' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::recent_job(max, resolve_info)
+            }
+            "User" => {
+                let name: &str = parameters
+                    .get("name")
+                    .expect(
+                        "failed to find parameter 'name' when resolving 'User' starting vertices",
+                    )
+                    .as_str()
+                    .expect(
+                        "unexpected null or other incorrect datatype for Trustfall type 'String!'",
+                    );
+                super::entrypoints::user(name, resolve_info)
+            }
+            "Item" => {
+                let id: i64 = parameters
+                    .get("id")
+                    .expect(
+                        "failed to find parameter 'id' when resolving 'Item' starting vertices",
+                    )
+                    .as_i64()
+                    .expect(
+                        "unexpected null or other incorrect datatype for Trustfall type 'Int!'",
+                    );
+                super::entrypoints::item(id, resolve_info)
+            }
+            "UpdatedItem" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'UpdatedItem' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::updated_item(max, resolve_info)
+            }
+            "UpdatedUserProfile" => {
+                let max: Option<i64> = parameters
+                    .get("max")
+                    .expect(
+                        "failed to find parameter 'max' when resolving 'UpdatedUserProfile' starting vertices",
+                    )
+                    .as_i64();
+                super::entrypoints::updated_user_profile(max, resolve_info)
+            }
+            "SearchByRelevance" => {
+                let query: &str = parameters
+                    .get("query")
+                    .expect(
+                        "failed to find parameter 'query' when resolving 'SearchByRelevance' starting vertices",
+                    )
+                    .as_str()
+                    .expect(
+                        "unexpected null or other incorrect datatype for Trustfall type 'String!'",
+                    );
+                super::entrypoints::search_by_relevance(query, resolve_info)
+            }
+            "SearchByDate" => {
+                let query: &str = parameters
+                    .get("query")
+                    .expect(
+                        "failed to find parameter 'query' when resolving 'SearchByDate' starting vertices",
+                    )
+                    .as_str()
+                    .expect(
+                        "unexpected null or other incorrect datatype for Trustfall type 'String!'",
+                    );
+                super::entrypoints::search_by_date(query, resolve_info)
+            }
+            _ => {
+                unreachable!(
+                    "attempted to resolve starting vertices for unexpected edge name: {edge_name}"
+                )
+            }
+        }
+    }
+
+    fn resolve_property(
+        &self,
+        contexts: ContextIterator<'a, Self::Vertex>,
+        type_name: &Arc<str>,
+        property_name: &Arc<str>,
+        resolve_info: &ResolveInfo,
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
+        match type_name.as_ref() {
+            "Webpage" => {
+                super::properties::resolve_webpage_property(
+                    contexts,
+                    property_name.as_ref(),
+                    resolve_info,
+                )
+            }
+            "Story" => {
+                super::properties::resolve_story_property(
+                    contexts,
+                    property_name.as_ref(),
+                    resolve_info,
+                )
+            }
+            "Item" => {
+                super::properties::resolve_item_property(
+                    contexts,
+                    property_name.as_ref(),
+                    resolve_info,
+                )
+            }
+            "Job" => {
+                super::properties::resolve_job_property(
+                    contexts,
+                    property_name.as_ref(),
+                    resolve_info,
+                )
+            }
+            "Comment" => {
+                super::properties::resolve_comment_property(
+                    contexts,
+                    property_name.as_ref(),
+                    resolve_info,
+                )
+            }
+            "User" => {
+                super::properties::resolve_user_property(
+                    contexts,
+                    property_name.as_ref(),
+                    resolve_info,
+                )
+            }
+            _ => {
+                unreachable!(
+                    "attempted to read property '{property_name}' on unexpected type: {type_name}"
+                )
+            }
+        }
+    }
+
+    fn resolve_neighbors(
+        &self,
+        contexts: ContextIterator<'a, Self::Vertex>,
+        type_name: &Arc<str>,
+        edge_name: &Arc<str>,
+        parameters: &EdgeParameters,
+        resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
+        match type_name.as_ref() {
+            "Story" => {
+                super::edges::resolve_story_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                )
+            }
+            "Job" => {
+                super::edges::resolve_job_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                )
+            }
+            "Comment" => {
+                super::edges::resolve_comment_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                )
+            }
+            "User" => {
+                super::edges::resolve_user_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                )
+            }
+            _ => {
+                unreachable!(
+                    "attempted to resolve edge '{edge_name}' on unexpected type: {type_name}"
+                )
+            }
+        }
+    }
+
+    fn resolve_coercion(
+        &self,
+        contexts: ContextIterator<'a, Self::Vertex>,
+        _type_name: &Arc<str>,
+        coerce_to_type: &Arc<str>,
+        _resolve_info: &ResolveInfo,
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
+        resolve_coercion_using_schema(contexts, Self::schema(), coerce_to_type.as_ref())
+    }
+}

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/edges.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/edges.rs
@@ -1,0 +1,175 @@
+use trustfall::provider::{ContextIterator, ContextOutcomeIterator, EdgeParameters, ResolveEdgeInfo, VertexIterator};
+
+use super::vertex::Vertex;
+
+pub(super) fn resolve_story_edge<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    edge_name: &str,
+    parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+    match edge_name {
+        "byUser" => story::by_user(contexts, resolve_info),
+        "comment" => story::comment(contexts, resolve_info),
+        "link" => story::link(contexts, resolve_info),
+        _ => {
+            unreachable!(
+                "attempted to resolve unexpected edge '{edge_name}' on type 'Story'"
+            )
+        }
+    }
+}
+
+mod story {
+    use trustfall::provider::{
+        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
+    };
+
+    use super::super::vertex::Vertex;
+
+    pub(super) fn by_user<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'byUser' for type 'Story'")
+    }
+
+    pub(super) fn comment<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'comment' for type 'Story'")
+    }
+
+    pub(super) fn link<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'link' for type 'Story'")
+    }
+}
+
+pub(super) fn resolve_job_edge<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    edge_name: &str,
+    parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+    match edge_name {
+        "link" => job::link(contexts, resolve_info),
+        _ => {
+            unreachable!(
+                "attempted to resolve unexpected edge '{edge_name}' on type 'Job'"
+            )
+        }
+    }
+}
+
+mod job {
+    use trustfall::provider::{
+        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
+    };
+
+    use super::super::vertex::Vertex;
+
+    pub(super) fn link<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'link' for type 'Job'")
+    }
+}
+
+pub(super) fn resolve_comment_edge<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    edge_name: &str,
+    parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+    match edge_name {
+        "byUser" => comment::by_user(contexts, resolve_info),
+        "reply" => comment::reply(contexts, resolve_info),
+        "link" => comment::link(contexts, resolve_info),
+        "parent" => comment::parent(contexts, resolve_info),
+        _ => {
+            unreachable!(
+                "attempted to resolve unexpected edge '{edge_name}' on type 'Comment'"
+            )
+        }
+    }
+}
+
+mod comment {
+    use trustfall::provider::{
+        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
+    };
+
+    use super::super::vertex::Vertex;
+
+    pub(super) fn by_user<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'byUser' for type 'Comment'")
+    }
+
+    pub(super) fn reply<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'reply' for type 'Comment'")
+    }
+
+    pub(super) fn link<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'link' for type 'Comment'")
+    }
+
+    pub(super) fn parent<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'parent' for type 'Comment'")
+    }
+}
+
+pub(super) fn resolve_user_edge<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    edge_name: &str,
+    parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+    match edge_name {
+        "submitted" => user::submitted(contexts, resolve_info),
+        "link" => user::link(contexts, resolve_info),
+        _ => {
+            unreachable!(
+                "attempted to resolve unexpected edge '{edge_name}' on type 'User'"
+            )
+        }
+    }
+}
+
+mod user {
+    use trustfall::provider::{
+        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
+    };
+
+    use super::super::vertex::Vertex;
+
+    pub(super) fn submitted<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'submitted' for type 'User'")
+    }
+
+    pub(super) fn link<'a>(
+        contexts: ContextIterator<'a, Vertex>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex, VertexIterator<'a, Vertex>> {
+        todo!("implement edge 'link' for type 'User'")
+    }
+}

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/entrypoints.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/entrypoints.rs
@@ -1,0 +1,95 @@
+use trustfall::provider::{ResolveInfo, VertexIterator};
+
+use super::vertex::Vertex;
+
+pub(super) fn front_page<'a>(_resolve_info: &ResolveInfo) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'FrontPage'")
+}
+
+pub(super) fn top<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'Top'")
+}
+
+pub(super) fn latest<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'Latest'")
+}
+
+pub(super) fn best<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'Best'")
+}
+
+pub(super) fn ask_hn<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'AskHN'")
+}
+
+pub(super) fn show_hn<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'ShowHN'")
+}
+
+pub(super) fn recent_job<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'RecentJob'")
+}
+
+pub(super) fn user<'a>(
+    name: &str,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'User'")
+}
+
+pub(super) fn item<'a>(
+    id: i64,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'Item'")
+}
+
+pub(super) fn updated_item<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'UpdatedItem'")
+}
+
+pub(super) fn updated_user_profile<'a>(
+    max: Option<i64>,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!(
+        "implement resolving starting vertices for entrypoint edge 'UpdatedUserProfile'"
+    )
+}
+
+pub(super) fn search_by_relevance<'a>(
+    query: &str,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!(
+        "implement resolving starting vertices for entrypoint edge 'SearchByRelevance'"
+    )
+}
+
+pub(super) fn search_by_date<'a>(
+    query: &str,
+    _resolve_info: &ResolveInfo,
+) -> VertexIterator<'a, Vertex> {
+    todo!("implement resolving starting vertices for entrypoint edge 'SearchByDate'")
+}

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/mod.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/mod.rs
@@ -1,0 +1,8 @@
+mod adapter;
+mod vertex;
+mod entrypoints;
+mod properties;
+mod edges;
+
+pub use adapter::Adapter;
+pub use vertex::Vertex;

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/properties.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/properties.rs
@@ -1,0 +1,148 @@
+use trustfall::{FieldValue, provider::{ContextIterator, ContextOutcomeIterator, ResolveInfo}};
+
+use super::vertex::Vertex;
+
+pub(super) fn resolve_webpage_property<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+    match property_name {
+        "url" => todo!("implement property 'url' in fn `resolve_webpage_property()`"),
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'Webpage'"
+            )
+        }
+    }
+}
+
+pub(super) fn resolve_story_property<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+    match property_name {
+        "id" => todo!("implement property 'id' in fn `resolve_story_property()`"),
+        "unixTime" => {
+            todo!("implement property 'unixTime' in fn `resolve_story_property()`")
+        }
+        "url" => todo!("implement property 'url' in fn `resolve_story_property()`"),
+        "byUsername" => {
+            todo!("implement property 'byUsername' in fn `resolve_story_property()`")
+        }
+        "score" => todo!("implement property 'score' in fn `resolve_story_property()`"),
+        "textHtml" => {
+            todo!("implement property 'textHtml' in fn `resolve_story_property()`")
+        }
+        "textPlain" => {
+            todo!("implement property 'textPlain' in fn `resolve_story_property()`")
+        }
+        "title" => todo!("implement property 'title' in fn `resolve_story_property()`"),
+        "submittedUrl" => {
+            todo!("implement property 'submittedUrl' in fn `resolve_story_property()`")
+        }
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'Story'"
+            )
+        }
+    }
+}
+
+pub(super) fn resolve_item_property<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+    match property_name {
+        "id" => todo!("implement property 'id' in fn `resolve_item_property()`"),
+        "unixTime" => {
+            todo!("implement property 'unixTime' in fn `resolve_item_property()`")
+        }
+        "url" => todo!("implement property 'url' in fn `resolve_item_property()`"),
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'Item'"
+            )
+        }
+    }
+}
+
+pub(super) fn resolve_job_property<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+    match property_name {
+        "id" => todo!("implement property 'id' in fn `resolve_job_property()`"),
+        "unixTime" => {
+            todo!("implement property 'unixTime' in fn `resolve_job_property()`")
+        }
+        "url" => todo!("implement property 'url' in fn `resolve_job_property()`"),
+        "title" => todo!("implement property 'title' in fn `resolve_job_property()`"),
+        "score" => todo!("implement property 'score' in fn `resolve_job_property()`"),
+        "submittedUrl" => {
+            todo!("implement property 'submittedUrl' in fn `resolve_job_property()`")
+        }
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'Job'"
+            )
+        }
+    }
+}
+
+pub(super) fn resolve_comment_property<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+    match property_name {
+        "id" => todo!("implement property 'id' in fn `resolve_comment_property()`"),
+        "unixTime" => {
+            todo!("implement property 'unixTime' in fn `resolve_comment_property()`")
+        }
+        "url" => todo!("implement property 'url' in fn `resolve_comment_property()`"),
+        "textHtml" => {
+            todo!("implement property 'textHtml' in fn `resolve_comment_property()`")
+        }
+        "textPlain" => {
+            todo!("implement property 'textPlain' in fn `resolve_comment_property()`")
+        }
+        "byUsername" => {
+            todo!("implement property 'byUsername' in fn `resolve_comment_property()`")
+        }
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'Comment'"
+            )
+        }
+    }
+}
+
+pub(super) fn resolve_user_property<'a>(
+    contexts: ContextIterator<'a, Vertex>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex, FieldValue> {
+    match property_name {
+        "id" => todo!("implement property 'id' in fn `resolve_user_property()`"),
+        "karma" => todo!("implement property 'karma' in fn `resolve_user_property()`"),
+        "aboutHtml" => {
+            todo!("implement property 'aboutHtml' in fn `resolve_user_property()`")
+        }
+        "aboutPlain" => {
+            todo!("implement property 'aboutPlain' in fn `resolve_user_property()`")
+        }
+        "unixCreatedAt" => {
+            todo!("implement property 'unixCreatedAt' in fn `resolve_user_property()`")
+        }
+        "url" => todo!("implement property 'url' in fn `resolve_user_property()`"),
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'User'"
+            )
+        }
+    }
+}

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/schema.graphql
@@ -1,0 +1,415 @@
+schema {
+    query: RootSchemaQuery
+}
+directive @filter(
+    """
+    Name of the filter operation to perform.
+    """
+    op: String!
+    """
+    List of string operands for the operator.
+    """
+    value: [String!]
+) on FIELD | INLINE_FRAGMENT
+directive @tag(
+    """
+    Name to apply to the given property field.
+    """
+    name: String
+) on FIELD
+directive @output(
+    """
+    What to designate the output field generated from this property field.
+    """
+    name: String
+) on FIELD
+directive @optional on FIELD
+directive @recurse(
+    """
+    Recurse up to this many times on this edge. A depth of 1 produces the current
+    vertex and its immediate neighbors along the given edge.
+    """
+    depth: Int!
+) on FIELD
+directive @fold on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
+
+"""
+All the possible data types where querying can begin in this API.
+"""
+type RootSchemaQuery {
+    """
+    Items on the front page of HackerNews. Equivalent to Top(max: 30).
+    """
+    FrontPage: [Item!]!
+
+    """
+    The top items on HackerNews. Items on the front page are the top 30.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of topmost items. Otherwise, queries will continue fetching top items
+    as deep as the HackerNews API allows.
+    """
+    Top(max: Int): [Item!]!
+
+    """
+    Latest story submissions on HackerNews.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching latest stories
+    as deep as the HackerNews API allows.
+    """
+    Latest(max: Int): [Story!]!
+
+    """
+    Best (recent & most highly-rated) story submissions on HackerNews.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching stories
+    as deep as the HackerNews API allows.
+    """
+    Best(max: Int): [Story!]!
+
+    """
+    Most recent "Ask HN" story submissions.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching stories
+    as deep as the HackerNews API allows.
+    """
+    AskHN(max: Int): [Story!]!
+
+    """
+    Most recent "Show HN" story submissions.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching stories
+    as deep as the HackerNews API allows.
+    """
+    ShowHN(max: Int): [Story!]!
+
+    """
+    Most recent Job submissions.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching jobs
+    as deep as the HackerNews API allows.
+    """
+    RecentJob(max: Int): [Story!]!
+
+    """
+    Look up a user by their username.
+    """
+    User(name: String!): User
+
+    """
+    Look up an item by its ID number.
+    """
+    Item(id: Int!): Item
+
+    """
+    Most-recently updated items, such as stories or job postings.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching items
+    as deep as the HackerNews API allows.
+    """
+    UpdatedItem(max: Int): [Item!]!
+
+    """
+    Most-recently updated user profiles.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching items
+    as deep as the HackerNews API allows.
+    """
+    UpdatedUserProfile(max: Int): [User!]!
+
+    """
+    Use HackerNews search to find items (stories, comments, etc.) based on the given query string.
+
+    Items are returned sorted by relevance, then points, then number of comments.
+
+    Search API docs: https://hn.algolia.com/api
+    """
+    SearchByRelevance(query: String!): [Item!]
+
+    """
+    Use HackerNews search to find items (stories, comments, etc.) based on the given query string.
+
+    Items are returned sorted by date, more recent first.
+
+    Search API docs: https://hn.algolia.com/api
+    """
+    SearchByDate(query: String!): [Item!]
+}
+
+"""
+One of the kinds of items on HackerNews: a story, job, comment, etc.
+"""
+interface Item implements Webpage {
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+}
+
+"""
+A HackerNews job posting linking to the job opening site.
+"""
+type Job implements Item & Webpage {
+    # properties from Item
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+
+    # own properties
+    """
+    The job posting's title: the one-liner seen on the front page, for example.
+    """
+    title: String!
+
+    """
+    The total number of points this submission has received.
+    """
+    score: Int!
+
+    """
+    The URL this job posting points to.
+    """
+    submittedUrl: String!
+
+    # edges
+    """
+    The web page this job posting links to.
+    """
+    link: Webpage!
+}
+
+"""
+A story submitted to HackerNews: either a link, or a text submission like Show HN.
+"""
+type Story implements Item & Webpage {
+    # properties from Item
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+
+    # own properties
+    """
+    The display name of the user that submitted this story.
+    """
+    byUsername: String!
+
+    """
+    The current score of this story submission.
+    """
+    score: Int!
+
+    """
+    For text submissions, contains the submitted text as HTML.
+    For link submissions, this field is null.
+    """
+    textHtml: String
+
+    """
+    For text submissions, contains the submitted text as plain text,
+    stripped of any HTML tags. For link submissions, this field is null.
+    """
+    textPlain: String
+
+    """
+    The story's title: the one-liner seen on the front page, for example.
+    """
+    title: String!
+
+    """
+    For link submissions, contains the submitted link.
+    For text submissions, this field is null.
+    """
+    submittedUrl: String
+
+    # edges
+    """
+    The profile of the user that submitted this story.
+    """
+    byUser: User!
+
+    """
+    The top-level comments on this story.
+    """
+    comment: [Comment!]
+
+    """
+    The web pages this story links to, if any.
+    For link submissions, this is the submitted link.
+    For text submissions, this includes all links in the text.
+    """
+    link: [Webpage!]
+}
+
+"""
+A comment submitted, for example, on a HackerNews story or job submission.
+"""
+type Comment implements Item & Webpage {
+    # properties from Item
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+
+    # own properties
+    """
+    The text contained in the comment, represented as HTML.
+    """
+    textHtml: String!
+
+    """
+    The text contained in the comment, as plain text with HTML tags removed.
+    """
+    textPlain: String!
+
+    """
+    The name of the user that submitted this comment.
+    """
+    byUsername: String!
+
+    # edges
+    """
+    The profile of the user that submitted this comment.
+    """
+    byUser: User!
+
+    """
+    The replies to this comment, if any.
+    """
+    reply: [Comment!]
+
+    """
+    Links contained within the comment, if any.
+    """
+    link: [Webpage!]
+
+    """
+    The parent item: for top-level comments, this is the story or job
+    where the comment was submitted, and for replies it's the comment
+    which is being replied to.
+    """
+    parent: Item! # either a parent comment or the story being commented on
+}
+
+"""
+The profile of a HackerNews user.
+"""
+type User implements Webpage {
+    """
+    The username of this user.
+    """
+    id: String!
+
+    """
+    The user's accumulated karma points.
+    """
+    karma: Int!
+
+    """
+    The HTML text the user has set in their "About" section, if any.
+    """
+    aboutHtml: String
+
+    """
+    The text the user has set in their "About" section, if any,
+    as plain text with HTML tags removed.
+    """
+    aboutPlain: String
+
+    """
+    The timestamp when the user account was created, as a number in Unix time.
+    """
+    unixCreatedAt: Int!
+
+    """
+    The URL of the user's HackerNews profile page.
+    """
+    url: String!
+
+    # The HackerNews API treats submissions of comments and stories the same way.
+    # The way to get only a user's submitted stories is to use this edge then
+    # apply a type coercion on the `Item` vertex on edge endpoint:
+    # `... on Story`
+    """
+    All submissions of this user, including all their stories and comments.
+
+    To get a user's submitted stories, apply a type coercion to the edge:
+    ```
+    submitted {
+      ... on Story {
+        < query submitted stories here >
+      }
+    }
+    ```
+    """
+    submitted: [Item!]
+
+    """
+    The web pages this user's "about" profile section links to, if any.
+    """
+    link: [Webpage!]
+}
+
+"""
+A web page.
+"""
+interface Webpage {
+    """
+    The URL of the web page.
+    """
+    url: String!
+}

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/vertex.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/vertex.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone, trustfall::provider::TrustfallEnumVertex)]
+pub enum Vertex {
+    Webpage(()),
+    Story(()),
+    Item(()),
+    Job(()),
+    Comment(()),
+    User(()),
+}

--- a/trustfall_stubgen/test_data/hackernews.graphql
+++ b/trustfall_stubgen/test_data/hackernews.graphql
@@ -1,0 +1,415 @@
+schema {
+    query: RootSchemaQuery
+}
+directive @filter(
+    """
+    Name of the filter operation to perform.
+    """
+    op: String!
+    """
+    List of string operands for the operator.
+    """
+    value: [String!]
+) on FIELD | INLINE_FRAGMENT
+directive @tag(
+    """
+    Name to apply to the given property field.
+    """
+    name: String
+) on FIELD
+directive @output(
+    """
+    What to designate the output field generated from this property field.
+    """
+    name: String
+) on FIELD
+directive @optional on FIELD
+directive @recurse(
+    """
+    Recurse up to this many times on this edge. A depth of 1 produces the current
+    vertex and its immediate neighbors along the given edge.
+    """
+    depth: Int!
+) on FIELD
+directive @fold on FIELD
+directive @transform(
+    """
+    Name of the transformation operation to perform.
+    """
+    op: String!
+) on FIELD
+
+"""
+All the possible data types where querying can begin in this API.
+"""
+type RootSchemaQuery {
+    """
+    Items on the front page of HackerNews. Equivalent to Top(max: 30).
+    """
+    FrontPage: [Item!]!
+
+    """
+    The top items on HackerNews. Items on the front page are the top 30.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of topmost items. Otherwise, queries will continue fetching top items
+    as deep as the HackerNews API allows.
+    """
+    Top(max: Int): [Item!]!
+
+    """
+    Latest story submissions on HackerNews.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching latest stories
+    as deep as the HackerNews API allows.
+    """
+    Latest(max: Int): [Story!]!
+
+    """
+    Best (recent & most highly-rated) story submissions on HackerNews.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching stories
+    as deep as the HackerNews API allows.
+    """
+    Best(max: Int): [Story!]!
+
+    """
+    Most recent "Ask HN" story submissions.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching stories
+    as deep as the HackerNews API allows.
+    """
+    AskHN(max: Int): [Story!]!
+
+    """
+    Most recent "Show HN" story submissions.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching stories
+    as deep as the HackerNews API allows.
+    """
+    ShowHN(max: Int): [Story!]!
+
+    """
+    Most recent Job submissions.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching jobs
+    as deep as the HackerNews API allows.
+    """
+    RecentJob(max: Int): [Story!]!
+
+    """
+    Look up a user by their username.
+    """
+    User(name: String!): User
+
+    """
+    Look up an item by its ID number.
+    """
+    Item(id: Int!): Item
+
+    """
+    Most-recently updated items, such as stories or job postings.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching items
+    as deep as the HackerNews API allows.
+    """
+    UpdatedItem(max: Int): [Item!]!
+
+    """
+    Most-recently updated user profiles.
+
+    The `max` parameter can be used to limit queries to the selected number
+    of latest items. Otherwise, queries will continue fetching items
+    as deep as the HackerNews API allows.
+    """
+    UpdatedUserProfile(max: Int): [User!]!
+
+    """
+    Use HackerNews search to find items (stories, comments, etc.) based on the given query string.
+
+    Items are returned sorted by relevance, then points, then number of comments.
+
+    Search API docs: https://hn.algolia.com/api
+    """
+    SearchByRelevance(query: String!): [Item!]
+
+    """
+    Use HackerNews search to find items (stories, comments, etc.) based on the given query string.
+
+    Items are returned sorted by date, more recent first.
+
+    Search API docs: https://hn.algolia.com/api
+    """
+    SearchByDate(query: String!): [Item!]
+}
+
+"""
+One of the kinds of items on HackerNews: a story, job, comment, etc.
+"""
+interface Item implements Webpage {
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+}
+
+"""
+A HackerNews job posting linking to the job opening site.
+"""
+type Job implements Item & Webpage {
+    # properties from Item
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+
+    # own properties
+    """
+    The job posting's title: the one-liner seen on the front page, for example.
+    """
+    title: String!
+
+    """
+    The total number of points this submission has received.
+    """
+    score: Int!
+
+    """
+    The URL this job posting points to.
+    """
+    submittedUrl: String!
+
+    # edges
+    """
+    The web page this job posting links to.
+    """
+    link: Webpage!
+}
+
+"""
+A story submitted to HackerNews: either a link, or a text submission like Show HN.
+"""
+type Story implements Item & Webpage {
+    # properties from Item
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+
+    # own properties
+    """
+    The display name of the user that submitted this story.
+    """
+    byUsername: String!
+
+    """
+    The current score of this story submission.
+    """
+    score: Int!
+
+    """
+    For text submissions, contains the submitted text as HTML.
+    For link submissions, this field is null.
+    """
+    textHtml: String
+
+    """
+    For text submissions, contains the submitted text as plain text,
+    stripped of any HTML tags. For link submissions, this field is null.
+    """
+    textPlain: String
+
+    """
+    The story's title: the one-liner seen on the front page, for example.
+    """
+    title: String!
+
+    """
+    For link submissions, contains the submitted link.
+    For text submissions, this field is null.
+    """
+    submittedUrl: String
+
+    # edges
+    """
+    The profile of the user that submitted this story.
+    """
+    byUser: User!
+
+    """
+    The top-level comments on this story.
+    """
+    comment: [Comment!]
+
+    """
+    The web pages this story links to, if any.
+    For link submissions, this is the submitted link.
+    For text submissions, this includes all links in the text.
+    """
+    link: [Webpage!]
+}
+
+"""
+A comment submitted, for example, on a HackerNews story or job submission.
+"""
+type Comment implements Item & Webpage {
+    # properties from Item
+    """
+    The item's unique identifier.
+    """
+    id: Int!
+
+    """
+    The item's timestamp, as a number in Unix time.
+    """
+    unixTime: Int!
+
+    """
+    The item's URL on HackerNews.
+    """
+    url: String!
+
+    # own properties
+    """
+    The text contained in the comment, represented as HTML.
+    """
+    textHtml: String!
+
+    """
+    The text contained in the comment, as plain text with HTML tags removed.
+    """
+    textPlain: String!
+
+    """
+    The name of the user that submitted this comment.
+    """
+    byUsername: String!
+
+    # edges
+    """
+    The profile of the user that submitted this comment.
+    """
+    byUser: User!
+
+    """
+    The replies to this comment, if any.
+    """
+    reply: [Comment!]
+
+    """
+    Links contained within the comment, if any.
+    """
+    link: [Webpage!]
+
+    """
+    The parent item: for top-level comments, this is the story or job
+    where the comment was submitted, and for replies it's the comment
+    which is being replied to.
+    """
+    parent: Item! # either a parent comment or the story being commented on
+}
+
+"""
+The profile of a HackerNews user.
+"""
+type User implements Webpage {
+    """
+    The username of this user.
+    """
+    id: String!
+
+    """
+    The user's accumulated karma points.
+    """
+    karma: Int!
+
+    """
+    The HTML text the user has set in their "About" section, if any.
+    """
+    aboutHtml: String
+
+    """
+    The text the user has set in their "About" section, if any,
+    as plain text with HTML tags removed.
+    """
+    aboutPlain: String
+
+    """
+    The timestamp when the user account was created, as a number in Unix time.
+    """
+    unixCreatedAt: Int!
+
+    """
+    The URL of the user's HackerNews profile page.
+    """
+    url: String!
+
+    # The HackerNews API treats submissions of comments and stories the same way.
+    # The way to get only a user's submitted stories is to use this edge then
+    # apply a type coercion on the `Item` vertex on edge endpoint:
+    # `... on Story`
+    """
+    All submissions of this user, including all their stories and comments.
+
+    To get a user's submitted stories, apply a type coercion to the edge:
+    ```
+    submitted {
+      ... on Story {
+        < query submitted stories here >
+      }
+    }
+    ```
+    """
+    submitted: [Item!]
+
+    """
+    The web pages this user's "about" profile section links to, if any.
+    """
+    link: [Webpage!]
+}
+
+"""
+A web page.
+"""
+interface Webpage {
+    """
+    The URL of the web page.
+    """
+    url: String!
+}


### PR DESCRIPTION
Trustfall adapters are a bit tricky to write from scratch. This is why we add a crate for auto-generating all the basic boilerplate for implementing a new adapter given a Trustfall schema for some dataset.

In a future PR, we'll write up this crate in a CLI binary crate to make it easy to use.
