### PR TITLE
Only declare module tree once in `trustfall_stubgen`.

### DIFF
--- a/trustfall_stubgen/src/main.rs
+++ b/trustfall_stubgen/src/main.rs
@@ -5,13 +5,6 @@ use std::path::PathBuf;
 use anyhow::Context;
 use clap::Parser;
 
-mod adapter_creator;
-mod edges_creator;
-mod entrypoints_creator;
-mod properties_creator;
-mod root;
-mod util;
-
 /// Generate a Trustfall adapter stub implementation for a given schema.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -64,5 +57,5 @@ fn main() -> Result<(), anyhow::Error> {
     let target = &cli.target;
     std::fs::create_dir_all(target).context("failed to create target directory")?;
 
-    root::generate_rust_stub(&schema_text, target)
+    trustfall_stubgen::generate_rust_stub(&schema_text, target)
 }


### PR DESCRIPTION
Applies the best practice described here: https://doc.rust-lang.org/book/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html#best-practices-for-packages-with-a-binary-and-a-library
