### PR TITLE
Remove `chrono` from dependencies. Removes datetime value variant.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,6 @@ dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
  "base64 0.13.1",
- "chrono",
  "consecrates",
  "csv",
  "futures-executor",
@@ -680,7 +679,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio 1.29.1",
- "trustfall_core",
+ "trustfall",
  "yaml-rust",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,6 @@ version = "0.5.1"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
- "chrono",
  "itertools",
  "maplit",
  "once_cell",

--- a/demo-hytradboi/Cargo.toml
+++ b/demo-hytradboi/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 async-graphql-parser = "^2.11.3"
 async-graphql-value = "^2.11.3"
 base64 = "0.13.0"
-chrono = { version = "0.4.19", features = ["serde"] }
 consecrates = "0.1.1"
 csv = "1.1.6"
 futures-executor = "0.3.21"
@@ -25,5 +24,5 @@ ron = "0.6.5"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.68"
 tokio = "1.17.0"
-trustfall_core = { path = "../trustfall_core" }
+trustfall = { path = "../trustfall" }
 yaml-rust = "0.4.5"

--- a/demo-hytradboi/schema.graphql
+++ b/demo-hytradboi/schema.graphql
@@ -62,7 +62,7 @@ type GitHubRepository implements Repository & Webpage {
     owner: String!
     name: String!
     fullName: String!
-    # lastModified: DateTime!
+    lastModified: Int!  # in seconds since epoch
 
     workflows: [GitHubWorkflow!]
     # rootDirectory: Directory

--- a/demo-hytradboi/src/actions_parser.rs
+++ b/demo-hytradboi/src/actions_parser.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use itertools::Itertools;
 use octorust::types::ContentFile;
-use trustfall_core::interpreter::VertexIterator;
+use trustfall::provider::VertexIterator;
 use yaml_rust::{Yaml, YamlLoader};
 
 use crate::vertex::{ActionsImportedStep, ActionsJob, ActionsRunStep, Vertex};

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -7,12 +7,12 @@ use hn_api::{types::Item, HnClient};
 use octorust::types::{ContentFile, FullRepository};
 use once_cell::sync::Lazy;
 use tokio::runtime::Runtime;
-use trustfall_core::{
-    interpreter::{
-        Adapter, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, ResolveInfo,
-        VertexIterator,
+use trustfall::{
+    provider::{
+        field_property, resolve_property_with, Adapter, ContextIterator, ContextOutcomeIterator,
+        EdgeParameters, ResolveEdgeInfo, ResolveInfo, VertexIterator,
     },
-    ir::{EdgeParameters, FieldValue},
+    FieldValue,
 };
 
 use crate::{
@@ -156,31 +156,7 @@ macro_rules! impl_item_property {
     };
 }
 
-macro_rules! impl_property {
-    ($contexts:ident, $conversion:ident, $attr:ident) => {
-        Box::new($contexts.map(|ctx| {
-            let vertex = ctx
-                .active_vertex()
-                .map(|vertex| vertex.$conversion().unwrap());
-            let value = vertex.map(|t| t.$attr.clone()).into();
-
-            (ctx, value)
-        }))
-    };
-
-    ($contexts:ident, $conversion:ident, $var:ident, $b:block) => {
-        Box::new($contexts.map(|ctx| {
-            let vertex = ctx
-                .active_vertex()
-                .map(|vertex| vertex.$conversion().unwrap());
-            let value = vertex.map(|$var| $b).into();
-
-            (ctx, value)
-        }))
-    };
-}
-
-impl Adapter<'static> for DemoAdapter {
+impl<'a> Adapter<'a> for DemoAdapter {
     type Vertex = Vertex;
 
     fn resolve_starting_vertices(
@@ -188,7 +164,7 @@ impl Adapter<'static> for DemoAdapter {
         edge_name: &Arc<str>,
         parameters: &EdgeParameters,
         _resolve_info: &ResolveInfo,
-    ) -> VertexIterator<'static, Self::Vertex> {
+    ) -> VertexIterator<'a, Self::Vertex> {
         match edge_name.as_ref() {
             "HackerNewsFrontPage" => self.front_page(),
             "HackerNewsTop" => {
@@ -210,11 +186,11 @@ impl Adapter<'static> for DemoAdapter {
 
     fn resolve_property(
         &self,
-        contexts: ContextIterator<'static, Self::Vertex>,
+        contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         property_name: &Arc<str>,
         _resolve_info: &ResolveInfo,
-    ) -> ContextOutcomeIterator<'static, Self::Vertex, FieldValue> {
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
         match (type_name.as_ref(), property_name.as_ref()) {
             (_, "__typename") => Box::new(contexts.map(|ctx| {
                 let value = match ctx.active_vertex() {
@@ -238,117 +214,174 @@ impl Adapter<'static> for DemoAdapter {
             }
 
             // properties on HackerNewsJob
-            ("HackerNewsJob", "score") => impl_property!(contexts, as_job, score),
-            ("HackerNewsJob", "title") => impl_property!(contexts, as_job, title),
-            ("HackerNewsJob", "url") => impl_property!(contexts, as_job, url),
+            ("HackerNewsJob", "score") => {
+                resolve_property_with(contexts, field_property!(as_job, score))
+            }
+            ("HackerNewsJob", "title") => {
+                resolve_property_with(contexts, field_property!(as_job, title))
+            }
+            ("HackerNewsJob", "url") => {
+                resolve_property_with(contexts, field_property!(as_job, url))
+            }
 
             // properties on HackerNewsStory
-            ("HackerNewsStory", "byUsername") => impl_property!(contexts, as_story, by),
-            ("HackerNewsStory", "text") => impl_property!(contexts, as_story, text),
-            ("HackerNewsStory", "commentsCount") => {
-                impl_property!(contexts, as_story, descendants)
+            ("HackerNewsStory", "byUsername") => {
+                resolve_property_with(contexts, field_property!(as_story, by))
             }
-            ("HackerNewsStory", "score") => impl_property!(contexts, as_story, score),
-            ("HackerNewsStory", "title") => impl_property!(contexts, as_story, title),
-            ("HackerNewsStory", "url") => impl_property!(contexts, as_story, url),
+            ("HackerNewsStory", "text") => {
+                resolve_property_with(contexts, field_property!(as_story, text))
+            }
+            ("HackerNewsStory", "commentsCount") => {
+                resolve_property_with(contexts, field_property!(as_story, descendants))
+            }
+            ("HackerNewsStory", "score") => {
+                resolve_property_with(contexts, field_property!(as_story, score))
+            }
+            ("HackerNewsStory", "title") => {
+                resolve_property_with(contexts, field_property!(as_story, title))
+            }
+            ("HackerNewsStory", "url") => {
+                resolve_property_with(contexts, field_property!(as_story, url))
+            }
 
             // properties on HackerNewsComment
-            ("HackerNewsComment", "byUsername") => impl_property!(contexts, as_comment, by),
-            ("HackerNewsComment", "text") => impl_property!(contexts, as_comment, text),
-            ("HackerNewsComment", "childCount") => {
-                impl_property!(contexts, as_comment, comment, {
-                    comment.kids.as_ref().map(|v| v.len() as u64).unwrap_or(0)
-                })
+            ("HackerNewsComment", "byUsername") => {
+                resolve_property_with(contexts, field_property!(as_comment, by))
             }
+            ("HackerNewsComment", "text") => {
+                resolve_property_with(contexts, field_property!(as_comment, text))
+            }
+            ("HackerNewsComment", "childCount") => resolve_property_with(
+                contexts,
+                field_property!(as_comment, kids, {
+                    kids.as_ref().map(|v| v.len() as u64).unwrap_or(0).into()
+                }),
+            ),
 
             // properties on HackerNewsUser
-            ("HackerNewsUser", "id") => impl_property!(contexts, as_user, id),
-            ("HackerNewsUser", "karma") => impl_property!(contexts, as_user, karma),
-            ("HackerNewsUser", "about") => impl_property!(contexts, as_user, about),
-            ("HackerNewsUser", "unixCreatedAt") => impl_property!(contexts, as_user, created),
-            ("HackerNewsUser", "delay") => impl_property!(contexts, as_user, delay),
+            ("HackerNewsUser", "id") => {
+                resolve_property_with(contexts, field_property!(as_user, id))
+            }
+            ("HackerNewsUser", "karma") => {
+                resolve_property_with(contexts, field_property!(as_user, karma))
+            }
+            ("HackerNewsUser", "about") => {
+                resolve_property_with(contexts, field_property!(as_user, about))
+            }
+            ("HackerNewsUser", "unixCreatedAt") => {
+                resolve_property_with(contexts, field_property!(as_user, created))
+            }
+            ("HackerNewsUser", "delay") => {
+                resolve_property_with(contexts, field_property!(as_user, delay))
+            }
 
             // properties on Crate
-            ("Crate", "name") => impl_property!(contexts, as_crate, name),
-            ("Crate", "latestVersion") => impl_property!(contexts, as_crate, max_version),
+            ("Crate", "name") => resolve_property_with(contexts, field_property!(as_crate, name)),
+            ("Crate", "latestVersion") => {
+                resolve_property_with(contexts, field_property!(as_crate, max_version))
+            }
 
             // properties on Webpage
             ("Webpage" | "Repository" | "GitHubRepository", "url") => {
-                impl_property!(contexts, as_webpage, url, { url })
+                resolve_property_with(contexts, |vertex| {
+                    vertex.as_webpage().expect("not a Webpage").into()
+                })
             }
 
             // properties on GitHubRepository
-            ("GitHubRepository", "owner") => {
-                impl_property!(contexts, as_github_repository, repo, {
-                    let (owner, _) = get_owner_and_repo(repo);
-                    owner
-                })
-            }
+            ("GitHubRepository", "owner") => resolve_property_with(contexts, |vertex| {
+                let repo = vertex
+                    .as_github_repository()
+                    .expect("not a GitHubRepository");
+                let (owner, _) = get_owner_and_repo(repo);
+                owner.into()
+            }),
             ("GitHubRepository", "name") => {
-                impl_property!(contexts, as_github_repository, name)
+                resolve_property_with(contexts, field_property!(as_github_repository, name))
             }
             ("GitHubRepository", "fullName") => {
-                impl_property!(contexts, as_github_repository, full_name)
+                resolve_property_with(contexts, field_property!(as_github_repository, full_name))
             }
             ("GitHubRepository", "lastModified") => {
-                impl_property!(contexts, as_github_repository, updated_at)
+                resolve_property_with(contexts, field_property!(as_github_repository, updated_at, {
+                    updated_at.map(|value| value.timestamp()).into()
+                }))
             }
 
             // properties on GitHubWorkflow
-            ("GitHubWorkflow", "name") => impl_property!(contexts, as_github_workflow, wf, {
-                wf.workflow.name.as_str()
-            }),
-            ("GitHubWorkflow", "path") => impl_property!(contexts, as_github_workflow, wf, {
-                wf.workflow.path.as_str()
-            }),
+            ("GitHubWorkflow", "name") => resolve_property_with(
+                contexts,
+                field_property!(as_github_workflow, workflow, {
+                    workflow.name.as_str().into()
+                }),
+            ),
+            ("GitHubWorkflow", "path") => resolve_property_with(
+                contexts,
+                field_property!(as_github_workflow, workflow, {
+                    workflow.path.as_str().into()
+                }),
+            ),
 
             // properties on GitHubActionsJob
             ("GitHubActionsJob", "name") => {
-                impl_property!(contexts, as_github_actions_job, name)
+                resolve_property_with(contexts, field_property!(as_github_actions_job, name))
             }
             ("GitHubActionsJob", "runsOn") => {
-                impl_property!(contexts, as_github_actions_job, runs_on)
+                resolve_property_with(contexts, field_property!(as_github_actions_job, runs_on))
             }
 
             // properties on GitHubActionsStep and its implementers
             (
                 "GitHubActionsStep" | "GitHubActionsImportedStep" | "GitHubActionsRunStep",
                 "name",
-            ) => impl_property!(contexts, as_github_actions_step, step_name, { step_name }),
+            ) => resolve_property_with(contexts, |vertex| {
+                vertex.as_github_actions_step().expect("not a step").into()
+            }),
 
             // properties on GitHubActionsImportedStep
-            ("GitHubActionsImportedStep", "uses") => {
-                impl_property!(contexts, as_github_actions_imported_step, uses)
-            }
+            ("GitHubActionsImportedStep", "uses") => resolve_property_with(
+                contexts,
+                field_property!(as_github_actions_imported_step, uses),
+            ),
 
             // properties on GitHubActionsRunStep
             ("GitHubActionsRunStep", "run") => {
-                impl_property!(contexts, as_github_actions_run_step, run)
+                resolve_property_with(contexts, field_property!(as_github_actions_run_step, run))
             }
 
             // properties on NameValuePair
-            ("NameValuePair", "name") => {
-                impl_property!(contexts, as_name_value_pair, pair, { pair.0.clone() })
-            }
-            ("NameValuePair", "value") => {
-                impl_property!(contexts, as_name_value_pair, pair, { pair.1.clone() })
-            }
+            ("NameValuePair", "name") => resolve_property_with(contexts, |vertex| {
+                vertex
+                    .as_name_value_pair()
+                    .expect("not a NameValuePair")
+                    .0
+                    .clone()
+                    .into()
+            }),
+            ("NameValuePair", "value") => resolve_property_with(contexts, |vertex| {
+                vertex
+                    .as_name_value_pair()
+                    .expect("not a NameValuePair")
+                    .0
+                    .clone()
+                    .into()
+            }),
             _ => unreachable!(),
         }
     }
 
     fn resolve_neighbors(
         &self,
-        contexts: ContextIterator<'static, Self::Vertex>,
+        contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         edge_name: &Arc<str>,
         _parameters: &EdgeParameters,
         _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'static, Self::Vertex, VertexIterator<'static, Self::Vertex>> {
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, VertexIterator<'a, Self::Vertex>> {
         match (type_name.as_ref(), edge_name.as_ref()) {
             ("HackerNewsStory", "byUser") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let story = vertex.as_story().unwrap();
@@ -371,7 +404,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsStory", "comment") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let story = vertex.as_story().unwrap();
@@ -406,7 +439,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsStory", "link") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let story = vertex.as_story().unwrap();
@@ -424,7 +457,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsJob", "link") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let job = vertex.as_job().unwrap();
@@ -441,7 +474,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "byUser") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let comment = vertex.as_comment().unwrap();
@@ -464,7 +497,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "parent") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let comment = vertex.as_comment().unwrap();
@@ -488,7 +521,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "topmostAncestor") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let comment = vertex.as_comment().unwrap();
@@ -525,7 +558,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsComment", "reply") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let comment = vertex.as_comment().unwrap();
@@ -557,7 +590,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("HackerNewsUser", "submitted") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let user = vertex.as_user().unwrap();
@@ -582,7 +615,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("Crate", "repository") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let cr = vertex.as_crate().unwrap();
@@ -600,7 +633,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubRepository", "workflows") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => Box::new(
                         WorkflowsPager::new(GITHUB_CLIENT.clone(), vertex, &RUNTIME)
@@ -613,7 +646,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubWorkflow", "jobs") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(vertex) => {
                         let workflow = vertex.as_github_workflow().unwrap();
@@ -634,7 +667,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubActionsJob", "step") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(Vertex::GitHubActionsJob(job)) => get_steps_in_job(job),
                     _ => unreachable!(),
@@ -644,7 +677,7 @@ impl Adapter<'static> for DemoAdapter {
             })),
             ("GitHubActionsRunStep", "env") => Box::new(contexts.map(|ctx| {
                 let vertex = ctx.active_vertex().cloned();
-                let neighbors: VertexIterator<'static, Self::Vertex> = match vertex {
+                let neighbors: VertexIterator<'a, Self::Vertex> = match vertex {
                     None => Box::new(std::iter::empty()),
                     Some(Vertex::GitHubActionsRunStep(s)) => get_env_for_run_step(s),
                     _ => unreachable!(),
@@ -658,11 +691,11 @@ impl Adapter<'static> for DemoAdapter {
 
     fn resolve_coercion(
         &self,
-        contexts: ContextIterator<'static, Self::Vertex>,
+        contexts: ContextIterator<'a, Self::Vertex>,
         type_name: &Arc<str>,
         coerce_to_type: &Arc<str>,
         _resolve_info: &ResolveInfo,
-    ) -> ContextOutcomeIterator<'static, Self::Vertex, bool> {
+    ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         let type_name = type_name.clone();
         let coerce_to_type = coerce_to_type.clone();
         let iterator = contexts.map(move |ctx| {

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -302,11 +302,12 @@ impl<'a> Adapter<'a> for DemoAdapter {
             ("GitHubRepository", "fullName") => {
                 resolve_property_with(contexts, field_property!(as_github_repository, full_name))
             }
-            ("GitHubRepository", "lastModified") => {
-                resolve_property_with(contexts, field_property!(as_github_repository, updated_at, {
+            ("GitHubRepository", "lastModified") => resolve_property_with(
+                contexts,
+                field_property!(as_github_repository, updated_at, {
                     updated_at.map(|value| value.timestamp()).into()
-                }))
-            }
+                }),
+            ),
 
             // properties on GitHubWorkflow
             ("GitHubWorkflow", "name") => resolve_property_with(

--- a/demo-hytradboi/src/main.rs
+++ b/demo-hytradboi/src/main.rs
@@ -7,10 +7,7 @@ use std::time::{Duration, Instant};
 use adapter::DemoAdapter;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use trustfall_core::ir::TransparentValue;
-use trustfall_core::{
-    frontend::parse, interpreter::execution::interpret_ir, ir::FieldValue, schema::Schema,
-};
+use trustfall::{execute_query, FieldValue, Schema, TransparentValue};
 
 mod actions_parser;
 mod adapter;
@@ -25,18 +22,14 @@ static SCHEMA: Lazy<Schema> =
 struct InputQuery<'a> {
     query: &'a str,
 
-    args: Arc<BTreeMap<Arc<str>, FieldValue>>,
+    args: BTreeMap<Arc<str>, FieldValue>,
 }
 
-fn execute_query(path: &str) {
+fn run_query(path: &str) {
     let content = fs::read_to_string(path).unwrap();
     let input_query: InputQuery = ron::from_str(&content).unwrap();
 
     let adapter = Arc::new(DemoAdapter::new());
-
-    let query = parse(&SCHEMA, input_query.query).unwrap();
-    let arguments = input_query.args;
-
     let max_results = 20usize;
 
     println!("Executing query:");
@@ -47,8 +40,8 @@ fn execute_query(path: &str) {
     println!("\nQuery args:");
     println!(
         "{:?}",
-        arguments
-            .as_ref()
+        input_query
+            .args
             .clone()
             .into_iter()
             .map(|(k, v)| (
@@ -62,7 +55,10 @@ fn execute_query(path: &str) {
 
     let mut total_query_duration: Duration = Default::default();
     let mut current_instant = Instant::now();
-    for (index, data_item) in interpret_ir(adapter, query, arguments).unwrap().enumerate() {
+    for (index, data_item) in execute_query(&SCHEMA, adapter, input_query.query, input_query.args)
+        .expect("not a valid query")
+        .enumerate()
+    {
         let next_item_duration = current_instant.elapsed();
         total_query_duration += next_item_duration;
 
@@ -109,7 +105,7 @@ fn main() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                execute_query(path)
+                run_query(path)
             }
         },
         Some(cmd) => panic!("Unrecognized command given: {cmd}"),

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -151,13 +151,13 @@ fn make_python_value(py: Python, value: FieldValue) -> Py<PyAny> {
         FieldValue::Float64(x) => x.into_py(py),
         FieldValue::String(x) => x.into_py(py),
         FieldValue::Boolean(x) => x.into_py(py),
-        FieldValue::DateTimeUtc(_) => todo!(),
         FieldValue::Enum(_) => todo!(),
         FieldValue::List(x) => x
             .into_iter()
             .map(|v| make_python_value(py, v))
             .collect::<Vec<_>>()
             .into_py(py),
+        _ => unimplemented!("unsupported value: {value:#?}")
     }
 }
 

--- a/pytrustfall/src/shim.rs
+++ b/pytrustfall/src/shim.rs
@@ -157,7 +157,7 @@ fn make_python_value(py: Python, value: FieldValue) -> Py<PyAny> {
             .map(|v| make_python_value(py, v))
             .collect::<Vec<_>>()
             .into_py(py),
-        _ => unimplemented!("unsupported value: {value:#?}")
+        _ => unimplemented!("unsupported value: {value:#?}"),
     }
 }
 

--- a/trustfall/examples/feeds/adapter.rs
+++ b/trustfall/examples/feeds/adapter.rs
@@ -65,7 +65,9 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
         match type_name {
             "Feed" => match property_name {
                 "id" => property(contexts, field_property!(as_feed, id)),
-                "updated" => property(contexts, field_property!(as_feed, updated)),
+                "updated" => property(contexts, field_property!(as_feed, updated, {
+                    updated.map(|t| t.timestamp()).into()
+                })),
                 "language" => property(contexts, field_property!(as_feed, language)),
                 "published" => property(contexts, field_property!(as_feed, published, {
                     published.map(|t| t.timestamp()).into()
@@ -100,7 +102,9 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
             "FeedEntry" => match property_name {
                 "id" => property(contexts, field_property!(as_feed_entry, id)),
                 "source" => property(contexts, field_property!(as_feed_entry, source)),
-                "updated" => property(contexts, field_property!(as_feed_entry, updated)),
+                "updated" => property(contexts, field_property!(as_feed_entry, updated, {
+                    updated.map(|t| t.timestamp()).into()
+                })),
                 "published" => property(contexts, field_property!(as_feed_entry, published, {
                     published.map(|t| t.timestamp()).into()
                 })),

--- a/trustfall/examples/feeds/adapter.rs
+++ b/trustfall/examples/feeds/adapter.rs
@@ -65,13 +65,17 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
         match type_name {
             "Feed" => match property_name {
                 "id" => property(contexts, field_property!(as_feed, id)),
-                "updated" => property(contexts, field_property!(as_feed, updated, {
-                    updated.map(|t| t.timestamp()).into()
-                })),
+                "updated" => property(
+                    contexts,
+                    field_property!(as_feed, updated, { updated.map(|t| t.timestamp()).into() }),
+                ),
                 "language" => property(contexts, field_property!(as_feed, language)),
-                "published" => property(contexts, field_property!(as_feed, published, {
-                    published.map(|t| t.timestamp()).into()
-                })),
+                "published" => property(
+                    contexts,
+                    field_property!(as_feed, published, {
+                        published.map(|t| t.timestamp()).into()
+                    }),
+                ),
                 "ttl" => property(contexts, field_property!(as_feed, ttl)),
                 "feed_type" => property(
                     contexts,
@@ -102,12 +106,18 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
             "FeedEntry" => match property_name {
                 "id" => property(contexts, field_property!(as_feed_entry, id)),
                 "source" => property(contexts, field_property!(as_feed_entry, source)),
-                "updated" => property(contexts, field_property!(as_feed_entry, updated, {
-                    updated.map(|t| t.timestamp()).into()
-                })),
-                "published" => property(contexts, field_property!(as_feed_entry, published, {
-                    published.map(|t| t.timestamp()).into()
-                })),
+                "updated" => property(
+                    contexts,
+                    field_property!(as_feed_entry, updated, {
+                        updated.map(|t| t.timestamp()).into()
+                    }),
+                ),
+                "published" => property(
+                    contexts,
+                    field_property!(as_feed_entry, published, {
+                        published.map(|t| t.timestamp()).into()
+                    }),
+                ),
                 _ => unreachable!("type {type_name} property {property_name} not found"),
             },
             "FeedContent" => match property_name {

--- a/trustfall/examples/feeds/adapter.rs
+++ b/trustfall/examples/feeds/adapter.rs
@@ -67,7 +67,9 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
                 "id" => property(contexts, field_property!(as_feed, id)),
                 "updated" => property(contexts, field_property!(as_feed, updated)),
                 "language" => property(contexts, field_property!(as_feed, language)),
-                "published" => property(contexts, field_property!(as_feed, published)),
+                "published" => property(contexts, field_property!(as_feed, published, {
+                    published.map(|t| t.timestamp()).into()
+                })),
                 "ttl" => property(contexts, field_property!(as_feed, ttl)),
                 "feed_type" => property(
                     contexts,
@@ -99,7 +101,9 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
                 "id" => property(contexts, field_property!(as_feed_entry, id)),
                 "source" => property(contexts, field_property!(as_feed_entry, source)),
                 "updated" => property(contexts, field_property!(as_feed_entry, updated)),
-                "published" => property(contexts, field_property!(as_feed_entry, published)),
+                "published" => property(contexts, field_property!(as_feed_entry, published, {
+                    published.map(|t| t.timestamp()).into()
+                })),
                 _ => unreachable!("type {type_name} property {property_name} not found"),
             },
             "FeedContent" => match property_name {

--- a/trustfall_core/Cargo.toml
+++ b/trustfall_core/Cargo.toml
@@ -33,7 +33,6 @@ async-graphql-value = "^2.11.3"
 maplit = "^1.0.2"
 once_cell = "1.17"
 smallvec = { version = "^1.6.1", features = ["serde"] }
-chrono = { version = "0.4.19", features = ["serde"] }
 regex = "1.5.4"
 thiserror = "1.0.30"
 itertools = "0.10.1"

--- a/trustfall_core/src/interpreter/filtering.rs
+++ b/trustfall_core/src/interpreter/filtering.rs
@@ -54,7 +54,6 @@ macro_rules! make_comparison_op_func {
                 (FieldValue::Null, _) => false,
                 (_, FieldValue::Null) => false,
                 (FieldValue::String(l), FieldValue::String(r)) => l $op r,
-                (FieldValue::DateTimeUtc(l), FieldValue::DateTimeUtc(r)) => l $op r,
                 (FieldValue::Int64(l), FieldValue::Int64(r)) => l $op r,
                 (FieldValue::Uint64(l), FieldValue::Uint64(r)) => l $op r,
                 (FieldValue::Float64(l), FieldValue::Float64(r)) => l $op r,

--- a/trustfall_core/src/ir/types.rs
+++ b/trustfall_core/src/ir/types.rs
@@ -226,10 +226,6 @@ pub fn is_argument_type_valid(variable_type: &Type, argument_value: &FieldValue)
             // This is a valid value only if the type is Boolean, ignoring nullability.
             matches!(&variable_type.base, BaseType::Named(n) if n == "Boolean")
         }
-        FieldValue::DateTimeUtc(_) => {
-            // This is a valid value only if the type is DateTime, ignoring nullability.
-            matches!(&variable_type.base, BaseType::Named(n) if n == "DateTime")
-        }
         FieldValue::List(nested_values) => {
             // This is a valid value only if the type is a list, and all the inner elements
             // are valid instances of the type inside the list.

--- a/trustfall_core/src/serialization/deserializers.rs
+++ b/trustfall_core/src/serialization/deserializers.rs
@@ -253,7 +253,6 @@ impl<'de> de::Deserializer<'de> for FieldValueDeserializer {
             FieldValue::Float64(v) => visitor.visit_f64(v),
             FieldValue::String(v) => visitor.visit_string(v),
             FieldValue::Boolean(v) => visitor.visit_bool(v),
-            FieldValue::DateTimeUtc(_) => todo!(),
             FieldValue::Enum(_) => todo!(),
             FieldValue::List(v) => visitor.visit_seq(v.into_deserializer()),
         }

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -9,6 +9,7 @@ use trustfall_core::{
     ir::FieldValue,
 };
 
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum JsFieldValue {
@@ -46,8 +47,7 @@ impl From<FieldValue> for JsFieldValue {
             FieldValue::Float64(n) => JsFieldValue::Float(n),
             FieldValue::Boolean(b) => JsFieldValue::Boolean(b),
             FieldValue::List(v) => JsFieldValue::List(v.into_iter().map(|x| x.into()).collect()),
-            FieldValue::DateTimeUtc(_) => unimplemented!(),
-            FieldValue::Enum(_) => unimplemented!(),
+            _ => unimplemented!("unsupported value: {v:#?}"),
         }
     }
 }


### PR DESCRIPTION
`chrono` is unmaintained and was causing `cargo deny` failures for other projects. It wasn't actually usable here, so I'm removing it and I'm also removing the `FieldValue` variant that used a datetime but was otherwise unfinished / unimplemented.