### PR TITLE
Replace various uses of `vec!` with arrays

### DIFF
--- a/trustfall_core/src/interpreter/filtering.rs
+++ b/trustfall_core/src/interpreter/filtering.rs
@@ -615,6 +615,8 @@ fn apply_filter_with_tagged_argument_value<'query, Vertex: Debug + Clone + 'quer
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::{
         interpreter::filtering::{equals, greater_than_or_equal, less_than, less_than_or_equal},
         ir::FieldValue,
@@ -624,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_integer_strict_inequality_comparisons() {
-        let test_data = vec![
+        let test_data = [
             // both values can convert to each other
             (FieldValue::Uint64(0), FieldValue::Int64(0), false),
             (FieldValue::Uint64(0), FieldValue::Int64(1), false),
@@ -656,7 +658,7 @@ mod tests {
 
     #[test]
     fn test_integer_non_strict_inequality_comparisons() {
-        let test_data = vec![
+        let test_data = [
             // both values can convert to each other
             (FieldValue::Uint64(0), FieldValue::Int64(0), true),
             (FieldValue::Uint64(0), FieldValue::Int64(1), false),
@@ -688,7 +690,7 @@ mod tests {
 
     #[test]
     fn test_integer_equality_comparisons() {
-        let test_data = vec![
+        let test_data = [
             // both values can convert to each other
             (FieldValue::Uint64(0), FieldValue::Int64(0), true),
             (FieldValue::Uint64(0), FieldValue::Int64(1), false),
@@ -758,45 +760,45 @@ mod tests {
 
     #[test]
     fn test_mixed_list_equality_comparison() {
-        let test_data = vec![
+        let test_data = [
             (
-                FieldValue::List(vec![FieldValue::Uint64(0), FieldValue::Int64(0)].into()),
-                FieldValue::List(vec![FieldValue::Uint64(0), FieldValue::Int64(0)].into()),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0), FieldValue::Int64(0)])),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0), FieldValue::Int64(0)])),
                 true,
             ),
             (
-                FieldValue::List(vec![FieldValue::Uint64(0), FieldValue::Int64(0)].into()),
-                FieldValue::List(vec![FieldValue::Int64(0), FieldValue::Uint64(0)].into()),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0), FieldValue::Int64(0)])),
+                FieldValue::List(Arc::new([FieldValue::Int64(0), FieldValue::Uint64(0)])),
                 true,
             ),
             (
-                FieldValue::List(vec![FieldValue::Int64(0), FieldValue::Uint64(0)].into()),
-                FieldValue::List(vec![FieldValue::Int64(0), FieldValue::Uint64(0)].into()),
+                FieldValue::List(Arc::new([FieldValue::Int64(0), FieldValue::Uint64(0)])),
+                FieldValue::List(Arc::new([FieldValue::Int64(0), FieldValue::Uint64(0)])),
                 true,
             ),
             (
-                FieldValue::List(vec![FieldValue::Uint64(0), FieldValue::Int64(-2)].into()),
-                FieldValue::List(vec![FieldValue::Uint64(0), FieldValue::Int64(-2)].into()),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0), FieldValue::Int64(-2)])),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0), FieldValue::Int64(-2)])),
                 true,
             ),
             (
-                FieldValue::List(vec![FieldValue::Int64(-1), FieldValue::Uint64(2)].into()),
-                FieldValue::List(vec![FieldValue::Int64(-1), FieldValue::Uint64(2)].into()),
+                FieldValue::List(Arc::new([FieldValue::Int64(-1), FieldValue::Uint64(2)])),
+                FieldValue::List(Arc::new([FieldValue::Int64(-1), FieldValue::Uint64(2)])),
                 true,
             ),
             (
-                FieldValue::List(vec![FieldValue::Int64(-1), FieldValue::Uint64(2)].into()),
-                FieldValue::List(vec![FieldValue::Uint64(2), FieldValue::Int64(-1)].into()),
+                FieldValue::List(Arc::new([FieldValue::Int64(-1), FieldValue::Uint64(2)])),
+                FieldValue::List(Arc::new([FieldValue::Uint64(2), FieldValue::Int64(-1)])),
                 false,
             ),
             (
-                FieldValue::List(vec![FieldValue::Uint64(0), FieldValue::Int64(0)].into()),
-                FieldValue::List(vec![FieldValue::Int64(0)].into()),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0), FieldValue::Int64(0)])),
+                FieldValue::List(Arc::new([FieldValue::Int64(0)])),
                 false,
             ),
             (
-                FieldValue::List(vec![FieldValue::Uint64(0)].into()),
-                FieldValue::List(vec![].into()),
+                FieldValue::List(Arc::new([FieldValue::Uint64(0)])),
+                FieldValue::List(Arc::new([])),
                 false,
             ),
         ];

--- a/trustfall_core/src/interpreter/hints/tests/mod.rs
+++ b/trustfall_core/src/interpreter/hints/tests/mod.rs
@@ -1372,7 +1372,7 @@ mod dynamic_property_values {
 
                     let destination = info.destination();
 
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Single(FieldValue::Int64(3)),
                         CandidateValue::Multiple(vec![FieldValue::Int64(3), FieldValue::Int64(4)]),
                     ];
@@ -1429,7 +1429,7 @@ mod dynamic_property_values {
 
                     let destination = info.destination();
 
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Range(Range::with_start(Bound::Excluded(FieldValue::Int64(0)), true)),
                         CandidateValue::Range(Range::with_start(Bound::Excluded(FieldValue::Int64(1)), true)),
                         CandidateValue::Range(Range::with_start(Bound::Excluded(FieldValue::Int64(2)), true)),
@@ -1532,7 +1532,7 @@ mod dynamic_property_values {
 
                     let destination = info.destination();
 
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Range(Range::with_end(Bound::Excluded("two".into()), true)),
                     ];
                     let candidate = destination.dynamically_required_property("name");
@@ -1603,7 +1603,7 @@ mod dynamic_property_values {
 
                     let destination = info.destination();
 
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Range(Range::with_end(Bound::Excluded("two".into()), true)),
                     ];
                     let candidate = destination.dynamically_required_property("name");
@@ -1657,7 +1657,7 @@ mod dynamic_property_values {
 
                     let destination = info.destination();
 
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Single(FieldValue::Int64(1)),
                     ];
                     let candidate = destination.dynamically_required_property("value");
@@ -1798,7 +1798,7 @@ mod dynamic_property_values {
 
                     // Here the value *is* dynamically known, since the `@optional`
                     // has already been resolved in a prior step.
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Range(Range::with_start(Bound::Excluded(FieldValue::Int64(1)), true)),
                     ];
                     let candidate = destination.dynamically_required_property("value");
@@ -1879,7 +1879,7 @@ mod dynamic_property_values {
 
                     // Here the value *is* dynamically known, since the property value can
                     // affect which vertices this edge is resolved to.
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Single(FieldValue::Int64(1)),
                     ];
                     let candidate = destination.dynamically_required_property("value");
@@ -1943,7 +1943,7 @@ mod dynamic_property_values {
                     // This value *is* dynamically known here: the "fold-count-filter" around it
                     // ensures that at least one such value must exist, or else vertices
                     // from the currently-resolved edge will be discarded.
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Single(FieldValue::Int64(1)),
                     ];
                     let candidate = next_neighbor.dynamically_required_property("value");
@@ -1967,7 +1967,7 @@ mod dynamic_property_values {
 
                     // Here the value is also dynamically known, since the property is local
                     // to the edge being resolved.
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Single(FieldValue::Int64(1)),
                     ];
                     let candidate = destination.dynamically_required_property("value");
@@ -2065,7 +2065,7 @@ mod dynamic_property_values {
 
                     // Here the value is also dynamically known, since the property is local
                     // to the edge being resolved.
-                    let expected_values = vec![
+                    let expected_values = [
                         CandidateValue::Single(FieldValue::Int64(1)),
                     ];
                     let candidate = destination.dynamically_required_property("value");

--- a/trustfall_core/src/interpreter/hints/vertex_info.rs
+++ b/trustfall_core/src/interpreter/hints/vertex_info.rs
@@ -402,8 +402,8 @@ mod tests {
             second => FieldValue::Int64(2),
             third => FieldValue::Int64(3),
             null => FieldValue::Null,
-            list => FieldValue::List(vec![FieldValue::Int64(1), FieldValue::Int64(2)].into()),
-            longer_list => FieldValue::List(vec![FieldValue::Int64(1), FieldValue::Int64(2), FieldValue::Int64(3)].into()),
+            list => FieldValue::List(Arc::new([FieldValue::Int64(1), FieldValue::Int64(2)])),
+            longer_list => FieldValue::List(Arc::new([FieldValue::Int64(1), FieldValue::Int64(2), FieldValue::Int64(3)])),
         };
 
         let test_data = [

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -869,6 +869,8 @@ pub struct VariableRef {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::FieldValue;
 
     fn serialize_then_deserialize(value: &FieldValue) -> FieldValue {
@@ -889,14 +891,11 @@ mod tests {
 
     #[test]
     fn serialize_then_deserialize_list() {
-        let value = FieldValue::List(
-            vec![
-                FieldValue::Int64(1),
-                FieldValue::Int64(2),
-                FieldValue::String("foo".into()),
-            ]
-            .into(),
-        );
+        let value = FieldValue::List(Arc::new([
+            FieldValue::Int64(1),
+            FieldValue::Int64(2),
+            FieldValue::String("foo".into()),
+        ]));
         let deserialized: FieldValue = serialize_then_deserialize(&value);
         assert_eq!(
             value,

--- a/trustfall_core/src/ir/types.rs
+++ b/trustfall_core/src/ir/types.rs
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn null_values_are_only_valid_for_nullable_types() {
-        let nullable_types = vec![
+        let nullable_types = [
             Type::new("Int").unwrap(),
             Type::new("String").unwrap(),
             Type::new("Boolean").unwrap(),
@@ -282,14 +282,14 @@ mod tests {
 
     #[test]
     fn int_values_are_valid_only_for_int_type_regardless_of_nullability() {
-        let matching_types = vec![Type::new("Int").unwrap(), Type::new("Int!").unwrap()];
-        let non_matching_types = vec![
+        let matching_types = [Type::new("Int").unwrap(), Type::new("Int!").unwrap()];
+        let non_matching_types = [
             Type::new("String").unwrap(),
             Type::new("[Int!]").unwrap(),
             Type::new("[Int!]!").unwrap(),
             Type::new("[[Int!]!]").unwrap(),
         ];
-        let values = vec![
+        let values = [
             FieldValue::Int64(-42),
             FieldValue::Int64(0),
             FieldValue::Uint64(0),
@@ -314,14 +314,14 @@ mod tests {
 
     #[test]
     fn string_values_are_valid_only_for_string_type_regardless_of_nullability() {
-        let matching_types = vec![Type::new("String").unwrap(), Type::new("String!").unwrap()];
-        let non_matching_types = vec![
+        let matching_types = [Type::new("String").unwrap(), Type::new("String!").unwrap()];
+        let non_matching_types = [
             Type::new("Int").unwrap(),
             Type::new("[String!]").unwrap(),
             Type::new("[String!]!").unwrap(),
             Type::new("[[String!]!]").unwrap(),
         ];
-        let values = vec![
+        let values = [
             FieldValue::String("".into()), // empty string is not the same value as null
             FieldValue::String("test string".into()),
         ];
@@ -344,17 +344,17 @@ mod tests {
 
     #[test]
     fn boolean_values_are_valid_only_for_boolean_type_regardless_of_nullability() {
-        let matching_types = vec![
+        let matching_types = [
             Type::new("Boolean").unwrap(),
             Type::new("Boolean!").unwrap(),
         ];
-        let non_matching_types = vec![
+        let non_matching_types = [
             Type::new("Int").unwrap(),
             Type::new("[Boolean!]").unwrap(),
             Type::new("[Boolean!]!").unwrap(),
             Type::new("[[Boolean!]!]").unwrap(),
         ];
-        let values = vec![FieldValue::Boolean(false), FieldValue::Boolean(true)];
+        let values = [FieldValue::Boolean(false), FieldValue::Boolean(true)];
 
         for value in &values {
             for matching_type in &matching_types {
@@ -378,14 +378,14 @@ mod tests {
             vec![Type::new("[Int!]").unwrap(), Type::new("[Int!]!").unwrap()];
         let nullable_contents_matching_types =
             vec![Type::new("[Int]").unwrap(), Type::new("[Int]!").unwrap()];
-        let non_matching_types = vec![
+        let non_matching_types = [
             Type::new("Int").unwrap(),
             Type::new("Int!").unwrap(),
             Type::new("[String!]").unwrap(),
             Type::new("[String!]!").unwrap(),
             Type::new("[[String!]!]").unwrap(),
         ];
-        let non_nullable_values = vec![
+        let non_nullable_values = [
             FieldValue::List((1..3).map(FieldValue::Int64).collect_vec().into()),
             FieldValue::List((1..3).map(FieldValue::Uint64).collect_vec().into()),
             FieldValue::List(
@@ -397,7 +397,7 @@ mod tests {
                 .into(),
             ),
         ];
-        let nullable_values = vec![
+        let nullable_values = [
             FieldValue::List(
                 vec![FieldValue::Int64(1), FieldValue::Null, FieldValue::Int64(2)].into(),
             ),

--- a/trustfall_core/src/ir/value.rs
+++ b/trustfall_core/src/ir/value.rs
@@ -485,7 +485,7 @@ mod tests {
 
     #[test]
     fn test_field_value_into() {
-        let test_data: Vec<(FieldValue, FieldValue)> = vec![
+        let test_data: &[(FieldValue, FieldValue)] = &[
             (123i64.into(), FieldValue::Int64(123)),
             (123u64.into(), FieldValue::Uint64(123)),
             (Option::<i64>::Some(123i64).into(), FieldValue::Int64(123)),
@@ -513,7 +513,7 @@ mod tests {
                 FieldValue::List(vec![FieldValue::Int64(1), FieldValue::Int64(2)].into()),
             ),
             (
-                vec!["a String".to_string()].as_slice().into(),
+                ["a String".to_string()].as_slice().into(),
                 FieldValue::List(vec![FieldValue::String("a String".to_string().into())].into()),
             ),
         ];

--- a/trustfall_core/src/schema/adapter/tests.rs
+++ b/trustfall_core/src/schema/adapter/tests.rs
@@ -40,7 +40,7 @@ fn check_vertex_type_properties() {
         .expect("execution error")
         .collect();
 
-    let expected_rows = vec![
+    let expected_rows = [
         btreemap! {
             "property".into() => "name".into(),
         },
@@ -49,7 +49,7 @@ fn check_vertex_type_properties() {
         },
     ];
 
-    assert_eq!(expected_rows, rows);
+    assert_eq!(expected_rows.as_slice(), rows);
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn check_vertex_type_properties_using_one_of() {
             .expect("to be comparable")
     });
 
-    let expected_rows = vec![
+    let expected_rows = [
         btreemap! {
             "property".into() => "is_interface".into(),
             "name".into() => "VertexType".into()
@@ -100,7 +100,7 @@ fn check_vertex_type_properties_using_one_of() {
         },
     ];
 
-    assert_eq!(expected_rows, rows);
+    assert_eq!(expected_rows.as_slice(), rows);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn check_entrypoint_target_edges() {
         .expect("execution error")
         .collect();
 
-    let expected_rows = vec![
+    let expected_rows = [
         btreemap! {
             "target".into() => "VertexType".into(),
             "edge".into() => "implements".into(),
@@ -149,7 +149,7 @@ fn check_entrypoint_target_edges() {
         },
     ];
 
-    assert_eq!(expected_rows, rows);
+    assert_eq!(expected_rows.as_slice(), rows);
 }
 
 #[test]
@@ -193,7 +193,7 @@ fn check_parameterized_edges() {
         .collect();
     rows.sort_unstable();
 
-    let mut expected_rows = vec![
+    let mut expected_rows = [
         Output {
             edge: "nullable".into(),
             parameter_name: "x".into(),
@@ -241,5 +241,5 @@ fn check_parameterized_edges() {
     ];
     expected_rows.sort_unstable();
 
-    similar_asserts::assert_eq!(expected_rows, rows);
+    similar_asserts::assert_eq!(expected_rows.as_slice(), rows);
 }

--- a/trustfall_wasm/tests/nodejs.rs
+++ b/trustfall_wasm/tests/nodejs.rs
@@ -40,7 +40,7 @@ pub fn test_execute_query_with_traversal_and_coercion() {
 
     let actual_results = run_numbers_query(query, args).expect("query and args were not valid");
 
-    let expected_results = vec![
+    let expected_results = [
         btreemap! {
             String::from("value") => JsFieldValue::Integer(2),
             String::from("next") => JsFieldValue::Integer(3),
@@ -59,5 +59,5 @@ pub fn test_execute_query_with_traversal_and_coercion() {
         },
     ];
 
-    assert_eq!(expected_results, actual_results);
+    assert_eq!(expected_results.as_slice(), actual_results);
 }

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -283,7 +283,7 @@ pub fn test_execute_query_with_traversal_and_coercion() {
 
     let actual_results = run_numbers_query(query, args).expect("query and args were not valid");
 
-    let expected_results = vec![
+    let expected_results = [
         btreemap! {
             String::from("value") => JsFieldValue::Integer(2),
             String::from("next") => JsFieldValue::Integer(3),
@@ -302,5 +302,5 @@ pub fn test_execute_query_with_traversal_and_coercion() {
         },
     ];
 
-    assert_eq!(expected_results, actual_results);
+    assert_eq!(expected_results.as_slice(), actual_results);
 }


### PR DESCRIPTION
This only applies to test code, but it's nice to reduce any unnecessary allocations without affecting maintainability.