### PR TITLE
Format with max small heuristics

### DIFF
--- a/demo-hytradboi/src/actions_parser.rs
+++ b/demo-hytradboi/src/actions_parser.rs
@@ -15,53 +15,42 @@ pub(crate) fn get_jobs_in_workflow_file(
     let docs = match YamlLoader::load_from_str(file_content.as_str()) {
         Ok(d) => d,
         Err(e) => {
-            eprintln!(
-                "invalid yaml in workflow file {}: {}",
-                content.path.as_str(),
-                e
-            );
+            eprintln!("invalid yaml in workflow file {}: {}", content.path.as_str(), e);
             return Box::new(std::iter::empty());
         }
     };
 
-    Box::new(
-        docs.into_iter()
-            .flat_map(move |workflow_yaml| -> VertexIterator<'static, Vertex> {
-                let jobs_element = workflow_yaml["jobs"].clone();
-                if jobs_element.is_badvalue() {
-                    eprintln!(
-                        "invalid yaml, couldn't find 'jobs' in workflow file {}:\n{}",
-                        content.path.as_str(),
-                        file_content
-                    );
-                }
+    Box::new(docs.into_iter().flat_map(move |workflow_yaml| -> VertexIterator<'static, Vertex> {
+        let jobs_element = workflow_yaml["jobs"].clone();
+        if jobs_element.is_badvalue() {
+            eprintln!(
+                "invalid yaml, couldn't find 'jobs' in workflow file {}:\n{}",
+                content.path.as_str(),
+                file_content
+            );
+        }
 
-                let jobs = match jobs_element.into_hash() {
-                    None => {
-                        eprintln!(
-                            "unexpected 'jobs' section in workflow file {}:\n{}",
-                            content.path.as_str(),
-                            file_content
-                        );
-                        return Box::new(std::iter::empty());
-                    }
-                    Some(jobs) => jobs,
-                };
+        let jobs = match jobs_element.into_hash() {
+            None => {
+                eprintln!(
+                    "unexpected 'jobs' section in workflow file {}:\n{}",
+                    content.path.as_str(),
+                    file_content
+                );
+                return Box::new(std::iter::empty());
+            }
+            Some(jobs) => jobs,
+        };
 
-                Box::new(jobs.into_iter().filter_map(|(name, job_content)| {
-                    let name = name.as_str()?.to_string();
-                    job_content.as_hash()?;
+        Box::new(jobs.into_iter().filter_map(|(name, job_content)| {
+            let name = name.as_str()?.to_string();
+            job_content.as_hash()?;
 
-                    let runs_on = job_content["runs-on"].as_str().map(|x| x.to_string());
+            let runs_on = job_content["runs-on"].as_str().map(|x| x.to_string());
 
-                    Some(Vertex::GitHubActionsJob(Rc::new(ActionsJob::new(
-                        job_content,
-                        name,
-                        runs_on,
-                    ))))
-                }))
-            }),
-    )
+            Some(Vertex::GitHubActionsJob(Rc::new(ActionsJob::new(job_content, name, runs_on))))
+        }))
+    }))
 }
 
 pub(crate) fn get_steps_in_job(job: Rc<ActionsJob>) -> VertexIterator<'static, Vertex> {
@@ -110,10 +99,7 @@ pub(crate) fn get_env_for_run_step(step: Rc<ActionsRunStep>) -> VertexIterator<'
     let env_hash = match step_hash.get(&env_key) {
         Some(Yaml::Hash(h)) => h.clone(),
         Some(unexpected) => {
-            eprintln!(
-                "unexpected value {:?} for 'env' key: {:?}",
-                unexpected, step.yaml
-            );
+            eprintln!("unexpected value {:?} for 'env' key: {:?}", unexpected, step.yaml);
             return Box::new(std::iter::empty());
         }
         None => {
@@ -122,22 +108,18 @@ pub(crate) fn get_env_for_run_step(step: Rc<ActionsRunStep>) -> VertexIterator<'
         }
     };
 
-    Box::new(
-        env_hash
-            .into_iter()
-            .filter_map(move |(key_yaml, value_yaml)| {
-                let key = key_yaml.as_str()?.to_string();
-                let value = match value_yaml {
-                    Yaml::Real(s) | Yaml::String(s) => s,
-                    Yaml::Integer(i) => i.to_string(),
-                    Yaml::Boolean(b) => b.to_string(),
-                    _ => {
-                        eprintln!("unexpected value for env key {key}: {value_yaml:?}");
-                        return None;
-                    }
-                };
+    Box::new(env_hash.into_iter().filter_map(move |(key_yaml, value_yaml)| {
+        let key = key_yaml.as_str()?.to_string();
+        let value = match value_yaml {
+            Yaml::Real(s) | Yaml::String(s) => s,
+            Yaml::Integer(i) => i.to_string(),
+            Yaml::Boolean(b) => b.to_string(),
+            _ => {
+                eprintln!("unexpected value for env key {key}: {value_yaml:?}");
+                return None;
+            }
+        };
 
-                Some(Vertex::NameValuePair(Rc::from((key, value))))
-            }),
-    )
+        Some(Vertex::NameValuePair(Rc::from((key, value))))
+    }))
 }

--- a/demo-hytradboi/src/adapter.rs
+++ b/demo-hytradboi/src/adapter.rs
@@ -32,14 +32,14 @@ static CRATES_CLIENT: Lazy<consecrates::Client> =
 static GITHUB_CLIENT: Lazy<octorust::Client> = Lazy::new(|| {
     octorust::Client::new(
         USER_AGENT,
-        Some(octorust::auth::Credentials::Token(
-            std::env::var("GITHUB_TOKEN").unwrap_or_else(|_| {
+        Some(octorust::auth::Credentials::Token(std::env::var("GITHUB_TOKEN").unwrap_or_else(
+            |_| {
                 fs::read_to_string("./localdata/gh_token")
                     .expect("could not find creds file")
                     .trim()
                     .to_string()
-            }),
-        )),
+            },
+        ))),
     )
     .unwrap()
 });
@@ -47,12 +47,8 @@ static GITHUB_CLIENT: Lazy<octorust::Client> = Lazy::new(|| {
 static REPOS_CLIENT: Lazy<octorust::repos::Repos> =
     Lazy::new(|| octorust::repos::Repos::new(GITHUB_CLIENT.clone()));
 
-static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-});
+static RUNTIME: Lazy<Runtime> =
+    Lazy::new(|| tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap());
 
 pub struct DemoAdapter;
 
@@ -125,11 +121,7 @@ impl DemoAdapter {
     }
 
     fn most_downloaded_crates(&self) -> VertexIterator<'static, Vertex> {
-        Box::new(
-            CratesPager::new(&CRATES_CLIENT)
-                .into_iter()
-                .map(|x| x.into()),
-        )
+        Box::new(CratesPager::new(&CRATES_CLIENT).into_iter().map(|x| x.into()))
     }
 }
 
@@ -290,9 +282,7 @@ impl<'a> Adapter<'a> for DemoAdapter {
 
             // properties on GitHubRepository
             ("GitHubRepository", "owner") => resolve_property_with(contexts, |vertex| {
-                let repo = vertex
-                    .as_github_repository()
-                    .expect("not a GitHubRepository");
+                let repo = vertex.as_github_repository().expect("not a GitHubRepository");
                 let (owner, _) = get_owner_and_repo(repo);
                 owner.into()
             }),
@@ -312,15 +302,11 @@ impl<'a> Adapter<'a> for DemoAdapter {
             // properties on GitHubWorkflow
             ("GitHubWorkflow", "name") => resolve_property_with(
                 contexts,
-                field_property!(as_github_workflow, workflow, {
-                    workflow.name.as_str().into()
-                }),
+                field_property!(as_github_workflow, workflow, { workflow.name.as_str().into() }),
             ),
             ("GitHubWorkflow", "path") => resolve_property_with(
                 contexts,
-                field_property!(as_github_workflow, workflow, {
-                    workflow.path.as_str().into()
-                }),
+                field_property!(as_github_workflow, workflow, { workflow.path.as_str().into() }),
             ),
 
             // properties on GitHubActionsJob
@@ -352,20 +338,10 @@ impl<'a> Adapter<'a> for DemoAdapter {
 
             // properties on NameValuePair
             ("NameValuePair", "name") => resolve_property_with(contexts, |vertex| {
-                vertex
-                    .as_name_value_pair()
-                    .expect("not a NameValuePair")
-                    .0
-                    .clone()
-                    .into()
+                vertex.as_name_value_pair().expect("not a NameValuePair").0.clone().into()
             }),
             ("NameValuePair", "value") => resolve_property_with(contexts, |vertex| {
-                vertex
-                    .as_name_value_pair()
-                    .expect("not a NameValuePair")
-                    .0
-                    .clone()
-                    .into()
+                vertex.as_name_value_pair().expect("not a NameValuePair").0.clone().into()
             }),
             _ => unreachable!(),
         }

--- a/demo-hytradboi/src/main.rs
+++ b/demo-hytradboi/src/main.rs
@@ -44,10 +44,7 @@ fn run_query(path: &str) {
             .args
             .clone()
             .into_iter()
-            .map(|(k, v)| (
-                k,
-                serde_json::to_string_pretty(&TransparentValue::from(v)).unwrap()
-            ))
+            .map(|(k, v)| (k, serde_json::to_string_pretty(&TransparentValue::from(v)).unwrap()))
             .collect::<BTreeMap<_, _>>()
     );
 

--- a/demo-hytradboi/src/pagers.rs
+++ b/demo-hytradboi/src/pagers.rs
@@ -54,11 +54,7 @@ pub(crate) struct WorkflowsPager<'a> {
 
 impl<'a> WorkflowsPager<'a> {
     pub(crate) fn new(client: octorust::Client, repo_vertex: Vertex, runtime: &'a Runtime) -> Self {
-        Self {
-            actions: octorust::actions::Actions::new(client),
-            repo_vertex,
-            runtime,
-        }
+        Self { actions: octorust::actions::Actions::new(client), repo_vertex, runtime }
     }
 }
 

--- a/demo-hytradboi/src/util.rs
+++ b/demo-hytradboi/src/util.rs
@@ -28,12 +28,7 @@ pub(crate) struct PaginationIterator<T, P: Pager<Item = T>> {
 
 impl<T, P: Pager<Item = T>> PaginationIterator<T, P> {
     pub(crate) fn new(pager: P) -> Self {
-        Self {
-            pager,
-            next_page: 1,
-            batch: None,
-            final_page_seen: false,
-        }
+        Self { pager, next_page: 1, batch: None, final_page_seen: false }
     }
 }
 

--- a/demo-hytradboi/src/vertex.rs
+++ b/demo-hytradboi/src/vertex.rs
@@ -57,11 +57,7 @@ pub struct ActionsJob {
 
 impl ActionsJob {
     pub(crate) fn new(yaml: Yaml, name: String, runs_on: Option<String>) -> Self {
-        Self {
-            yaml,
-            name,
-            runs_on,
-        }
+        Self { yaml, name, runs_on }
     }
 }
 

--- a/experiments/schemaless/src/schema_inference.rs
+++ b/experiments/schemaless/src/schema_inference.rs
@@ -101,28 +101,21 @@ impl InferredSchema {
 
     pub(crate) fn add_new_anon_type(&mut self) -> Rc<str> {
         let anon_type: Rc<str> = Rc::from(format!("_AnonType{}", self.next_anon_type_number));
-        self.next_anon_type_number = self
-            .next_anon_type_number
-            .checked_add(1)
-            .expect("wow! how big is your query?!");
+        self.next_anon_type_number =
+            self.next_anon_type_number.checked_add(1).expect("wow! how big is your query?!");
 
         let existing = self.types.insert(
             anon_type.clone(),
             InferredVertexType::new(anon_type.clone(), VertexKind::Type),
         );
-        assert!(
-            existing.is_none(),
-            "unexpected type name conflict: {anon_type}",
-        );
+        assert!(existing.is_none(), "unexpected type name conflict: {anon_type}",);
 
         anon_type
     }
 
     pub(crate) fn ensure_vertex_kind_is_interface(&mut self, type_name: &Rc<str>) {
-        self.types
-            .get_mut(type_name)
-            .expect("vertex type was never added")
-            .kind = VertexKind::Interface;
+        self.types.get_mut(type_name).expect("vertex type was never added").kind =
+            VertexKind::Interface;
     }
 
     pub(crate) fn ensure_vertex_type_implements(
@@ -277,13 +270,7 @@ impl InferredSchema {
         let is_interface = self
             .types
             .iter()
-            .filter_map(|(k, v)| {
-                if k.as_ref() != type_name {
-                    Some(v)
-                } else {
-                    None
-                }
-            })
+            .filter_map(|(k, v)| if k.as_ref() != type_name { Some(v) } else { None })
             .flat_map(|v| v.implements.iter())
             .any(|implemented| implemented.as_ref() == type_name);
         let type_kind = if is_interface { "interface" } else { "type" };
@@ -334,9 +321,7 @@ impl InferredSchema {
         field_name: &str,
         field_info: &InferredField,
     ) {
-        let field_ty = field_info
-            .ty
-            .to_graphql_type(Self::TYPE_CHOICE_FOR_FREE_TYPES);
+        let field_ty = field_info.ty.to_graphql_type(Self::TYPE_CHOICE_FOR_FREE_TYPES);
         let parameters = if field_info.parameters.is_empty() {
             String::new()
         } else {
@@ -428,10 +413,8 @@ fn recurse_into_selection_set(
             return Err("illegal query: contains directives applied to an inline fragment".into());
         }
 
-        let coerce_to: Option<Rc<str>> = fragment
-            .type_condition
-            .as_ref()
-            .map(|tc| Rc::from(tc.node.on.node.to_string()));
+        let coerce_to: Option<Rc<str>> =
+            fragment.type_condition.as_ref().map(|tc| Rc::from(tc.node.on.node.to_string()));
 
         let coerced_type = if let Some(coerce_to) = coerce_to {
             inferred.ensure_type_exists(coerce_to.clone());
@@ -483,21 +466,18 @@ fn recurse_into_selection_set(
                 return Err("illegal query: found property-only directive on field that seems to be an edge".into());
             } else if has_non_empty_selection_set || has_only_edge_directives {
                 // found an edge
-                let inferred_type_name = if field
-                    .directives
-                    .iter()
-                    .any(|d| d.node.name.node.as_ref() == "recurse")
-                {
-                    // Found an edge that is being recursed,
-                    // assume for simplicity that it points to the same type we came from.
-                    // This is almost always true in practice, although it doesn't necessarily
-                    // have to hold.
-                    current_type.clone()
-                } else {
-                    // We can't know the exact type of the destination vertex, so make
-                    // a new type with a generated name.
-                    inferred.add_new_anon_type()
-                };
+                let inferred_type_name =
+                    if field.directives.iter().any(|d| d.node.name.node.as_ref() == "recurse") {
+                        // Found an edge that is being recursed,
+                        // assume for simplicity that it points to the same type we came from.
+                        // This is almost always true in practice, although it doesn't necessarily
+                        // have to hold.
+                        current_type.clone()
+                    } else {
+                        // We can't know the exact type of the destination vertex, so make
+                        // a new type with a generated name.
+                        inferred.add_new_anon_type()
+                    };
                 let inferred_type =
                     InferredType::List(Box::new(InferredType::Vertex(inferred_type_name.clone())));
 

--- a/experiments/schemaless_wasm/src/lib.rs
+++ b/experiments/schemaless_wasm/src/lib.rs
@@ -77,10 +77,7 @@ pub struct MyIterator {
 impl MyIterator {
     pub fn next(&mut self) -> MyIteratorElement {
         if self.current_num > self.max_num {
-            MyIteratorElement {
-                done: true,
-                value: None,
-            }
+            MyIteratorElement { done: true, value: None }
         } else {
             let value = Some(self.current_num);
             self.current_num += 1;
@@ -91,8 +88,5 @@ impl MyIterator {
 
 #[wasm_bindgen]
 pub fn get_iterator() -> MyIterator {
-    MyIterator {
-        max_num: 5,
-        current_num: 0,
-    }
+    MyIterator { max_num: 5, current_num: 0 }
 }

--- a/experiments/trustfall_rustdoc/src/lib.rs
+++ b/experiments/trustfall_rustdoc/src/lib.rs
@@ -46,10 +46,7 @@ pub fn run_query(
     trustfall_wasm::util::initialize().expect("init failed");
 
     let schema = RustdocAdapter::schema();
-    let adapter = Arc::new(RustdocAdapter::new(
-        crate_info.inner.borrow_indexed_crate(),
-        None,
-    ));
+    let adapter = Arc::new(RustdocAdapter::new(crate_info.inner.borrow_indexed_crate(), None));
 
     let query = trustfall_core::frontend::parse(&schema, query).map_err(|e| e.to_string())?;
     let args = from_js_args(args)?;

--- a/pytrustfall/src/errors.rs
+++ b/pytrustfall/src/errors.rs
@@ -1,23 +1,11 @@
 use pyo3::{create_exception, types::PyModule, PyResult, Python};
 
-create_exception!(
-    pytrustfall,
-    InvalidSchemaError,
-    pyo3::exceptions::PyException
-);
+create_exception!(pytrustfall, InvalidSchemaError, pyo3::exceptions::PyException);
 create_exception!(pytrustfall, ParseError, pyo3::exceptions::PyException);
 create_exception!(pytrustfall, ValidationError, pyo3::exceptions::PyException);
 create_exception!(pytrustfall, FrontendError, pyo3::exceptions::PyException);
-create_exception!(
-    pytrustfall,
-    InvalidIRQueryError,
-    pyo3::exceptions::PyException
-);
-create_exception!(
-    pytrustfall,
-    QueryArgumentsError,
-    pyo3::exceptions::PyException
-);
+create_exception!(pytrustfall, InvalidIRQueryError, pyo3::exceptions::PyException);
+create_exception!(pytrustfall, QueryArgumentsError, pyo3::exceptions::PyException);
 
 pub(crate) fn register(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("InvalidSchemaError", py.get_type::<InvalidSchemaError>())?;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# Rust code formatting; see https://rust-lang.github.io/rustfmt
+use_small_heuristics = "Max"

--- a/trustfall/examples/feeds/adapter.rs
+++ b/trustfall/examples/feeds/adapter.rs
@@ -173,15 +173,13 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
             },
             "FeedEntry" => match edge_name {
                 "title" => neighbors(contexts, iterable!(as_feed_entry, title, Vertex::FeedText)),
-                "content" => neighbors(
-                    contexts,
-                    iterable!(as_feed_entry, content, Vertex::FeedContent),
-                ),
+                "content" => {
+                    neighbors(contexts, iterable!(as_feed_entry, content, Vertex::FeedContent))
+                }
                 "links" => neighbors(contexts, iterable!(as_feed_entry, links, Vertex::FeedLink)),
-                "summary" => neighbors(
-                    contexts,
-                    iterable!(as_feed_entry, summary, Vertex::FeedText),
-                ),
+                "summary" => {
+                    neighbors(contexts, iterable!(as_feed_entry, summary, Vertex::FeedText))
+                }
                 "rights" => neighbors(contexts, iterable!(as_feed_entry, rights, Vertex::FeedText)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
@@ -190,10 +188,7 @@ impl<'a> BasicAdapter<'a> for FeedAdapter<'a> {
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             "ChannelImage" => match edge_name {
-                "link" => neighbors(
-                    contexts,
-                    iterable!(as_channel_image, link, Vertex::FeedLink),
-                ),
+                "link" => neighbors(contexts, iterable!(as_channel_image, link, Vertex::FeedLink)),
                 _ => unreachable!("type {type_name} edge {edge_name} not found"),
             },
             _ => unreachable!("type {type_name} not found"),

--- a/trustfall/examples/feeds/main.rs
+++ b/trustfall/examples/feeds/main.rs
@@ -34,10 +34,7 @@ struct InputQuery<'a> {
 }
 
 fn refresh_data() {
-    let data = [
-        (PCGAMER_FEED_URI, PCGAMER_FEED_LOCATION),
-        (WIRED_FEED_URI, WIRED_FEED_LOCATION),
-    ];
+    let data = [(PCGAMER_FEED_URI, PCGAMER_FEED_LOCATION), (WIRED_FEED_URI, WIRED_FEED_LOCATION)];
     for (uri, location) in data {
         let all_data = reqwest::blocking::get(uri).unwrap().bytes().unwrap();
         let write_file_path = location.to_owned() + "-temp";
@@ -78,10 +75,7 @@ fn run_query(path: &str) {
 }
 
 fn read_feed_data() -> Vec<Feed> {
-    let data = [
-        (PCGAMER_FEED_URI, PCGAMER_FEED_LOCATION),
-        (WIRED_FEED_URI, WIRED_FEED_LOCATION),
-    ];
+    let data = [(PCGAMER_FEED_URI, PCGAMER_FEED_LOCATION), (WIRED_FEED_URI, WIRED_FEED_LOCATION)];
 
     data.iter()
         .map(|(feed_uri, feed_file)| {

--- a/trustfall/examples/weather/main.rs
+++ b/trustfall/examples/weather/main.rs
@@ -72,14 +72,10 @@ fn read_metar_data() -> Vec<MetarReport> {
         buf.truncate(0);
     }
 
-    let mut csv_reader = csv::ReaderBuilder::new()
-        .has_headers(false)
-        .from_reader(reader);
+    let mut csv_reader = csv::ReaderBuilder::new().has_headers(false).from_reader(reader);
 
-    let metars: Vec<MetarReport> = csv_reader
-        .deserialize::<CsvMetarReport>()
-        .map(|x| x.unwrap().into())
-        .collect();
+    let metars: Vec<MetarReport> =
+        csv_reader.deserialize::<CsvMetarReport>().map(|x| x.unwrap().into()).collect();
 
     metars
 }
@@ -107,10 +103,7 @@ fn run_query(path: &str) {
 }
 
 fn refresh_data() {
-    let all_data = reqwest::blocking::get(METAR_DOC_URL)
-        .unwrap()
-        .text()
-        .unwrap();
+    let all_data = reqwest::blocking::get(METAR_DOC_URL).unwrap().text().unwrap();
     let write_file_path = METAR_DOC_LOCATION.to_owned() + "-temp";
 
     let write_file = File::create(&write_file_path).unwrap();

--- a/trustfall/examples/weather/metar.rs
+++ b/trustfall/examples/weather/metar.rs
@@ -154,28 +154,20 @@ impl From<CsvMetarReport> for MetarReport {
     fn from(csv_metar: CsvMetarReport) -> Self {
         let mut cloud_cover: Vec<MetarCloudCover> = vec![];
         if let Some(sky_cover) = csv_metar.sky_cover_1 {
-            cloud_cover.push(MetarCloudCover {
-                sky_cover,
-                base_altitude: csv_metar.cloud_base_ft_agl_1,
-            })
+            cloud_cover
+                .push(MetarCloudCover { sky_cover, base_altitude: csv_metar.cloud_base_ft_agl_1 })
         }
         if let Some(sky_cover) = csv_metar.sky_cover_2 {
-            cloud_cover.push(MetarCloudCover {
-                sky_cover,
-                base_altitude: csv_metar.cloud_base_ft_agl_2,
-            })
+            cloud_cover
+                .push(MetarCloudCover { sky_cover, base_altitude: csv_metar.cloud_base_ft_agl_2 })
         }
         if let Some(sky_cover) = csv_metar.sky_cover_3 {
-            cloud_cover.push(MetarCloudCover {
-                sky_cover,
-                base_altitude: csv_metar.cloud_base_ft_agl_3,
-            })
+            cloud_cover
+                .push(MetarCloudCover { sky_cover, base_altitude: csv_metar.cloud_base_ft_agl_3 })
         }
         if let Some(sky_cover) = csv_metar.sky_cover_4 {
-            cloud_cover.push(MetarCloudCover {
-                sky_cover,
-                base_altitude: csv_metar.cloud_base_ft_agl_4,
-            })
+            cloud_cover
+                .push(MetarCloudCover { sky_cover, base_altitude: csv_metar.cloud_base_ft_agl_4 })
         }
 
         let visibility = get_visibility(&csv_metar.raw_metar);

--- a/trustfall/src/lib.rs
+++ b/trustfall/src/lib.rs
@@ -74,16 +74,7 @@ pub fn execute_query<'vertex>(
     variables: BTreeMap<impl Into<Arc<str>>, impl Into<FieldValue>>,
 ) -> anyhow::Result<Box<dyn Iterator<Item = BTreeMap<Arc<str>, FieldValue>> + 'vertex>> {
     let parsed_query = trustfall_core::frontend::parse(schema, query)?;
-    let vars = Arc::new(
-        variables
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect(),
-    );
+    let vars = Arc::new(variables.into_iter().map(|(k, v)| (k.into(), v.into())).collect());
 
-    Ok(trustfall_core::interpreter::execution::interpret_ir(
-        adapter,
-        parsed_query,
-        vars,
-    )?)
+    Ok(trustfall_core::interpreter::execution::interpret_ir(adapter, parsed_query, vars)?)
 }

--- a/trustfall/tests/helper_macros.rs
+++ b/trustfall/tests/helper_macros.rs
@@ -14,11 +14,7 @@ struct Value {
 }
 impl Value {
     fn initial(&self) -> String {
-        self.name
-            .chars()
-            .next()
-            .map(String::from)
-            .unwrap_or_default()
+        self.name.chars().next().map(String::from).unwrap_or_default()
     }
 }
 
@@ -30,9 +26,7 @@ impl trustfall::provider::BasicAdapter<'static> for Adapter {
         _edge_name: &str,
         _parameters: &trustfall::provider::EdgeParameters,
     ) -> trustfall::provider::VertexIterator<'static, Self::Vertex> {
-        Box::new(std::iter::once(V::Variant(Value {
-            name: String::from("Berit"),
-        })))
+        Box::new(std::iter::once(V::Variant(Value { name: String::from("Berit") })))
     }
     fn resolve_property(
         &self,

--- a/trustfall_core/fuzz/fuzz_targets/adapter_batching/numbers_adapter.rs
+++ b/trustfall_core/fuzz/fuzz_targets/adapter_batching/numbers_adapter.rs
@@ -156,11 +156,8 @@ fn get_factors(primes: &BTreeSet<i64>, num: i64) -> BTreeSet<i64> {
             pos_factors
         }
         x if x >= 2 => {
-            let factors: BTreeSet<i64> = primes
-                .iter()
-                .copied()
-                .filter(|prime| num % *prime == 0)
-                .collect();
+            let factors: BTreeSet<i64> =
+                primes.iter().copied().filter(|prime| num % *prime == 0).collect();
             factors
         }
         _ => unreachable!(),
@@ -351,10 +348,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
                 })
             }
             _ => {
-                unreachable!(
-                    "Unexpected edge {} on vertex type {}",
-                    &edge_name, &type_name
-                );
+                unreachable!("Unexpected edge {} on vertex type {}", &edge_name, &type_name);
             }
         }
     }
@@ -367,17 +361,13 @@ impl<'a> Adapter<'a> for NumbersAdapter {
         resolve_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         match (type_name.as_ref(), coerce_to_type.as_ref()) {
-            ("Number", "Prime") => resolve_coercion_with(contexts, |vertex| {
-                matches!(vertex, NumbersVertex::Prime(..))
-            }),
+            ("Number", "Prime") => {
+                resolve_coercion_with(contexts, |vertex| matches!(vertex, NumbersVertex::Prime(..)))
+            }
             ("Number", "Composite") => resolve_coercion_with(contexts, |vertex| {
                 matches!(vertex, NumbersVertex::Composite(..))
             }),
-            _ => unimplemented!(
-                "Unexpected coercion attempted: {} {}",
-                type_name,
-                coerce_to_type
-            ),
+            _ => unimplemented!("Unexpected coercion attempted: {} {}", type_name, coerce_to_type),
         }
     }
 }

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -23,9 +23,7 @@ pub struct FilesystemInterpreter {
 
 impl FilesystemInterpreter {
     pub fn new(origin: String) -> FilesystemInterpreter {
-        FilesystemInterpreter {
-            origin: Rc::new(origin),
-        }
+        FilesystemInterpreter { origin: Rc::new(origin) }
     }
 }
 
@@ -37,10 +35,7 @@ struct OriginIterator {
 
 impl OriginIterator {
     pub fn new(vertex: DirectoryVertex) -> OriginIterator {
-        OriginIterator {
-            origin_vertex: vertex,
-            produced: false,
-        }
+        OriginIterator { origin_vertex: vertex, produced: false }
     }
 }
 
@@ -123,11 +118,7 @@ impl SubdirectoryIterator {
     pub fn new(origin: Rc<String>, directory: &DirectoryVertex) -> Self {
         let mut buf = PathBuf::new();
         buf.extend([&*origin, &directory.path]);
-        Self {
-            origin,
-            directory: directory.clone(),
-            dir_iter: fs::read_dir(buf).unwrap(),
-        }
+        Self { origin, directory: directory.clone(), dir_iter: fs::read_dir(buf).unwrap() }
     }
 }
 
@@ -151,10 +142,8 @@ impl Iterator for SubdirectoryIterator {
 
                             let mut buf = PathBuf::new();
                             buf.extend([&self.directory.path, &name]);
-                            let result = DirectoryVertex {
-                                name,
-                                path: buf.to_str().unwrap().to_owned(),
-                            };
+                            let result =
+                                DirectoryVertex { name, path: buf.to_str().unwrap().to_owned() };
                             return Some(FilesystemVertex::Directory(result));
                         }
                     }
@@ -171,10 +160,8 @@ pub type ContextAndValue = (DataContext<FilesystemVertex>, FieldValue);
 
 type IndividualEdgeResolver<'a> =
     fn(Rc<String>, &FilesystemVertex) -> VertexIterator<'a, FilesystemVertex>;
-type ContextAndIterableOfEdges<'a> = (
-    DataContext<FilesystemVertex>,
-    VertexIterator<'a, FilesystemVertex>,
-);
+type ContextAndIterableOfEdges<'a> =
+    (DataContext<FilesystemVertex>, VertexIterator<'a, FilesystemVertex>);
 
 struct EdgeResolverIterator<'a> {
     origin: Rc<String>,
@@ -188,19 +175,12 @@ impl<'a> EdgeResolverIterator<'a> {
         contexts: VertexIterator<'a, DataContext<FilesystemVertex>>,
         edge_resolver: IndividualEdgeResolver<'a>,
     ) -> Self {
-        Self {
-            origin,
-            contexts,
-            edge_resolver,
-        }
+        Self { origin, contexts, edge_resolver }
     }
 }
 
 impl<'a> Iterator for EdgeResolverIterator<'a> {
-    type Item = (
-        DataContext<FilesystemVertex>,
-        VertexIterator<'a, FilesystemVertex>,
-    );
+    type Item = (DataContext<FilesystemVertex>, VertexIterator<'a, FilesystemVertex>);
 
     fn next(&mut self) -> Option<ContextAndIterableOfEdges<'a>> {
         if let Some(context) = self.contexts.next() {
@@ -270,10 +250,7 @@ impl<'a> Adapter<'a> for FilesystemInterpreter {
     ) -> VertexIterator<'a, Self::Vertex> {
         assert!(edge_name.as_ref() == "OriginDirectory");
         assert!(parameters.is_empty());
-        let vertex = DirectoryVertex {
-            name: "<origin>".to_owned(),
-            path: "".to_owned(),
-        };
+        let vertex = DirectoryVertex { name: "<origin>".to_owned(), path: "".to_owned() };
         Box::new(OriginIterator::new(vertex))
     }
 
@@ -328,11 +305,7 @@ impl<'a> Adapter<'a> for FilesystemInterpreter {
                 "extension" => Box::new(contexts.map(|context| match context.active_vertex() {
                     None => (context, FieldValue::Null),
                     Some(FilesystemVertex::File(ref x)) => {
-                        let value = x
-                            .extension
-                            .clone()
-                            .map(Into::into)
-                            .unwrap_or(FieldValue::Null);
+                        let value = x.extension.clone().map(Into::into).unwrap_or(FieldValue::Null);
                         (context, value)
                     }
                     _ => unreachable!(),

--- a/trustfall_core/src/frontend/outputs.rs
+++ b/trustfall_core/src/frontend/outputs.rs
@@ -44,9 +44,7 @@ impl<'query> OutputHandler<'query> {
     }
 
     pub(super) fn end_subcomponent(&mut self) -> BTreeMap<Arc<str>, Vec<FieldRef>> {
-        self.component_outputs_stack
-            .pop()
-            .expect("stack was unexpectedly empty")
+        self.component_outputs_stack.pop().expect("stack was unexpectedly empty")
     }
 
     fn make_output_name(&self, local_name: &str, transforms: Option<&[&str]>) -> Arc<str> {

--- a/trustfall_core/src/frontend/tags.rs
+++ b/trustfall_core/src/frontend/tags.rs
@@ -41,8 +41,7 @@ impl<'a> TagHandler<'a> {
         field: FieldRef,
         path: &ComponentPath,
     ) -> Result<(), BTreeMapOccupiedError<'_, &'a str, TagEntry<'a>>> {
-        self.tags
-            .insert_or_error(name, TagEntry::new(name, field, path.clone()))?;
+        self.tags.insert_or_error(name, TagEntry::new(name, field, path.clone()))?;
 
         Ok(())
     }
@@ -63,10 +62,8 @@ impl<'a> TagHandler<'a> {
         use_path: &ComponentPath,
         use_vid: Vid,
     ) -> Result<&TagEntry, TagLookupError> {
-        let entry = self
-            .tags
-            .get(name)
-            .ok_or_else(|| TagLookupError::UndefinedTag(name.to_string()))?;
+        let entry =
+            self.tags.get(name).ok_or_else(|| TagLookupError::UndefinedTag(name.to_string()))?;
 
         if entry.path.is_parent(use_path) {
             match &entry.field {
@@ -89,10 +86,8 @@ impl<'a> TagHandler<'a> {
 
                 // The -1 in the index calculation is because the root component
                 // cannot import tags -- it has no parent component to import from.
-                let (component_root, imported_tags) = self
-                    .component_imported_tags
-                    .get_mut(entry.path.len() - 1)
-                    .unwrap();
+                let (component_root, imported_tags) =
+                    self.component_imported_tags.get_mut(entry.path.len() - 1).unwrap();
                 assert_eq!(*component_root, importing_component_root);
                 imported_tags.push(entry.field.clone());
             }
@@ -107,12 +102,8 @@ impl<'a> TagHandler<'a> {
     }
 
     pub(super) fn finish(self) -> Result<(), BTreeSet<&'a str>> {
-        let unused_tags: BTreeSet<_> = self
-            .tags
-            .keys()
-            .copied()
-            .filter(|x| !self.used_tags.contains(x))
-            .collect();
+        let unused_tags: BTreeSet<_> =
+            self.tags.keys().copied().filter(|x| !self.used_tags.contains(x)).collect();
         if unused_tags.is_empty() {
             Ok(())
         } else {

--- a/trustfall_core/src/frontend/util.rs
+++ b/trustfall_core/src/frontend/util.rs
@@ -24,9 +24,7 @@ pub(super) struct ComponentPath {
 
 impl ComponentPath {
     pub(super) fn new(starting_vid: Vid) -> Self {
-        Self {
-            path: vec![starting_vid],
-        }
+        Self { path: vec![starting_vid] }
     }
 
     #[inline(always)]

--- a/trustfall_core/src/frontend/validation.rs
+++ b/trustfall_core/src/frontend/validation.rs
@@ -53,10 +53,7 @@ fn validate_field<'a>(
     let old_path_length = path.len();
     let field_def = schema
         .fields
-        .get(&(
-            Arc::from(parent_type_name.to_string()),
-            Arc::from(node.name.to_string()),
-        ))
+        .get(&(Arc::from(parent_type_name.to_string()), Arc::from(node.name.to_string())))
         .ok_or_else(|| {
             path.push(&node.name);
             FrontendError::ValidationError(ValidationError::NonExistentPath(
@@ -89,10 +86,7 @@ fn validate_field<'a>(
                 | TypeKind::Enum(_)
                 | TypeKind::InputObject(_) => unreachable!(),
             };
-            if !implemented_interfaces
-                .iter()
-                .any(|x| x.node.as_ref() == pre_coercion_type_name)
-            {
+            if !implemented_interfaces.iter().any(|x| x.node.as_ref() == pre_coercion_type_name) {
                 // The specified coerced-to type does not implement the source interface.
                 return Err(FrontendError::ValidationError(
                     ValidationError::CannotCoerceToUnrelatedType(
@@ -103,9 +97,9 @@ fn validate_field<'a>(
             }
         } else {
             // The coerced-to type is not part of the schema.
-            return Err(FrontendError::ValidationError(
-                ValidationError::NonExistentType(coerced.to_string()),
-            ));
+            return Err(FrontendError::ValidationError(ValidationError::NonExistentType(
+                coerced.to_string(),
+            )));
         }
 
         path.push(coerced);

--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -139,10 +139,7 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
                     expected_arg_count,
                     parsed_args.len()
                 ),
-                value
-                    .node
-                    .get_argument("value")
-                    .map_or(value.pos, |arg| arg.pos),
+                value.node.get_argument("value").map_or(value.pos, |arg| arg.pos),
             ));
         }
 
@@ -154,10 +151,7 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
             "<" => Ok(Operation::LessThan((), parsed_args.pop().unwrap())),
             "<=" => Ok(Operation::LessThanOrEqual((), parsed_args.pop().unwrap())),
             ">" => Ok(Operation::GreaterThan((), parsed_args.pop().unwrap())),
-            ">=" => Ok(Operation::GreaterThanOrEqual(
-                (),
-                parsed_args.pop().unwrap(),
-            )),
+            ">=" => Ok(Operation::GreaterThanOrEqual((), parsed_args.pop().unwrap())),
             "contains" => Ok(Operation::Contains((), parsed_args.pop().unwrap())),
             "not_contains" => Ok(Operation::NotContains((), parsed_args.pop().unwrap())),
             "one_of" => Ok(Operation::OneOf((), parsed_args.pop().unwrap())),
@@ -248,9 +242,7 @@ impl TryFrom<&Positioned<Directive>> for OutputDirective {
             })?;
         }
 
-        Ok(Self {
-            name: output_argument,
-        })
+        Ok(Self { name: output_argument })
     }
 }
 
@@ -494,16 +486,15 @@ impl TryFrom<&Positioned<Directive>> for RecurseDirective {
             )
         })?;
         let depth = match &depth_argument.node {
-            Value::Number(n) => n
-                .as_u64()
-                .and_then(|v| NonZeroUsize::new(v as usize))
-                .ok_or_else(|| {
+            Value::Number(n) => {
+                n.as_u64().and_then(|v| NonZeroUsize::new(v as usize)).ok_or_else(|| {
                     ParseError::InappropriateTypeForDirectiveArgument(
                         "@recurse".to_owned(),
                         "depth".to_owned(),
                         depth_argument.pos,
                     )
-                }),
+                })
+            }
             _ => Err(ParseError::InappropriateTypeForDirectiveArgument(
                 "@recurse".to_owned(),
                 "depth".to_owned(),
@@ -541,10 +532,8 @@ pub(crate) struct FoldGroup {
 }
 
 fn ensure_name_is_valid(name: &str) -> Result<(), Vec<char>> {
-    let mut invalid_char_iter = name
-        .chars()
-        .filter(|c| !c.is_ascii_alphanumeric() && *c != '_')
-        .peekable();
+    let mut invalid_char_iter =
+        name.chars().filter(|c| !c.is_ascii_alphanumeric() && *c != '_').peekable();
     if invalid_char_iter.peek().is_some() {
         let mut seen_chars: HashSet<char> = Default::default();
         let mut invalid_chars: Vec<_> = Default::default();

--- a/trustfall_core/src/graphql_query/error.rs
+++ b/trustfall_core/src/graphql_query/error.rs
@@ -60,10 +60,7 @@ pub enum ParseError {
     #[error("Tag name \"{0}\" contains invalid characters: {1:?}")]
     InvalidTagName(String, Vec<char>, Pos),
 
-    #[serde(
-        skip_deserializing,
-        serialize_with = "fail_serialize_invalid_graphql_error"
-    )]
+    #[serde(skip_deserializing, serialize_with = "fail_serialize_invalid_graphql_error")]
     #[error("{0}")]
     InvalidGraphQL(async_graphql_parser::Error),
 
@@ -90,9 +87,7 @@ fn fail_serialize_invalid_graphql_error<S: Serializer>(
     _: &async_graphql_parser::Error,
     _: S,
 ) -> Result<S::Ok, S::Error> {
-    Err(S::Error::custom(
-        "cannot serialize InvalidGraphQL error variant",
-    ))
+    Err(S::Error::custom("cannot serialize InvalidGraphQL error variant"))
 }
 
 impl From<async_graphql_parser::Error> for ParseError {

--- a/trustfall_core/src/graphql_query/query.rs
+++ b/trustfall_core/src/graphql_query/query.rs
@@ -125,9 +125,7 @@ fn try_get_query_root(document: &ExecutableDocument) -> Result<&Positioned<Field
 
     match &document.operations {
         DocumentOperations::Multiple(mult) => {
-            return Err(ParseError::MultipleOperationsInDocument(
-                mult.values().next().unwrap().pos,
-            ))
+            return Err(ParseError::MultipleOperationsInDocument(mult.values().next().unwrap().pos))
         }
         DocumentOperations::Single(op) => {
             let root_node = &op.node;
@@ -163,14 +161,12 @@ fn try_get_query_root(document: &ExecutableDocument) -> Result<&Positioned<Field
             let root_node = root_items.first().unwrap();
             match &root_node.node {
                 Selection::Field(positioned_field) => Ok(positioned_field),
-                Selection::FragmentSpread(fs) => Err(ParseError::UnsupportedQueryRoot(
-                    "a fragment spread".to_string(),
-                    fs.pos,
-                )),
-                Selection::InlineFragment(inl) => Err(ParseError::UnsupportedQueryRoot(
-                    "an inline fragment".to_string(),
-                    inl.pos,
-                )),
+                Selection::FragmentSpread(fs) => {
+                    Err(ParseError::UnsupportedQueryRoot("a fragment spread".to_string(), fs.pos))
+                }
+                Selection::InlineFragment(inl) => {
+                    Err(ParseError::UnsupportedQueryRoot("an inline fragment".to_string(), inl.pos))
+                }
             }
         }
     }
@@ -235,10 +231,7 @@ fn make_field_node(field: &Positioned<Field>) -> Result<FieldNode, ParseError> {
         .iter()
         .find(|selection| matches!(selection.node, Selection::FragmentSpread(_)));
     if let Some(s) = fragment_spread {
-        return Err(ParseError::UnsupportedSyntax(
-            "fragment spread".to_string(),
-            s.pos,
-        ));
+        return Err(ParseError::UnsupportedSyntax("fragment spread".to_string(), s.pos));
     }
 
     let inline_fragment = field
@@ -419,11 +412,7 @@ fn make_field_connection(field: &Positioned<Field>) -> Result<FieldConnection, P
     Ok(FieldConnection {
         position: field.pos,
         name: field.node.name.node.as_ref().to_owned().into(),
-        alias: field
-            .node
-            .alias
-            .as_ref()
-            .map(|p| p.node.as_ref().to_owned().into()),
+        alias: field.node.alias.as_ref().map(|p| p.node.as_ref().to_owned().into()),
         arguments,
         optional,
         recurse,
@@ -441,10 +430,7 @@ fn make_fold_group(
                 Some(make_transform_group(transform, directive_iter)?)
             }
             ParsedDirective::Fold(_, pos) => {
-                return Err(ParseError::UnsupportedDuplicatedDirective(
-                    "@fold".to_string(),
-                    pos,
-                ));
+                return Err(ParseError::UnsupportedDuplicatedDirective("@fold".to_string(), pos));
             }
             _ => {
                 return Err(ParseError::UnsupportedDirectivePosition(
@@ -458,10 +444,7 @@ fn make_fold_group(
         None
     };
 
-    Ok(FoldGroup {
-        fold,
-        transform: transform_group,
-    })
+    Ok(FoldGroup { fold, transform: transform_group })
 }
 
 fn make_transform_group(
@@ -500,13 +483,7 @@ fn make_transform_group(
     // all other directives apply to the transformed value and are processed here.
     assert!(directive_iter.next().is_none());
 
-    Ok(TransformGroup {
-        transform,
-        output,
-        tag,
-        filter,
-        retransform,
-    })
+    Ok(TransformGroup { transform, output, tag, filter, retransform })
 }
 
 /// Parses a query document. May fail if there is no query root.
@@ -527,10 +504,7 @@ pub fn parse_document(document: &ExecutableDocument) -> Result<Query, ParseError
 
     let root_field = make_field_node(query_root)?;
 
-    Ok(Query {
-        root_connection,
-        root_field,
-    })
+    Ok(Query { root_connection, root_field })
 }
 
 #[cfg(test)]
@@ -563,12 +537,9 @@ mod tests {
         let document = parse_query(test_query.query).unwrap();
         let check_data = fs::read_to_string(check_path).unwrap();
 
-        let constructed_test_item =
-            parse_document(&document).map(move |query| TestParsedGraphQLQuery {
-                schema_name: test_query.schema_name,
-                query,
-                arguments,
-            });
+        let constructed_test_item = parse_document(&document).map(move |query| {
+            TestParsedGraphQLQuery { schema_name: test_query.schema_name, query, arguments }
+        });
 
         let check_parsed: TestParsedGraphQLQueryResult = ron::from_str(&check_data).unwrap();
 

--- a/trustfall_core/src/interpreter/filtering.rs
+++ b/trustfall_core/src/interpreter/filtering.rs
@@ -205,9 +205,7 @@ pub(super) fn regex_matches_slow_path(left: &FieldValue, right: &FieldValue) -> 
             // Bad regex values can happen in ways that can't be prevented,
             // for example: when using a tag argument and the tagged value isn't a valid regex.
             // In such cases, we declare that the regex doesn't match.
-            Regex::new(r)
-                .map(|pattern| pattern.is_match(l))
-                .unwrap_or(false)
+            Regex::new(r).map(|pattern| pattern.is_match(l)).unwrap_or(false)
         }
         (FieldValue::Null, FieldValue::Null)
         | (FieldValue::Null, FieldValue::String(_))
@@ -278,11 +276,8 @@ pub(super) fn apply_filter<'query, AdapterT: Adapter<'query>>(
     //       - turn "in_collection" filter arguments into sets if possible
     match filter.right() {
         Some(Argument::Variable(var)) => {
-            let query_arguments = &carrier
-                .query
-                .as_ref()
-                .expect("query was not returned")
-                .arguments;
+            let query_arguments =
+                &carrier.query.as_ref().expect("query was not returned").arguments;
             let right_value = query_arguments[var.variable_name.as_ref()].to_owned();
             apply_filter_with_static_argument_value(filter, right_value, iterator)
         }
@@ -415,24 +410,18 @@ fn apply_filter_with_static_argument_value<'query, Vertex: Debug + Clone + 'quer
             (!has_substring(&left_value, &right_value)).then_some(ctx)
         })),
         Operation::RegexMatches(_, _) => {
-            let pattern = Regex::new(
-                right_value
-                    .as_str()
-                    .expect("regex argument was not a string"),
-            )
-            .expect("regex argument was not a valid regex");
+            let pattern =
+                Regex::new(right_value.as_str().expect("regex argument was not a string"))
+                    .expect("regex argument was not a valid regex");
             Box::new(iterator.filter_map(move |mut ctx| {
                 let left_value = ctx.values.pop().expect("no value present");
                 regex_matches_optimized(&left_value, &pattern).then_some(ctx)
             }))
         }
         Operation::NotRegexMatches(_, _) => {
-            let pattern = Regex::new(
-                right_value
-                    .as_str()
-                    .expect("regex argument was not a string"),
-            )
-            .expect("regex argument was not a valid regex");
+            let pattern =
+                Regex::new(right_value.as_str().expect("regex argument was not a string"))
+                    .expect("regex argument was not a valid regex");
             Box::new(iterator.filter_map(move |mut ctx| {
                 let left_value = ctx.values.pop().expect("no value present");
                 (!regex_matches_optimized(&left_value, &pattern)).then_some(ctx)
@@ -447,168 +436,168 @@ fn apply_filter_with_tagged_argument_value<'query, Vertex: Debug + Clone + 'quer
     argument_value_iterator: ContextOutcomeIterator<'query, Vertex, TaggedValue>,
 ) -> ContextIterator<'query, Vertex> {
     match filter {
-        Operation::Equals(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+        Operation::Equals(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 equals(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotEquals(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotEquals(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!equals(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
-        Operation::LessThan(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::LessThan(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 less_than(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::LessThanOrEqual(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::LessThanOrEqual(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 less_than_or_equal(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::GreaterThan(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::GreaterThan(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 greater_than(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::GreaterThanOrEqual(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::GreaterThanOrEqual(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 greater_than_or_equal(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::Contains(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::Contains(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 contains(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotContains(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotContains(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!contains(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
-        Operation::OneOf(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::OneOf(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 one_of(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotOneOf(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotOneOf(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!one_of(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
-        Operation::HasPrefix(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::HasPrefix(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 has_prefix(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotHasPrefix(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotHasPrefix(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!has_prefix(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
-        Operation::HasSuffix(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::HasSuffix(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 has_suffix(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotHasSuffix(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotHasSuffix(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!has_suffix(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
-        Operation::HasSubstring(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::HasSubstring(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 has_substring(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotHasSubstring(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotHasSubstring(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!has_substring(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
-        Operation::RegexMatches(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::RegexMatches(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 regex_matches_slow_path(&left_value, &right_value).then_some(ctx)
-            },
-        )),
-        Operation::NotRegexMatches(_, _) => Box::new(argument_value_iterator.filter_map(
-            move |(mut ctx, tagged_value)| {
+            }))
+        }
+        Operation::NotRegexMatches(_, _) => {
+            Box::new(argument_value_iterator.filter_map(move |(mut ctx, tagged_value)| {
                 let left_value = ctx.values.pop().expect("no value present");
                 let TaggedValue::Some(right_value) = tagged_value else {
                     return Some(ctx);
                 };
                 (!regex_matches_slow_path(&left_value, &right_value)).then_some(ctx)
-            },
-        )),
+            }))
+        }
         Operation::IsNull(_) | Operation::IsNotNull(_) => unreachable!("{filter:?}"),
     }
 }
@@ -643,16 +632,8 @@ mod tests {
         ];
 
         for (left, right, expected_outcome) in test_data {
-            assert_eq!(
-                expected_outcome,
-                greater_than(&left, &right),
-                "{left:?} > {right:?}",
-            );
-            assert_eq!(
-                expected_outcome,
-                less_than(&right, &left),
-                "{right:?} < {left:?}",
-            );
+            assert_eq!(expected_outcome, greater_than(&left, &right), "{left:?} > {right:?}",);
+            assert_eq!(expected_outcome, less_than(&right, &left), "{right:?} < {left:?}",);
         }
     }
 
@@ -707,29 +688,15 @@ mod tests {
         ];
 
         for (left, right, expected_outcome) in test_data {
-            assert_eq!(
-                expected_outcome,
-                equals(&left, &right),
-                "{left:?} = {right:?}",
-            );
-            assert_eq!(
-                expected_outcome,
-                equals(&right, &left),
-                "{right:?} = {left:?}",
-            );
+            assert_eq!(expected_outcome, equals(&left, &right), "{left:?} = {right:?}",);
+            assert_eq!(expected_outcome, equals(&right, &left), "{right:?} = {left:?}",);
 
             if expected_outcome {
                 // both >= and <= comparisons in either direction should return true
                 assert!(less_than_or_equal(&left, &right), "{left:?} <= {right:?}",);
-                assert!(
-                    greater_than_or_equal(&left, &right),
-                    "{left:?} >= {right:?}",
-                );
+                assert!(greater_than_or_equal(&left, &right), "{left:?} >= {right:?}",);
                 assert!(less_than_or_equal(&right, &left), "{right:?} <= {left:?}",);
-                assert!(
-                    greater_than_or_equal(&right, &left),
-                    "{right:?} >= {left:?}",
-                );
+                assert!(greater_than_or_equal(&right, &left), "{right:?} >= {left:?}",);
 
                 // both > and < comparisons in either direction should return false
                 assert!(!less_than(&left, &right), "{left:?} < {right:?}");
@@ -804,16 +771,8 @@ mod tests {
         ];
 
         for (left, right, expected_outcome) in test_data {
-            assert_eq!(
-                expected_outcome,
-                equals(&left, &right),
-                "{left:?} = {right:?}",
-            );
-            assert_eq!(
-                expected_outcome,
-                equals(&right, &left),
-                "{right:?} = {left:?}",
-            );
+            assert_eq!(expected_outcome, equals(&left, &right), "{left:?} = {right:?}",);
+            assert_eq!(expected_outcome, equals(&right, &left), "{right:?} = {left:?}",);
         }
     }
 }

--- a/trustfall_core/src/interpreter/helpers/tests.rs
+++ b/trustfall_core/src/interpreter/helpers/tests.rs
@@ -43,9 +43,8 @@ type Vertex {
     .expect("failed to parse schema");
     let contexts = Box::new(std::iter::once(DataContext::new(Some(Vertex::Variant))));
 
-    let outputs: Vec<_> = resolve_typename(contexts, &schema, "Vertex")
-        .map(|(_ctx, value)| value)
-        .collect();
+    let outputs: Vec<_> =
+        resolve_typename(contexts, &schema, "Vertex").map(|(_ctx, value)| value).collect();
 
     assert_eq!(vec![FieldValue::from("Vertex")], outputs);
 }
@@ -91,8 +90,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -106,8 +104,7 @@ mod correctness {
                         panic!("oops! we forgot to implement __typename on Named");
                     }
 
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -135,14 +132,11 @@ mod correctness {
                     coerce_to_type: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -164,8 +158,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -175,8 +168,7 @@ mod correctness {
                     property_name: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -208,14 +200,11 @@ mod correctness {
                     coerce_to_type: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -237,8 +226,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -248,8 +236,7 @@ mod correctness {
                     property_name: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -281,14 +268,11 @@ mod correctness {
                         panic!("oops! we forgot to implement coercion from Named to Number");
                     }
 
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -326,8 +310,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -343,8 +326,7 @@ mod correctness {
                         let _ = contexts.next();
                     }
 
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -372,14 +354,11 @@ mod correctness {
                     coerce_to_type: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -404,8 +383,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -415,8 +393,7 @@ mod correctness {
                     property_name: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -450,14 +427,11 @@ mod correctness {
                     coerce_to_type: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -480,8 +454,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -491,8 +464,7 @@ mod correctness {
                     property_name: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -526,14 +498,11 @@ mod correctness {
                         let _ = contexts.next();
                     }
 
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -573,8 +542,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -629,14 +597,11 @@ mod correctness {
                     coerce_to_type: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -661,8 +626,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -672,8 +636,7 @@ mod correctness {
                     property_name: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -714,14 +677,11 @@ mod correctness {
                     coerce_to_type: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
-                    self.inner
-                        .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+                    self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)
@@ -746,8 +706,7 @@ mod correctness {
                     parameters: &EdgeParameters,
                     resolve_info: &ResolveInfo,
                 ) -> VertexIterator<'a, Self::Vertex> {
-                    self.inner
-                        .resolve_starting_vertices(edge_name, parameters, resolve_info)
+                    self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
                 }
 
                 fn resolve_property(
@@ -757,8 +716,7 @@ mod correctness {
                     property_name: &Arc<str>,
                     resolve_info: &ResolveInfo,
                 ) -> ContextOutcomeIterator<'a, Self::Vertex, FieldValue> {
-                    self.inner
-                        .resolve_property(contexts, type_name, property_name, resolve_info)
+                    self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
                 }
 
                 fn resolve_neighbors(
@@ -807,9 +765,7 @@ mod correctness {
                 }
             }
 
-            let adapter = AdapterWrapper {
-                inner: NumbersAdapter::new(),
-            };
+            let adapter = AdapterWrapper { inner: NumbersAdapter::new() };
             let schema = adapter.inner.schema().clone();
 
             super::super::super::correctness::check_adapter_invariants(&schema, adapter)

--- a/trustfall_core/src/interpreter/hints/candidates.rs
+++ b/trustfall_core/src/interpreter/hints/candidates.rs
@@ -254,31 +254,19 @@ impl<T: Clone> Range<&T> {
             Bound::Included(b) => Bound::Included(b.clone()),
             Bound::Excluded(b) => Bound::Excluded(b.clone()),
         };
-        Range {
-            start,
-            end,
-            null_included: self.null_included,
-        }
+        Range { start, end, null_included: self.null_included }
     }
 }
 
 impl<T> Range<T> {
     /// The full, unbounded range of values.
     pub const fn full() -> Range<T> {
-        Self {
-            start: Bound::Unbounded,
-            end: Bound::Unbounded,
-            null_included: true,
-        }
+        Self { start: Bound::Unbounded, end: Bound::Unbounded, null_included: true }
     }
 
     /// The full range of values, except null.
     pub const fn full_non_null() -> Range<T> {
-        Self {
-            start: Bound::Unbounded,
-            end: Bound::Unbounded,
-            null_included: false,
-        }
+        Self { start: Bound::Unbounded, end: Bound::Unbounded, null_included: false }
     }
 
     /// Converts from `&Range<T>` to `Range<&T>`.
@@ -305,11 +293,7 @@ impl<T: Debug + Clone + PartialEq + Eq + PartialOrd + NullableValue> Range<T> {
             }
             Bound::Unbounded => {}
         }
-        Self {
-            start,
-            end,
-            null_included,
-        }
+        Self { start, end, null_included }
     }
 
     pub(super) fn with_start(start: Bound<T>, null_included: bool) -> Self {
@@ -319,11 +303,7 @@ impl<T: Debug + Clone + PartialEq + Eq + PartialOrd + NullableValue> Range<T> {
             }
             Bound::Unbounded => {}
         }
-        Self {
-            start,
-            end: Bound::Unbounded,
-            null_included,
-        }
+        Self { start, end: Bound::Unbounded, null_included }
     }
 
     pub(super) fn with_end(end: Bound<T>, null_included: bool) -> Self {
@@ -333,11 +313,7 @@ impl<T: Debug + Clone + PartialEq + Eq + PartialOrd + NullableValue> Range<T> {
             }
             Bound::Unbounded => {}
         }
-        Self {
-            start: Bound::Unbounded,
-            end,
-            null_included,
-        }
+        Self { start: Bound::Unbounded, end, null_included }
     }
 
     pub(super) fn intersect(&mut self, other: Range<T>) {
@@ -494,28 +470,16 @@ mod tests {
             (Impossible, Impossible, Impossible),
             (Impossible, Single(&one), Impossible),
             (Impossible, Multiple(vec![&one, &two]), Impossible),
-            (
-                Impossible,
-                Range(R::with_start(Bound::Included(&one), true)),
-                Impossible,
-            ),
+            (Impossible, Range(R::with_start(Bound::Included(&one), true)), Impossible),
             //
             // Intersecting Impossible into anything produces Imposssible.
             (Single(&one), Impossible, Impossible),
             (Multiple(vec![&one, &two]), Impossible, Impossible),
-            (
-                Range(R::with_start(Bound::Included(&one), true)),
-                Impossible,
-                Impossible,
-            ),
+            (Range(R::with_start(Bound::Included(&one), true)), Impossible, Impossible),
             //
             // Intersecting null into non-null, or vice versa, produces Impossible.
             (Single(&FieldValue::NULL), Single(&one), Impossible),
-            (
-                Single(&FieldValue::NULL),
-                Multiple(vec![&one, &two]),
-                Impossible,
-            ),
+            (Single(&FieldValue::NULL), Multiple(vec![&one, &two]), Impossible),
             (
                 Single(&FieldValue::NULL),
                 Range(R::with_start(Bound::Included(&one), false)),
@@ -526,23 +490,11 @@ mod tests {
             (Single(&one), Single(&two), Impossible),
             (Single(&one), Multiple(vec![&two, &three]), Impossible),
             (Multiple(vec![&one, &two]), Single(&three), Impossible),
-            (
-                Multiple(vec![&one, &two]),
-                Multiple(vec![&three, &four]),
-                Impossible,
-            ),
+            (Multiple(vec![&one, &two]), Multiple(vec![&three, &four]), Impossible),
             //
             // Intersecting values with a non-overlapping range produces Impossible.
-            (
-                Single(&one),
-                Range(R::with_start(Bound::Excluded(&one), true)),
-                Impossible,
-            ),
-            (
-                Single(&one),
-                Range(R::with_start(Bound::Included(&two), false)),
-                Impossible,
-            ),
+            (Single(&one), Range(R::with_start(Bound::Excluded(&one), true)), Impossible),
+            (Single(&one), Range(R::with_start(Bound::Included(&two), false)), Impossible),
             (
                 Multiple(vec![&two, &three]),
                 Range(R::with_end(Bound::Included(&one), true)),
@@ -559,16 +511,8 @@ mod tests {
             (Single(&one), Single(&one), Single(&one)),
             (Multiple(vec![&one, &two]), Single(&one), Single(&one)),
             (Single(&one), Multiple(vec![&one, &two]), Single(&one)),
-            (
-                Single(&one),
-                Range(R::with_start(Bound::Included(&one), false)),
-                Single(&one),
-            ),
-            (
-                Single(&one),
-                Range(R::with_end(Bound::Excluded(&two), false)),
-                Single(&one),
-            ),
+            (Single(&one), Range(R::with_start(Bound::Included(&one), false)), Single(&one)),
+            (Single(&one), Range(R::with_end(Bound::Excluded(&two), false)), Single(&one)),
             //
             // Intersecting null into multiple or a range that contains null produces null.
             (
@@ -650,17 +594,9 @@ mod tests {
                 Range(R::new(Bound::Included(&two), Bound::Included(&three), true)),
             ),
             (
-                Range(R::new(
-                    Bound::Included(&one),
-                    Bound::Included(&three),
-                    false,
-                )),
+                Range(R::new(Bound::Included(&one), Bound::Included(&three), false)),
                 Range(R::new(Bound::Included(&two), Bound::Included(&four), true)),
-                Range(R::new(
-                    Bound::Included(&two),
-                    Bound::Included(&three),
-                    false,
-                )),
+                Range(R::new(Bound::Included(&two), Bound::Included(&three), false)),
             ),
             (
                 Range(R::new(Bound::Included(&one), Bound::Excluded(&three), true)),
@@ -668,31 +604,15 @@ mod tests {
                 Range(R::new(Bound::Included(&two), Bound::Excluded(&three), true)),
             ),
             (
-                Range(R::new(
-                    Bound::Included(&one),
-                    Bound::Included(&three),
-                    false,
-                )),
+                Range(R::new(Bound::Included(&one), Bound::Included(&three), false)),
                 Range(R::new(Bound::Excluded(&two), Bound::Included(&four), true)),
-                Range(R::new(
-                    Bound::Excluded(&two),
-                    Bound::Included(&three),
-                    false,
-                )),
+                Range(R::new(Bound::Excluded(&two), Bound::Included(&three), false)),
             ),
             //
             // Intersecting overlapping multiple values (or multiple + range)
             // can produce either a Single or a Multiple, depending on the overlap size.
-            (
-                Multiple(vec![&one, &two]),
-                Multiple(vec![&two, &three]),
-                Single(&two),
-            ),
-            (
-                Multiple(vec![&two, &three]),
-                Multiple(vec![&one, &two]),
-                Single(&two),
-            ),
+            (Multiple(vec![&one, &two]), Multiple(vec![&two, &three]), Single(&two)),
+            (Multiple(vec![&two, &three]), Multiple(vec![&one, &two]), Single(&two)),
             (
                 Multiple(vec![&two, &three]),
                 Multiple(vec![&one, &two, &three, &four]),
@@ -730,17 +650,11 @@ mod tests {
         for (original, intersected, expected) in test_cases {
             let mut base = original.clone();
             base.intersect(intersected.clone());
-            assert_eq!(
-                expected, base,
-                "{original:?} + {intersected:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{original:?} + {intersected:?} = {base:?} != {expected:?}");
 
             let mut base = intersected.clone();
             base.intersect(original.clone());
-            assert_eq!(
-                expected, base,
-                "{intersected:?} + {original:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{intersected:?} + {original:?} = {base:?} != {expected:?}");
         }
     }
 
@@ -797,17 +711,11 @@ mod tests {
 
             let mut base = original.clone();
             base.intersect(intersected.clone());
-            assert_eq!(
-                expected, base,
-                "{original:?} + {intersected:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{original:?} + {intersected:?} = {base:?} != {expected:?}");
 
             let mut base = intersected.clone();
             base.intersect(original.clone());
-            assert_eq!(
-                expected, base,
-                "{intersected:?} + {original:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{intersected:?} + {original:?} = {base:?} != {expected:?}");
         }
     }
 
@@ -836,10 +744,7 @@ mod tests {
         for (original, intersected, expected) in test_cases {
             let mut base = original.clone();
             base.intersect(intersected.clone());
-            assert_eq!(
-                expected, base,
-                "{original:?} + {intersected:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{original:?} + {intersected:?} = {base:?} != {expected:?}");
         }
     }
 
@@ -865,16 +770,8 @@ mod tests {
                 Multiple(vec![&one, &three]),
             ),
             (Multiple(vec![&one, &two]), &two, Single(&one)),
-            (
-                Multiple(vec![&one, &FieldValue::NULL]),
-                &one,
-                Single(&FieldValue::NULL),
-            ),
-            (
-                Multiple(vec![&one, &FieldValue::NULL]),
-                &FieldValue::NULL,
-                Single(&one),
-            ),
+            (Multiple(vec![&one, &FieldValue::NULL]), &one, Single(&FieldValue::NULL)),
+            (Multiple(vec![&one, &FieldValue::NULL]), &FieldValue::NULL, Single(&one)),
             (Single(&one), &one, Impossible),
             (Single(&FieldValue::NULL), &FieldValue::NULL, Impossible),
             (All, &FieldValue::NULL, Range(R::full_non_null())),
@@ -921,14 +818,7 @@ mod tests {
             (Range(R::with_start(Bound::Excluded(&two), false)), &two),
             (Range(R::with_end(Bound::Included(&one), false)), &two),
             (Range(R::with_end(Bound::Excluded(&one), false)), &one),
-            (
-                Range(R::new(
-                    Bound::Included(&one),
-                    Bound::Included(&three),
-                    false,
-                )),
-                &two,
-            ),
+            (Range(R::new(Bound::Included(&one), Bound::Included(&three), false)), &two),
         ];
 
         for (candidate, excluded) in test_data {
@@ -951,11 +841,7 @@ mod tests {
         let unsigned_two = FieldValue::Uint64(2);
         let test_data = [
             (Single(&signed_one), &unsigned_one, Impossible),
-            (
-                Multiple(vec![&signed_one, &signed_two]),
-                &unsigned_one,
-                Single(&signed_two),
-            ),
+            (Multiple(vec![&signed_one, &signed_two]), &unsigned_one, Single(&signed_two)),
             (
                 Range(R::with_start(Bound::Included(&signed_one), true)),
                 &unsigned_one,
@@ -967,11 +853,7 @@ mod tests {
                 Range(R::with_end(Bound::Excluded(&signed_one), true)),
             ),
             (Single(&unsigned_one), &signed_one, Impossible),
-            (
-                Multiple(vec![&unsigned_one, &unsigned_two]),
-                &signed_one,
-                Single(&unsigned_two),
-            ),
+            (Multiple(vec![&unsigned_one, &unsigned_two]), &signed_one, Single(&unsigned_two)),
             (
                 Range(R::with_start(Bound::Included(&unsigned_one), true)),
                 &signed_one,
@@ -1009,60 +891,39 @@ mod tests {
                 Range(R::new(Bound::Included(&one), Bound::Included(&one), true)),
                 Multiple(vec![&FieldValue::NULL, &one]),
             ),
-            (
-                Range(R::new(Bound::Included(&one), Bound::Included(&one), false)),
-                Single(&one),
-            ),
+            (Range(R::new(Bound::Included(&one), Bound::Included(&one), false)), Single(&one)),
             (
                 Range(R::new(Bound::Included(&one), Bound::Excluded(&one), true)),
                 Single(&FieldValue::NULL),
             ),
-            (
-                Range(R::new(Bound::Included(&one), Bound::Excluded(&one), false)),
-                Impossible,
-            ),
+            (Range(R::new(Bound::Included(&one), Bound::Excluded(&one), false)), Impossible),
             (
                 Range(R::new(Bound::Included(&two), Bound::Included(&one), true)),
                 Single(&FieldValue::NULL),
             ),
-            (
-                Range(R::new(Bound::Included(&two), Bound::Included(&one), false)),
-                Impossible,
-            ),
+            (Range(R::new(Bound::Included(&two), Bound::Included(&one), false)), Impossible),
             (
                 Range(R::new(Bound::Excluded(&two), Bound::Included(&one), true)),
                 Single(&FieldValue::NULL),
             ),
-            (
-                Range(R::new(Bound::Excluded(&two), Bound::Included(&one), false)),
-                Impossible,
-            ),
+            (Range(R::new(Bound::Excluded(&two), Bound::Included(&one), false)), Impossible),
             (
                 Range(R::new(Bound::Included(&two), Bound::Excluded(&one), true)),
                 Single(&FieldValue::NULL),
             ),
-            (
-                Range(R::new(Bound::Included(&two), Bound::Excluded(&one), false)),
-                Impossible,
-            ),
+            (Range(R::new(Bound::Included(&two), Bound::Excluded(&one), false)), Impossible),
             (
                 Range(R::new(Bound::Excluded(&two), Bound::Excluded(&one), true)),
                 Single(&FieldValue::NULL),
             ),
-            (
-                Range(R::new(Bound::Excluded(&two), Bound::Excluded(&one), false)),
-                Impossible,
-            ),
+            (Range(R::new(Bound::Excluded(&two), Bound::Excluded(&one), false)), Impossible),
         ];
 
         for (unnormalized, expected) in test_cases {
             let mut base = unnormalized.clone();
             base.normalize();
 
-            assert_eq!(
-                expected, base,
-                "{unnormalized:?}.normalize() = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{unnormalized:?}.normalize() = {base:?} != {expected:?}");
         }
     }
 
@@ -1077,16 +938,8 @@ mod tests {
         let test_cases = [
             //
             // Causing a Multiple to lose all its elements turns it into Impossible
-            (
-                Multiple(vec![&one, &two, &three]),
-                Single(&four),
-                Impossible,
-            ),
-            (
-                Multiple(vec![&one, &two]),
-                Multiple(vec![&three, &four]),
-                Impossible,
-            ),
+            (Multiple(vec![&one, &two, &three]), Single(&four), Impossible),
+            (Multiple(vec![&one, &two]), Multiple(vec![&three, &four]), Impossible),
             (
                 Multiple(vec![&one, &two]),
                 Range(R::with_start(Bound::Included(&three), true)),
@@ -1104,16 +957,8 @@ mod tests {
             ),
             //
             // Causing a Multiple to lose all but one of its elements turns it into Single
-            (
-                Multiple(vec![&one, &two, &three]),
-                Single(&two),
-                Single(&two),
-            ),
-            (
-                Multiple(vec![&one, &two, &three]),
-                Multiple(vec![&two, &four]),
-                Single(&two),
-            ),
+            (Multiple(vec![&one, &two, &three]), Single(&two), Single(&two)),
+            (Multiple(vec![&one, &two, &three]), Multiple(vec![&two, &four]), Single(&two)),
             (
                 Multiple(vec![&two, &three, &FieldValue::NULL]),
                 Range(R::with_end(Bound::Included(&two), false)),
@@ -1129,17 +974,11 @@ mod tests {
         for (original, intersected, expected) in test_cases {
             let mut base = original.clone();
             base.intersect(intersected.clone());
-            assert_eq!(
-                expected, base,
-                "{original:?} + {intersected:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{original:?} + {intersected:?} = {base:?} != {expected:?}");
 
             let mut base = intersected.clone();
             base.intersect(original.clone());
-            assert_eq!(
-                expected, base,
-                "{intersected:?} + {original:?} = {base:?} != {expected:?}"
-            );
+            assert_eq!(expected, base, "{intersected:?} + {original:?} = {base:?} != {expected:?}");
         }
     }
 
@@ -1159,11 +998,7 @@ mod tests {
             let unsigned_one = FieldValue::Uint64(1);
             let unsigned_three = FieldValue::Uint64(3);
             let test_data = [
-                Range(R::new(
-                    Bound::Excluded(&signed_one),
-                    Bound::Excluded(&signed_three),
-                    false,
-                )),
+                Range(R::new(Bound::Excluded(&signed_one), Bound::Excluded(&signed_three), false)),
                 Range(R::new(
                     Bound::Excluded(&unsigned_one),
                     Bound::Excluded(&unsigned_three),
@@ -1199,22 +1034,10 @@ mod tests {
                 (Range(R::full_non_null()), &FieldValue::Int64(i64::MAX)),
                 (Range(R::full_non_null()), &FieldValue::Uint64(u64::MIN)),
                 (Range(R::full_non_null()), &FieldValue::Uint64(u64::MAX)),
-                (
-                    Range(R::with_start(Bound::Excluded(&signed_one), false)),
-                    &signed_two,
-                ),
-                (
-                    Range(R::with_start(Bound::Excluded(&unsigned_one), false)),
-                    &unsigned_two,
-                ),
-                (
-                    Range(R::with_end(Bound::Excluded(&signed_two), false)),
-                    &signed_one,
-                ),
-                (
-                    Range(R::with_end(Bound::Excluded(&unsigned_two), false)),
-                    &unsigned_one,
-                ),
+                (Range(R::with_start(Bound::Excluded(&signed_one), false)), &signed_two),
+                (Range(R::with_start(Bound::Excluded(&unsigned_one), false)), &unsigned_two),
+                (Range(R::with_end(Bound::Excluded(&signed_two), false)), &signed_one),
+                (Range(R::with_end(Bound::Excluded(&unsigned_two), false)), &unsigned_one),
                 (
                     Range(R::new(
                         Bound::Included(&unsigned_one),

--- a/trustfall_core/src/interpreter/hints/dynamic.rs
+++ b/trustfall_core/src/interpreter/hints/dynamic.rs
@@ -191,13 +191,7 @@ impl<'a> DynamicallyResolvedValue<'a> {
         operation: Operation<(), ()>,
         initial_candidate: CandidateValue<FieldValue>,
     ) -> Self {
-        Self {
-            query,
-            resolve_on_component,
-            field,
-            operation,
-            initial_candidate,
-        }
+        Self { query, resolve_on_component, field, operation, initial_candidate }
     }
 
     #[allow(dead_code)] // false-positive: dead in the bin target, not dead in the lib
@@ -247,16 +241,13 @@ impl<'a> DynamicallyResolvedValue<'a> {
             + 'vertex,
     ) -> ContextOutcomeIterator<'vertex, AdapterT::Vertex, VertexIterator<'vertex, AdapterT::Vertex>>
     {
-        Box::new(
-            self.resolve(adapter, contexts)
-                .map(move |(ctx, candidate)| {
-                    let neighbors = match ctx.active_vertex.as_ref() {
-                        Some(vertex) => neighbor_resolver(vertex, candidate),
-                        None => Box::new(std::iter::empty()),
-                    };
-                    (ctx, neighbors)
-                }),
-        )
+        Box::new(self.resolve(adapter, contexts).map(move |(ctx, candidate)| {
+            let neighbors = match ctx.active_vertex.as_ref() {
+                Some(vertex) => neighbor_resolver(vertex, candidate),
+                None => Box::new(std::iter::empty()),
+            };
+            (ctx, neighbors)
+        }))
     }
 
     fn compute_candidate_from_tagged_value<'vertex, AdapterT: Adapter<'vertex>>(
@@ -265,9 +256,7 @@ impl<'a> DynamicallyResolvedValue<'a> {
         adapter: &AdapterT,
         contexts: ContextIterator<'vertex, AdapterT::Vertex>,
     ) -> ContextOutcomeIterator<'vertex, AdapterT::Vertex, CandidateValue<FieldValue>> {
-        let mut carrier = QueryCarrier {
-            query: Some(self.query),
-        };
+        let mut carrier = QueryCarrier { query: Some(self.query) };
         let iterator = compute_context_field_with_separate_value(
             adapter,
             &mut carrier,

--- a/trustfall_core/src/interpreter/hints/filters.rs
+++ b/trustfall_core/src/interpreter/hints/filters.rs
@@ -72,12 +72,10 @@ pub(super) fn candidate_from_statically_evaluated_filters<'a, 'b, T: Debug + Clo
         } else {
             CandidateValue::Range(Range::full_non_null())
         };
-        candidates
-            .into_iter()
-            .fold(initial_candidate, |mut acc, e| {
-                acc.intersect(e);
-                acc
-            })
+        candidates.into_iter().fold(initial_candidate, |mut acc, e| {
+            acc.intersect(e);
+            acc
+        })
     };
     candidate.normalize();
 
@@ -103,20 +101,15 @@ pub(super) fn candidate_from_statically_evaluated_filters<'a, 'b, T: Debug + Clo
     // a `!=` or equivalent filter operation.
     let disallowed_values = filters_and_values
         .iter()
-        .filter_map(
-            |(op, value)| -> Option<Box<dyn Iterator<Item = &FieldValue>>> {
-                match op {
-                    Operation::NotEquals(..) => Some(Box::new(std::iter::once(*value))),
-                    Operation::NotOneOf(..) => Some(Box::new(
-                        value
-                            .as_slice()
-                            .expect("not_one_of operand was not a list")
-                            .iter(),
-                    )),
-                    _ => None,
-                }
-            },
-        )
+        .filter_map(|(op, value)| -> Option<Box<dyn Iterator<Item = &FieldValue>>> {
+            match op {
+                Operation::NotEquals(..) => Some(Box::new(std::iter::once(*value))),
+                Operation::NotOneOf(..) => Some(Box::new(
+                    value.as_slice().expect("not_one_of operand was not a list").iter(),
+                )),
+                _ => None,
+            }
+        })
         .flatten();
     for disallowed in disallowed_values {
         candidate.exclude_single_value(&disallowed);
@@ -131,10 +124,8 @@ pub(super) fn fold_requires_at_least_one_element(
     query_variables: &BTreeMap<Arc<str>, FieldValue>,
     fold: &IRFold,
 ) -> bool {
-    let relevant_filters = fold
-        .post_filters
-        .iter()
-        .filter(|op| matches!(op.left(), FoldSpecificFieldKind::Count));
+    let relevant_filters =
+        fold.post_filters.iter().filter(|op| matches!(op.left(), FoldSpecificFieldKind::Count));
     let is_subject_field_nullable = false; // the "count" value can't be null
     candidate_from_statically_evaluated_filters(
         relevant_filters,

--- a/trustfall_core/src/interpreter/hints/mod.rs
+++ b/trustfall_core/src/interpreter/hints/mod.rs
@@ -66,11 +66,7 @@ pub struct ResolveEdgeInfo {
 
 impl ResolveInfo {
     pub(crate) fn new(query: InterpretedQuery, current_vid: Vid, vertex_completed: bool) -> Self {
-        Self {
-            query,
-            current_vid,
-            vertex_completed,
-        }
+        Self { query, current_vid, vertex_completed }
     }
 
     pub(crate) fn into_inner(self) -> InterpretedQuery {
@@ -182,12 +178,7 @@ impl ResolveEdgeInfo {
         target_vid: Vid,
         crossing_eid: Eid,
     ) -> Self {
-        Self {
-            query,
-            current_vid,
-            target_vid,
-            crossing_eid,
-        }
+        Self { query, current_vid, target_vid, crossing_eid }
     }
 
     pub(crate) fn into_inner(self) -> InterpretedQuery {
@@ -449,10 +440,7 @@ impl InternalVertexInfo for NeighborInfo {
 /// With recursions to depth 2+, there are "middle" layers of vertices that don't have to satisfy
 /// the filters (and will be filtered out) but can still have more edge expansions in the recursion.
 fn check_locally_non_binding_filters_for_edge(edge: &IREdge) -> bool {
-    edge.recursive
-        .as_ref()
-        .map(|r| r.depth.get() >= 2)
-        .unwrap_or(false)
+    edge.recursive.as_ref().map(|r| r.depth.get() >= 2).unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/trustfall_core/src/interpreter/hints/tests/mod.rs
+++ b/trustfall_core/src/interpreter/hints/tests/mod.rs
@@ -22,10 +22,7 @@ struct TrackCalls<F> {
 
 impl<F> TrackCalls<F> {
     fn new_underlying(underlying: F) -> Self {
-        Self {
-            underlying: Some(underlying),
-            calls: 0,
-        }
+        Self { underlying: Some(underlying), calls: 0 }
     }
 }
 
@@ -87,8 +84,7 @@ impl<'a> Adapter<'a> for TestAdapter {
             x.call(resolve_info);
         }
         drop(map_ref);
-        self.inner
-            .resolve_starting_vertices(edge_name, parameters, resolve_info)
+        self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
     }
 
     fn resolve_property(
@@ -103,8 +99,7 @@ impl<'a> Adapter<'a> for TestAdapter {
             x.call(resolve_info);
         }
         drop(map_ref);
-        self.inner
-            .resolve_property(contexts, type_name, property_name, resolve_info)
+        self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
     }
 
     fn resolve_neighbors(
@@ -120,8 +115,7 @@ impl<'a> Adapter<'a> for TestAdapter {
             x.call(resolve_info);
         }
         drop(map_ref);
-        self.inner
-            .resolve_neighbors(contexts, type_name, edge_name, parameters, resolve_info)
+        self.inner.resolve_neighbors(contexts, type_name, edge_name, parameters, resolve_info)
     }
 
     fn resolve_coercion(
@@ -136,8 +130,7 @@ impl<'a> Adapter<'a> for TestAdapter {
             x.call(resolve_info);
         }
         drop(map_ref);
-        self.inner
-            .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+        self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
     }
 }
 
@@ -164,11 +157,7 @@ fn run_query<A: Adapter<'static> + 'static>(adapter: A, input_name: &str) -> Arc
         adapter.clone(),
         Arc::new(input.ir_query.try_into().unwrap()),
         Arc::new(
-            input
-                .arguments
-                .iter()
-                .map(|(k, v)| (Arc::from(k.to_owned()), v.clone()))
-                .collect(),
+            input.arguments.iter().map(|(k, v)| (Arc::from(k.to_owned()), v.clone())).collect(),
         ),
     )
     .unwrap()
@@ -1218,10 +1207,7 @@ mod dynamic_property_values {
 
     impl<F> TrackCalls<F> {
         fn new_underlying(underlying: F) -> Self {
-            Self {
-                underlying,
-                calls: 0,
-            }
+            Self { underlying, calls: 0 }
         }
     }
 
@@ -1285,8 +1271,7 @@ mod dynamic_property_values {
                 let _ = x.call(&self.inner, Box::new(std::iter::empty()), resolve_info);
             }
             drop(map_ref);
-            self.inner
-                .resolve_starting_vertices(edge_name, parameters, resolve_info)
+            self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info)
         }
 
         fn resolve_property(
@@ -1301,8 +1286,7 @@ mod dynamic_property_values {
                 contexts = x.call(&self.inner, contexts, resolve_info);
             }
             drop(map_ref);
-            self.inner
-                .resolve_property(contexts, type_name, property_name, resolve_info)
+            self.inner.resolve_property(contexts, type_name, property_name, resolve_info)
         }
 
         fn resolve_neighbors(
@@ -1319,8 +1303,7 @@ mod dynamic_property_values {
                 contexts = x.call(&self.inner, contexts, resolve_info);
             }
             drop(map_ref);
-            self.inner
-                .resolve_neighbors(contexts, type_name, edge_name, parameters, resolve_info)
+            self.inner.resolve_neighbors(contexts, type_name, edge_name, parameters, resolve_info)
         }
 
         fn resolve_coercion(
@@ -1335,8 +1318,7 @@ mod dynamic_property_values {
                 contexts = x.call(&self.inner, contexts, resolve_info);
             }
             drop(map_ref);
-            self.inner
-                .resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
+            self.inner.resolve_coercion(contexts, type_name, coerce_to_type, resolve_info)
         }
     }
 

--- a/trustfall_core/src/interpreter/hints/vertex_info.rs
+++ b/trustfall_core/src/interpreter/hints/vertex_info.rs
@@ -241,10 +241,8 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
         // - a `!=` filter,
         // breaking ties based on which filter was specified first.
         let filter_to_use = {
-            relevant_filters
-                .iter()
-                .find(|op| matches!(op, Operation::Equals(..)))
-                .unwrap_or_else(|| {
+            relevant_filters.iter().find(|op| matches!(op, Operation::Equals(..))).unwrap_or_else(
+                || {
                     relevant_filters
                         .iter()
                         .find(|op| matches!(op, Operation::OneOf(..)))
@@ -262,7 +260,8 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
                                 })
                                 .unwrap_or(first_filter)
                         })
-                })
+                },
+            )
         };
 
         let field = filter_to_use
@@ -327,10 +326,7 @@ fn filters_on_local_property<'a: 'b, 'b>(
     vertex: &'a IRVertex,
     property_name: &'b str,
 ) -> impl Iterator<Item = &'a Operation<LocalField, Argument>> + 'b {
-    vertex
-        .filters
-        .iter()
-        .filter(move |op| op.left().field_name.as_ref() == property_name)
+    vertex.filters.iter().filter(move |op| op.left().field_name.as_ref() == property_name)
 }
 
 fn compute_statically_known_candidate<'a, 'b>(
@@ -392,10 +388,8 @@ mod tests {
             variable_type: list_int_type.clone(),
         });
 
-        let local_field = LocalField {
-            field_name: Arc::from("my_field"),
-            field_type: nullable_int_type.clone(),
-        };
+        let local_field =
+            LocalField { field_name: Arc::from("my_field"), field_type: nullable_int_type.clone() };
 
         let variables = btreemap! {
             first => FieldValue::Int64(1),
@@ -517,16 +511,10 @@ mod tests {
             ),
             //
             // `!= 1` by itself doesn't produce any candidates
-            (
-                vec![Operation::NotEquals(local_field.clone(), first_var.clone())],
-                None,
-            ),
+            (vec![Operation::NotEquals(local_field.clone(), first_var.clone())], None),
             //
             // `not_one_of [1, 2]` by itself doesn't produce any candidates
-            (
-                vec![Operation::NotEquals(local_field.clone(), list_var.clone())],
-                None,
-            ),
+            (vec![Operation::NotEquals(local_field.clone(), list_var.clone())], None),
         ];
 
         for (filters, expected_output) in test_data {
@@ -561,10 +549,8 @@ mod tests {
             variable_type: int_type.clone(),
         });
 
-        let local_field = LocalField {
-            field_name: Arc::from("my_field"),
-            field_type: int_type.clone(),
-        };
+        let local_field =
+            LocalField { field_name: Arc::from("my_field"), field_type: int_type.clone() };
 
         let variables = btreemap! {
             first => FieldValue::Int64(1),
@@ -574,20 +560,14 @@ mod tests {
             // The local field is non-nullable.
             // When we apply a range bound on the field, the range must be non-nullable too.
             (
-                vec![Operation::GreaterThanOrEqual(
-                    local_field.clone(),
-                    first_var.clone(),
-                )],
+                vec![Operation::GreaterThanOrEqual(local_field.clone(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Included(&variables["first"]),
                     false,
                 ))),
             ),
             (
-                vec![Operation::GreaterThan(
-                    local_field.clone(),
-                    first_var.clone(),
-                )],
+                vec![Operation::GreaterThan(local_field.clone(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Excluded(&variables["first"]),
                     false,
@@ -601,10 +581,7 @@ mod tests {
                 ))),
             ),
             (
-                vec![Operation::LessThanOrEqual(
-                    local_field.clone(),
-                    first_var.clone(),
-                )],
+                vec![Operation::LessThanOrEqual(local_field.clone(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_end(
                     Bound::Included(&variables["first"]),
                     false,

--- a/trustfall_core/src/interpreter/mod.rs
+++ b/trustfall_core/src/interpreter/mod.rs
@@ -195,9 +195,7 @@ impl<Vertex: Clone + Debug> DataContext<Vertex> {
     }
 
     fn record_vertex(&mut self, vid: Vid) {
-        self.vertices
-            .insert_or_error(vid, self.active_vertex.clone())
-            .unwrap();
+        self.vertices.insert_or_error(vid, self.active_vertex.clone()).unwrap();
     }
 
     fn activate_vertex(self, vid: &Vid) -> DataContext<Vertex> {
@@ -351,10 +349,7 @@ impl InterpretedQuery {
         }
         if !missing_arguments.is_empty() {
             errors.push(QueryArgumentsError::MissingArguments(
-                missing_arguments
-                    .into_iter()
-                    .map(|x| x.to_string())
-                    .collect(),
+                missing_arguments.into_iter().map(|x| x.to_string()).collect(),
             ));
         }
 
@@ -365,18 +360,12 @@ impl InterpretedQuery {
             .collect_vec();
         if !unused_arguments.is_empty() {
             errors.push(QueryArgumentsError::UnusedArguments(
-                unused_arguments
-                    .into_iter()
-                    .map(|x| x.to_string())
-                    .collect(),
+                unused_arguments.into_iter().map(|x| x.to_string()).collect(),
             ));
         }
 
         if errors.is_empty() {
-            Ok(Self {
-                indexed_query,
-                arguments,
-            })
+            Ok(Self { indexed_query, arguments })
         } else {
             Err(errors.into())
         }

--- a/trustfall_core/src/interpreter/replay.rs
+++ b/trustfall_core/src/interpreter/replay.rs
@@ -60,9 +60,7 @@ where
             .expect("Expected to have an item but found none.");
         assert_eq!(
             self.parent_opid,
-            trace_op
-                .parent_opid
-                .expect("Expected an operation with a parent_opid."),
+            trace_op.parent_opid.expect("Expected an operation with a parent_opid."),
             "Expected parent_opid {:?} did not match operation {:#?}",
             self.parent_opid,
             trace_op,
@@ -106,9 +104,7 @@ where
                 .expect("Expected to have an item but found none.");
             assert_eq!(
                 self.parent_opid,
-                input_op
-                    .parent_opid
-                    .expect("Expected an operation with a parent_opid."),
+                input_op.parent_opid.expect("Expected an operation with a parent_opid."),
                 "Expected parent_opid {:?} did not match operation {:#?}",
                 self.parent_opid,
                 input_op,
@@ -121,9 +117,7 @@ where
                     .expect("Expected to have an item but found none.");
                 assert_eq!(
                     self.parent_opid,
-                    input_op
-                        .parent_opid
-                        .expect("Expected an operation with a parent_opid."),
+                    input_op.parent_opid.expect("Expected an operation with a parent_opid."),
                     "Expected parent_opid {:?} did not match operation {:#?}",
                     self.parent_opid,
                     input_op,
@@ -186,9 +180,7 @@ where
                 .expect("Expected to have an item but found none.");
             assert_eq!(
                 self.parent_opid,
-                input_op
-                    .parent_opid
-                    .expect("Expected an operation with a parent_opid."),
+                input_op.parent_opid.expect("Expected an operation with a parent_opid."),
                 "Expected parent_opid {:?} did not match operation {:#?}",
                 self.parent_opid,
                 input_op,
@@ -201,9 +193,7 @@ where
                     .expect("Expected to have an item but found none.");
                 assert_eq!(
                     self.parent_opid,
-                    input_op
-                        .parent_opid
-                        .expect("Expected an operation with a parent_opid."),
+                    input_op.parent_opid.expect("Expected an operation with a parent_opid."),
                     "Expected parent_opid {:?} did not match operation {:#?}",
                     self.parent_opid,
                     input_op,
@@ -266,9 +256,7 @@ where
                 .expect("Expected to have an item but found none.");
             assert_eq!(
                 self.parent_opid,
-                input_op
-                    .parent_opid
-                    .expect("Expected an operation with a parent_opid."),
+                input_op.parent_opid.expect("Expected an operation with a parent_opid."),
                 "Expected parent_opid {:?} did not match operation {:#?}",
                 self.parent_opid,
                 input_op,
@@ -281,9 +269,7 @@ where
                     .expect("Expected to have an item but found none.");
                 assert_eq!(
                     self.parent_opid,
-                    input_op
-                        .parent_opid
-                        .expect("Expected an operation with a parent_opid."),
+                    input_op.parent_opid.expect("Expected an operation with a parent_opid."),
                     "Expected parent_opid {:?} did not match operation {:#?}",
                     self.parent_opid,
                     input_op,
@@ -353,9 +339,7 @@ where
         assert!(!self.exhausted);
         assert_eq!(
             self.parent_iterator_opid,
-            trace_op
-                .parent_opid
-                .expect("Expected an operation with a parent_opid."),
+            trace_op.parent_opid.expect("Expected an operation with a parent_opid."),
             "Expected parent_opid {:?} did not match operation {:#?}",
             self.parent_iterator_opid,
             trace_op,
@@ -508,17 +492,11 @@ pub fn assert_interpreted_results<'query, 'trace, Vertex>(
     'trace: 'query,
 {
     let next_op = Rc::new(RefCell::new(trace.ops.iter()));
-    let trace_reader_adapter = Arc::new(TraceReaderAdapter {
-        next_op: next_op.clone(),
-    });
+    let trace_reader_adapter = Arc::new(TraceReaderAdapter { next_op: next_op.clone() });
 
     let query: Arc<IndexedQuery> = Arc::new(trace.ir_query.clone().try_into().unwrap());
     let arguments = Arc::new(
-        trace
-            .arguments
-            .iter()
-            .map(|(k, v)| (Arc::from(k.to_owned()), v.clone()))
-            .collect(),
+        trace.arguments.iter().map(|(k, v)| (Arc::from(k.to_owned()), v.clone())).collect(),
     );
     let mut trace_iter = interpret_ir(trace_reader_adapter, query, arguments).unwrap();
     let mut expected_iter = expected_results.iter();

--- a/trustfall_core/src/interpreter/trace.rs
+++ b/trustfall_core/src/interpreter/trace.rs
@@ -36,21 +36,13 @@ where
 {
     #[allow(dead_code)]
     pub fn new(ir_query: IRQuery, arguments: BTreeMap<String, FieldValue>) -> Self {
-        Self {
-            ops: Default::default(),
-            ir_query,
-            arguments,
-        }
+        Self { ops: Default::default(), ir_query, arguments }
     }
 
     pub fn record(&mut self, content: TraceOpContent<Vertex>, parent: Option<Opid>) -> Opid {
         let next_opid = Opid(NonZeroUsize::new(self.ops.len() + 1).unwrap());
 
-        let op = TraceOp {
-            opid: next_opid,
-            parent_opid: parent,
-            content,
-        };
+        let op = TraceOp { opid: next_opid, parent_opid: parent, content };
         self.ops.insert_or_error(next_opid, op).unwrap();
         next_opid
     }
@@ -129,10 +121,7 @@ fn make_iter_with_end_action<T, I: Iterator<Item = T>, F: FnOnce()>(
     inner: I,
     on_end: F,
 ) -> OnIterEnd<T, I, F> {
-    OnIterEnd {
-        inner,
-        on_end_func: Some(on_end),
-    }
+    OnIterEnd { inner, on_end_func: Some(on_end) }
 }
 
 pub struct PreActionIter<T, I: Iterator<Item = T>, F: Fn()> {
@@ -177,11 +166,7 @@ where
     AdapterT::Vertex: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + 'vertex,
 {
     pub fn new(adapter: AdapterT, tracer: Rc<RefCell<Trace<AdapterT::Vertex>>>) -> Self {
-        Self {
-            tracer,
-            inner: adapter,
-            _phantom: PhantomData,
-        }
+        Self { tracer, inner: adapter, _phantom: PhantomData }
     }
 
     pub fn finish(self) -> Trace<AdapterT::Vertex> {
@@ -231,9 +216,7 @@ where
         );
         drop(trace);
 
-        let inner_iter = self
-            .inner
-            .resolve_starting_vertices(edge_name, parameters, resolve_info);
+        let inner_iter = self.inner.resolve_starting_vertices(edge_name, parameters, resolve_info);
         let tracer_ref_1 = self.tracer.clone();
         let tracer_ref_2 = self.tracer.clone();
         Box::new(
@@ -295,8 +278,7 @@ where
             }),
         );
         let inner_iter =
-            self.inner
-                .resolve_property(wrapped_contexts, type_name, property_name, resolve_info);
+            self.inner.resolve_property(wrapped_contexts, type_name, property_name, resolve_info);
 
         let tracer_ref_4 = self.tracer.clone();
         let tracer_ref_5 = self.tracer.clone();
@@ -455,8 +437,7 @@ where
             }),
         );
         let inner_iter =
-            self.inner
-                .resolve_coercion(wrapped_contexts, type_name, coerce_to_type, resolve_info);
+            self.inner.resolve_coercion(wrapped_contexts, type_name, coerce_to_type, resolve_info);
 
         let tracer_ref_4 = self.tracer.clone();
         let tracer_ref_5 = self.tracer.clone();

--- a/trustfall_core/src/ir/indexed.rs
+++ b/trustfall_core/src/ir/indexed.rs
@@ -79,12 +79,7 @@ impl TryFrom<IRQuery> for IndexedQuery {
             &mut vec![],
         )?;
 
-        Ok(Self {
-            ir_query,
-            vids,
-            eids,
-            outputs,
-        })
+        Ok(Self { ir_query, vids, eids, outputs })
     }
 }
 
@@ -171,9 +166,8 @@ fn add_data_from_component(
         let output_vid = field.vertex_id;
 
         // the output must be from a vertex in this component
-        let output_component = vids
-            .get(&output_vid)
-            .ok_or(InvalidIRQueryError::GetBetterVariant(1))?;
+        let output_component =
+            vids.get(&output_vid).ok_or(InvalidIRQueryError::GetBetterVariant(1))?;
         if !ptr::eq(component.as_ref(), output_component.as_ref()) {
             return Err(InvalidIRQueryError::GetBetterVariant(2));
         }
@@ -185,11 +179,7 @@ fn add_data_from_component(
             &component_optional_vertices,
             are_folds_optional,
         );
-        let output = Output {
-            name: output_name.clone(),
-            value_type: output_type,
-            vid: output_vid,
-        };
+        let output = Output { name: output_name.clone(), value_type: output_type, vid: output_vid };
         let existing = outputs.insert(output_name, output);
         if existing.is_some() {
             return Err(InvalidIRQueryError::GetBetterVariant(3));
@@ -203,15 +193,13 @@ fn add_data_from_component(
         }
 
         // the edge's endpoints must be vertices from this component
-        let from_component = vids
-            .get(&edge.from_vid)
-            .ok_or(InvalidIRQueryError::GetBetterVariant(5))?;
+        let from_component =
+            vids.get(&edge.from_vid).ok_or(InvalidIRQueryError::GetBetterVariant(5))?;
         if !ptr::eq(component.as_ref(), from_component.as_ref()) {
             return Err(InvalidIRQueryError::GetBetterVariant(6));
         }
-        let to_component = vids
-            .get(&edge.to_vid)
-            .ok_or(InvalidIRQueryError::GetBetterVariant(7))?;
+        let to_component =
+            vids.get(&edge.to_vid).ok_or(InvalidIRQueryError::GetBetterVariant(7))?;
         if !ptr::eq(component.as_ref(), to_component.as_ref()) {
             return Err(InvalidIRQueryError::GetBetterVariant(8));
         }
@@ -229,9 +217,8 @@ fn add_data_from_component(
         }
 
         // The folded edge's "from" vertex must be from this component.
-        let from_component = vids
-            .get(&fold.from_vid)
-            .ok_or(InvalidIRQueryError::GetBetterVariant(11))?;
+        let from_component =
+            vids.get(&fold.from_vid).ok_or(InvalidIRQueryError::GetBetterVariant(11))?;
         if !ptr::eq(component.as_ref(), from_component.as_ref()) {
             return Err(InvalidIRQueryError::GetBetterVariant(12));
         }
@@ -257,11 +244,7 @@ fn add_data_from_component(
             outputs
                 .insert_or_error(
                     name.clone(),
-                    Output {
-                        name: name.clone(),
-                        value_type: output_type,
-                        vid: fold.to_vid,
-                    },
+                    Output { name: name.clone(), value_type: output_type, vid: fold.to_vid },
                 )
                 .map_err(|_| InvalidIRQueryError::GetBetterVariant(15))?;
         }
@@ -275,9 +258,7 @@ fn add_data_from_component(
             &fold.component,
             are_folds_optional,
         )?;
-        are_folds_optional
-            .pop()
-            .expect("pushed value is no longer present");
+        are_folds_optional.pop().expect("pushed value is no longer present");
     }
 
     Ok(())

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -232,10 +232,8 @@ pub enum FoldSpecificFieldKind {
     Count, // Represents the number of elements in an IRFold's component.
 }
 
-static NON_NULL_INT_TYPE: Lazy<Type> = Lazy::new(|| Type {
-    base: BaseType::Named(Name::new("Int")),
-    nullable: false,
-});
+static NON_NULL_INT_TYPE: Lazy<Type> =
+    Lazy::new(|| Type { base: BaseType::Named(Name::new("Int")), nullable: false });
 
 impl FoldSpecificFieldKind {
     pub fn field_type(&self) -> &Type {
@@ -624,14 +622,12 @@ impl<LeftT: NamedTypedValue> Operation<LeftT, Argument> {
                 if left_type.nullable {
                     Ok(())
                 } else {
-                    Err(vec![
-                        FilterTypeError::NonNullableTypeFilteredForNullability(
-                            self.operation_name().to_owned(),
-                            left.named().to_string(),
-                            left_type.to_string(),
-                            matches!(self, Operation::IsNotNull(..)),
-                        ),
-                    ])
+                    Err(vec![FilterTypeError::NonNullableTypeFilteredForNullability(
+                        self.operation_name().to_owned(),
+                        left.named().to_string(),
+                        left_type.to_string(),
+                        matches!(self, Operation::IsNotNull(..)),
+                    )])
                 }
             }
             Operation::Equals(_, _) | Operation::NotEquals(_, _) => {
@@ -881,12 +877,7 @@ mod tests {
     fn serialize_then_deserialize_enum() {
         let value = FieldValue::Enum("foo".into());
         let deserialized: FieldValue = serialize_then_deserialize(&value);
-        assert_eq!(
-            value,
-            deserialized,
-            "Serialized as: {}",
-            ron::to_string(&value).unwrap()
-        );
+        assert_eq!(value, deserialized, "Serialized as: {}", ron::to_string(&value).unwrap());
     }
 
     #[test]
@@ -897,47 +888,27 @@ mod tests {
             FieldValue::String("foo".into()),
         ]));
         let deserialized: FieldValue = serialize_then_deserialize(&value);
-        assert_eq!(
-            value,
-            deserialized,
-            "Serialized as: {}",
-            ron::to_string(&value).unwrap()
-        );
+        assert_eq!(value, deserialized, "Serialized as: {}", ron::to_string(&value).unwrap());
     }
 
     #[test]
     fn serialize_then_deserialize_float() {
         let value = FieldValue::Float64(1.0);
         let deserialized: FieldValue = serialize_then_deserialize(&value);
-        assert_eq!(
-            value,
-            deserialized,
-            "Serialized as: {}",
-            ron::to_string(&value).unwrap()
-        );
+        assert_eq!(value, deserialized, "Serialized as: {}", ron::to_string(&value).unwrap());
     }
 
     #[test]
     fn serialize_then_deserialize_i64() {
         let value = FieldValue::Int64(-123);
         let deserialized: FieldValue = serialize_then_deserialize(&value);
-        assert_eq!(
-            value,
-            deserialized,
-            "Serialized as: {}",
-            ron::to_string(&value).unwrap()
-        );
+        assert_eq!(value, deserialized, "Serialized as: {}", ron::to_string(&value).unwrap());
     }
 
     #[test]
     fn serialize_then_deserialize_u64() {
         let value = FieldValue::Uint64((i64::MAX as u64) + 1);
         let deserialized: FieldValue = serialize_then_deserialize(&value);
-        assert_eq!(
-            value,
-            deserialized,
-            "Serialized as: {}",
-            ron::to_string(&value).unwrap()
-        );
+        assert_eq!(value, deserialized, "Serialized as: {}", ron::to_string(&value).unwrap());
     }
 }

--- a/trustfall_core/src/ir/serialization.rs
+++ b/trustfall_core/src/ir/serialization.rs
@@ -45,9 +45,7 @@ where
 {
     let mut serializer = serializer.serialize_map(Some(value.len()))?;
 
-    value
-        .iter()
-        .try_for_each(|(k, v)| serializer.serialize_entry(k, &v.to_string()))?;
+    value.iter().try_for_each(|(k, v)| serializer.serialize_entry(k, &v.to_string()))?;
 
     serializer.end()
 }

--- a/trustfall_core/src/ir/types.rs
+++ b/trustfall_core/src/ir/types.rs
@@ -171,20 +171,13 @@ pub fn intersect_types(left: &Type, right: &Type) -> Option<Type> {
     match (&left.base, &right.base) {
         (BaseType::Named(l), BaseType::Named(r)) => {
             if l == r {
-                Some(Type {
-                    base: left.base.clone(),
-                    nullable,
-                })
+                Some(Type { base: left.base.clone(), nullable })
             } else {
                 None
             }
         }
-        (BaseType::List(left), BaseType::List(right)) => {
-            intersect_types(left, right).map(|inner| Type {
-                base: BaseType::List(Box::new(inner)),
-                nullable,
-            })
-        }
+        (BaseType::List(left), BaseType::List(right)) => intersect_types(left, right)
+            .map(|inner| Type { base: BaseType::List(Box::new(inner)), nullable }),
         (BaseType::Named(_), BaseType::List(_)) | (BaseType::List(_), BaseType::Named(_)) => None,
     }
 }
@@ -230,9 +223,9 @@ pub fn is_argument_type_valid(variable_type: &Type, argument_value: &FieldValue)
             // This is a valid value only if the type is a list, and all the inner elements
             // are valid instances of the type inside the list.
             match &variable_type.base {
-                BaseType::List(inner) => nested_values
-                    .iter()
-                    .all(|value| is_argument_type_valid(inner.as_ref(), value)),
+                BaseType::List(inner) => {
+                    nested_values.iter().all(|value| is_argument_type_valid(inner.as_ref(), value))
+                }
                 BaseType::Named(_) => false,
             }
         }
@@ -258,18 +251,11 @@ mod tests {
         ];
         let non_nullable_types = nullable_types
             .iter()
-            .map(|t| Type {
-                base: t.base.clone(),
-                nullable: false,
-            })
+            .map(|t| Type { base: t.base.clone(), nullable: false })
             .collect_vec();
 
         for nullable_type in &nullable_types {
-            assert!(
-                is_argument_type_valid(nullable_type, &FieldValue::Null),
-                "{}",
-                nullable_type
-            );
+            assert!(is_argument_type_valid(nullable_type, &FieldValue::Null), "{}", nullable_type);
         }
         for non_nullable_type in &non_nullable_types {
             assert!(
@@ -298,10 +284,7 @@ mod tests {
 
         for value in &values {
             for matching_type in &matching_types {
-                assert!(
-                    is_argument_type_valid(matching_type, value),
-                    "{matching_type} {value:?}",
-                );
+                assert!(is_argument_type_valid(matching_type, value), "{matching_type} {value:?}",);
             }
             for non_matching_type in &non_matching_types {
                 assert!(
@@ -328,10 +311,7 @@ mod tests {
 
         for value in &values {
             for matching_type in &matching_types {
-                assert!(
-                    is_argument_type_valid(matching_type, value),
-                    "{matching_type} {value:?}",
-                );
+                assert!(is_argument_type_valid(matching_type, value), "{matching_type} {value:?}",);
             }
             for non_matching_type in &non_matching_types {
                 assert!(
@@ -344,10 +324,7 @@ mod tests {
 
     #[test]
     fn boolean_values_are_valid_only_for_boolean_type_regardless_of_nullability() {
-        let matching_types = [
-            Type::new("Boolean").unwrap(),
-            Type::new("Boolean!").unwrap(),
-        ];
+        let matching_types = [Type::new("Boolean").unwrap(), Type::new("Boolean!").unwrap()];
         let non_matching_types = [
             Type::new("Int").unwrap(),
             Type::new("[Boolean!]").unwrap(),
@@ -358,10 +335,7 @@ mod tests {
 
         for value in &values {
             for matching_type in &matching_types {
-                assert!(
-                    is_argument_type_valid(matching_type, value),
-                    "{matching_type} {value:?}",
-                );
+                assert!(is_argument_type_valid(matching_type, value), "{matching_type} {value:?}",);
             }
             for non_matching_type in &non_matching_types {
                 assert!(
@@ -416,16 +390,10 @@ mod tests {
         for value in &non_nullable_values {
             // Values without nulls match both the nullable and the non-nullable types.
             for matching_type in &nullable_contents_matching_types {
-                assert!(
-                    is_argument_type_valid(matching_type, value),
-                    "{matching_type} {value:?}",
-                );
+                assert!(is_argument_type_valid(matching_type, value), "{matching_type} {value:?}",);
             }
             for matching_type in &non_nullable_contents_matching_types {
-                assert!(
-                    is_argument_type_valid(matching_type, value),
-                    "{matching_type} {value:?}",
-                );
+                assert!(is_argument_type_valid(matching_type, value), "{matching_type} {value:?}",);
             }
 
             // Regardless of nulls, these types don't match.
@@ -440,10 +408,7 @@ mod tests {
         for value in &nullable_values {
             // Nullable values match only the nullable types.
             for matching_type in &nullable_contents_matching_types {
-                assert!(
-                    is_argument_type_valid(matching_type, value),
-                    "{matching_type} {value:?}",
-                );
+                assert!(is_argument_type_valid(matching_type, value), "{matching_type} {value:?}",);
             }
 
             // The nullable values don't match the non-nullable types.

--- a/trustfall_core/src/ir/value.rs
+++ b/trustfall_core/src/ir/value.rs
@@ -85,10 +85,7 @@ impl From<FieldValue> for TransparentValue {
             FieldValue::Boolean(x) => TransparentValue::Boolean(x),
             FieldValue::Enum(x) => TransparentValue::Enum(x),
             FieldValue::List(x) => TransparentValue::List(
-                x.iter()
-                    .map(|v| v.clone().into())
-                    .collect::<Vec<_>>()
-                    .into(),
+                x.iter().map(|v| v.clone().into()).collect::<Vec<_>>().into(),
             ),
         }
     }
@@ -104,12 +101,9 @@ impl From<TransparentValue> for FieldValue {
             TransparentValue::String(x) => FieldValue::String(x),
             TransparentValue::Boolean(x) => FieldValue::Boolean(x),
             TransparentValue::Enum(x) => FieldValue::Enum(x),
-            TransparentValue::List(x) => FieldValue::List(
-                x.iter()
-                    .map(|v| v.clone().into())
-                    .collect::<Vec<_>>()
-                    .into(),
-            ),
+            TransparentValue::List(x) => {
+                FieldValue::List(x.iter().map(|v| v.clone().into()).collect::<Vec<_>>().into())
+            }
         }
     }
 }
@@ -454,10 +448,7 @@ impl TryFrom<Value> for FieldValue {
             Value::Number(n) => convert_number_to_field_value(&n),
             Value::String(s) => Ok(Self::String(s.into())),
             Value::Boolean(b) => Ok(Self::Boolean(b)),
-            Value::List(l) => l
-                .into_iter()
-                .map(Self::try_from)
-                .collect::<Result<Self, _>>(),
+            Value::List(l) => l.into_iter().map(Self::try_from).collect::<Result<Self, _>>(),
             Value::Enum(n) => {
                 // We have an enum value, so we know the variant name but the variant on its own
                 // doesn't tell us the name of the enum type it belongs in. We'll have to determine
@@ -499,21 +490,12 @@ mod tests {
         test(Some::<i64>(123), FieldValue::Int64(123));
         test(Some::<u64>(123), FieldValue::Uint64(123));
 
-        test(
-            FiniteF64::try_from(3.15).unwrap(),
-            FieldValue::Float64(3.15),
-        );
+        test(FiniteF64::try_from(3.15).unwrap(), FieldValue::Float64(3.15));
 
         test("a &str", FieldValue::String("a &str".into()));
-        test(
-            "a String".to_string(),
-            FieldValue::String("a String".into()),
-        );
+        test("a String".to_string(), FieldValue::String("a String".into()));
 
-        test(
-            vec![1, 2],
-            FieldValue::List(vec![FieldValue::Int64(1), FieldValue::Int64(2)].into()),
-        );
+        test(vec![1, 2], FieldValue::List(vec![FieldValue::Int64(1), FieldValue::Int64(2)].into()));
 
         test(
             ["a String".to_string()].as_slice(),

--- a/trustfall_core/src/numbers_interpreter.rs
+++ b/trustfall_core/src/numbers_interpreter.rs
@@ -191,11 +191,8 @@ fn get_factors(primes: &BTreeSet<i64>, num: i64) -> BTreeSet<i64> {
             pos_factors
         }
         x if x >= 2 => {
-            let factors: BTreeSet<i64> = primes
-                .iter()
-                .copied()
-                .filter(|prime| num % *prime == 0)
-                .collect();
+            let factors: BTreeSet<i64> =
+                primes.iter().copied().filter(|prime| num % *prime == 0).collect();
             factors
         }
         _ => unreachable!(),
@@ -412,10 +409,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
                 })
             }
             _ => {
-                unreachable!(
-                    "Unexpected edge {} on vertex type {}",
-                    &edge_name, &type_name
-                );
+                unreachable!("Unexpected edge {} on vertex type {}", &edge_name, &type_name);
             }
         }
     }
@@ -428,9 +422,9 @@ impl<'a> Adapter<'a> for NumbersAdapter {
         resolve_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, Self::Vertex, bool> {
         match (type_name.as_ref(), coerce_to_type.as_ref()) {
-            ("Number" | "Named", "Prime") => resolve_coercion_with(contexts, |vertex| {
-                matches!(vertex, NumbersVertex::Prime(..))
-            }),
+            ("Number" | "Named", "Prime") => {
+                resolve_coercion_with(contexts, |vertex| matches!(vertex, NumbersVertex::Prime(..)))
+            }
             ("Number" | "Named", "Composite") => resolve_coercion_with(contexts, |vertex| {
                 matches!(vertex, NumbersVertex::Composite(..))
             }),
@@ -448,11 +442,7 @@ impl<'a> Adapter<'a> for NumbersAdapter {
                         | NumbersVertex::Neither(..)
                 )
             }),
-            _ => unimplemented!(
-                "Unexpected coercion attempted: {} {}",
-                type_name,
-                coerce_to_type
-            ),
+            _ => unimplemented!("Unexpected coercion attempted: {} {}", type_name, coerce_to_type),
         }
     }
 }

--- a/trustfall_core/src/schema/adapter/mod.rs
+++ b/trustfall_core/src/schema/adapter/mod.rs
@@ -64,9 +64,7 @@ impl<'a> SchemaAdapter<'a> {
     /// Make an adapter for querying the given Trustfall schema.
     #[inline(always)]
     pub fn new(schema_to_query: &'a Schema) -> Self {
-        Self {
-            schema: schema_to_query,
-        }
+        Self { schema: schema_to_query }
     }
 
     /// A schema that describes Trustfall schemas.
@@ -163,11 +161,7 @@ pub struct Property<'a> {
 impl<'a> Property<'a> {
     #[inline(always)]
     fn new(parent: &'a TypeDefinition, name: &'a str, type_: &'a Type) -> Self {
-        Self {
-            parent,
-            name,
-            type_,
-        }
+        Self { parent, name, type_ }
     }
 }
 
@@ -254,29 +248,21 @@ impl<'a> crate::interpreter::Adapter<'a> for SchemaAdapter<'a> {
                     let possibilities_as_owned_strings = possibilities
                         .iter()
                         .map(|el| {
-                            el.as_str()
-                                .expect("for name possibility to be a string")
-                                .to_string()
+                            el.as_str().expect("for name possibility to be a string").to_string()
                         })
                         .collect::<Vec<_>>();
 
                     let vertex_types = &self.schema.vertex_types;
 
-                    Box::new(
-                        possibilities_as_owned_strings
-                            .into_iter()
-                            .filter_map(move |wanted| {
-                                vertex_types.get(wanted.as_str()).and_then(|exact_wanted| {
-                                    if exact_wanted.name.node != root_query_type {
-                                        Some(SchemaVertex::VertexType(VertexType::new(
-                                            exact_wanted,
-                                        )))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            }),
-                    )
+                    Box::new(possibilities_as_owned_strings.into_iter().filter_map(move |wanted| {
+                        vertex_types.get(wanted.as_str()).and_then(|exact_wanted| {
+                            if exact_wanted.name.node != root_query_type {
+                                Some(SchemaVertex::VertexType(VertexType::new(exact_wanted)))
+                            } else {
+                                None
+                            }
+                        })
+                    }))
                 } else {
                     Box::new(self.schema.vertex_types.values().filter_map(move |v| {
                         (v.name.node != root_query_type)
@@ -346,10 +332,7 @@ impl<'a> crate::interpreter::Adapter<'a> for SchemaAdapter<'a> {
                         .as_ref()
                         .map(|v| {
                             let value = &v.node;
-                            value
-                                .clone()
-                                .try_into()
-                                .expect("failed to convert ConstValue")
+                            value.clone().try_into().expect("failed to convert ConstValue")
                         })
                         .or_else(|| {
                             // Nullable edge parameters have an implicit default value of `null`.

--- a/trustfall_core/src/schema/adapter/tests.rs
+++ b/trustfall_core/src/schema/adapter/tests.rs
@@ -75,11 +75,7 @@ fn check_vertex_type_properties_using_one_of() {
         .expect("execution error")
         .collect();
 
-    rows.sort_by(|a, b| {
-        a["property"]
-            .partial_cmp(&b["property"])
-            .expect("to be comparable")
-    });
+    rows.sort_by(|a, b| a["property"].partial_cmp(&b["property"]).expect("to be comparable"));
 
     let expected_rows = [
         btreemap! {
@@ -180,10 +176,9 @@ fn check_parameterized_edges() {
         parameter_default: Option<String>,
     }
 
-    let test_schema = Schema::parse(include_str!(
-        "../../../test_data/schemas/parameterized_edges.graphql"
-    ))
-    .unwrap();
+    let test_schema =
+        Schema::parse(include_str!("../../../test_data/schemas/parameterized_edges.graphql"))
+            .unwrap();
     let adapter = Arc::new(SchemaAdapter::new(&test_schema));
 
     let indexed = crate::frontend::parse(&SCHEMA, query).expect("not a valid query");

--- a/trustfall_core/src/schema/error.rs
+++ b/trustfall_core/src/schema/error.rs
@@ -8,10 +8,7 @@ pub enum InvalidSchemaError {
     #[error("Multiple schema errors: {0}")]
     MultipleErrors(DisplayVec<InvalidSchemaError>),
 
-    #[serde(
-        skip_deserializing,
-        serialize_with = "fail_serialize_schema_parse_error"
-    )]
+    #[serde(skip_deserializing, serialize_with = "fail_serialize_schema_parse_error")]
     #[error("Schema failed to parse.")]
     SchemaParseError(#[from] async_graphql_parser::Error),
 
@@ -148,7 +145,5 @@ fn fail_serialize_schema_parse_error<S: Serializer>(
     _: &async_graphql_parser::Error,
     _: S,
 ) -> Result<S::Ok, S::Error> {
-    Err(S::Error::custom(
-        "cannot serialize SchemaParseError error variant",
-    ))
+    Err(S::Error::custom("cannot serialize SchemaParseError error variant"))
 }

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -142,9 +142,7 @@ directive @transform(op: String!) on FIELD
 
                     match &node.kind {
                         TypeKind::Scalar => {
-                            scalars
-                                .insert_or_error(type_name.clone(), node.clone())
-                                .unwrap();
+                            scalars.insert_or_error(type_name.clone(), node.clone()).unwrap();
                         }
                         TypeKind::Object(_) | TypeKind::Interface(_) => {
                             match vertex_types.insert_or_error(type_name.clone(), node.clone()) {
@@ -194,12 +192,8 @@ directive @transform(op: String!) on FIELD
         }
 
         let schema = schema.expect("Schema definition was not present.");
-        let query_type_name = schema
-            .query
-            .as_ref()
-            .expect("No query type was declared in the schema")
-            .node
-            .as_ref();
+        let query_type_name =
+            schema.query.as_ref().expect("No query type was declared in the schema").node.as_ref();
         let query_type_definition = vertex_types
             .get(query_type_name)
             .expect("The query type set in the schema object was never defined.");
@@ -269,9 +263,7 @@ directive @transform(op: String!) on FIELD
 
         Some(self.vertex_types.iter().filter_map(move |(name, defn)| {
             if name.as_ref() == type_name
-                || get_vertex_type_implements(defn)
-                    .iter()
-                    .any(|x| x.node.as_ref() == type_name)
+                || get_vertex_type_implements(defn).iter().any(|x| x.node.as_ref() == type_name)
             {
                 Some(name.as_ref())
             } else {
@@ -359,11 +351,7 @@ fn check_type_and_property_and_edge_invariants(
                         type_name.to_string(),
                         field_defn.name.node.to_string(),
                         field_type.to_string(),
-                        field_defn
-                            .arguments
-                            .iter()
-                            .map(|x| x.node.name.node.to_string())
-                            .collect(),
+                        field_defn.arguments.iter().map(|x| x.node.name.node.to_string()).collect(),
                     ));
                 }
             } else if vertex_types.contains_key(base_named_type) {
@@ -536,10 +524,8 @@ fn check_required_transitive_implementations(
     let mut errors: Vec<InvalidSchemaError> = vec![];
 
     for (type_name, type_defn) in vertex_types {
-        let implementations: BTreeSet<&str> = get_vertex_type_implements(type_defn)
-            .iter()
-            .map(|x| x.node.as_ref())
-            .collect();
+        let implementations: BTreeSet<&str> =
+            get_vertex_type_implements(type_defn).iter().map(|x| x.node.as_ref()).collect();
 
         // Check the `implements` portion of the type definition.
         for implements_type in implementations.iter().copied() {
@@ -684,10 +670,7 @@ fn check_field_type_narrowing(
                             field_name.to_owned(),
                             type_name.to_string(),
                             implementation.to_owned(),
-                            missing_parameters
-                                .into_iter()
-                                .map(ToOwned::to_owned)
-                                .collect_vec(),
+                            missing_parameters.into_iter().map(ToOwned::to_owned).collect_vec(),
                         ));
                     }
 
@@ -703,10 +686,7 @@ fn check_field_type_narrowing(
                             field_name.to_owned(),
                             type_name.to_string(),
                             implementation.to_owned(),
-                            unexpected_parameters
-                                .into_iter()
-                                .map(ToOwned::to_owned)
-                                .collect_vec(),
+                            unexpected_parameters.into_iter().map(ToOwned::to_owned).collect_vec(),
                         ));
                     }
 
@@ -813,10 +793,8 @@ fn get_field_origins(
             };
             let parent_fields = get_vertex_type_fields(implemented_defn);
             for field in parent_fields {
-                let parent_field_origin = &field_origins[&(
-                    Arc::from(implemented_interface),
-                    Arc::from(field.node.name.node.as_ref()),
-                )];
+                let parent_field_origin = &field_origins
+                    [&(Arc::from(implemented_interface), Arc::from(field.node.name.node.as_ref()))];
 
                 implemented_fields
                     .entry(field.node.name.node.as_ref())
@@ -926,9 +904,6 @@ mod tests {
 
         let mut number_subtypes = schema.subtypes("Number").unwrap().collect_vec();
         number_subtypes.sort_unstable();
-        assert_eq!(
-            vec!["Composite", "Neither", "Number", "Prime"],
-            number_subtypes
-        );
+        assert_eq!(vec!["Composite", "Neither", "Number", "Prime"], number_subtypes);
     }
 }

--- a/trustfall_core/src/serialization/deserializers.rs
+++ b/trustfall_core/src/serialization/deserializers.rs
@@ -23,10 +23,7 @@ struct QueryResultMapDeserializer<I: Iterator<Item = (Arc<str>, FieldValue)>> {
 
 impl<I: Iterator<Item = (Arc<str>, FieldValue)>> QueryResultMapDeserializer<I> {
     fn new(iter: I) -> Self {
-        Self {
-            iter,
-            next_value: Default::default(),
-        }
+        Self { iter, next_value: Default::default() }
     }
 }
 
@@ -52,9 +49,7 @@ impl<'de> de::Deserializer<'de> for QueryResultDeserializer {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_map(QueryResultMapDeserializer::new(
-            self.query_result.into_iter(),
-        ))
+        visitor.visit_map(QueryResultMapDeserializer::new(self.query_result.into_iter()))
     }
 
     serde::forward_to_deserialize_any! {

--- a/trustfall_core/src/serialization/tests.rs
+++ b/trustfall_core/src/serialization/tests.rs
@@ -18,16 +18,8 @@ fn deserialize_simple() {
         Arc::from("bar") => FieldValue::String("the answer to everything".into()),
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
-    assert_eq!(
-        Output {
-            foo: 42,
-            bar: "the answer to everything".to_string(),
-        },
-        output_value
-    );
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
+    assert_eq!(Output { foo: 42, bar: "the answer to everything".to_string() }, output_value);
 }
 
 #[test]
@@ -46,16 +38,8 @@ fn deserialize_list() {
         Arc::from("bar") => FieldValue::List(vec_str.clone().into_iter().map(Into::into).collect()),
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
-    assert_eq!(
-        Output {
-            foo: vec_int,
-            bar: vec_str,
-        },
-        output_value
-    );
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
+    assert_eq!(Output { foo: vec_int, bar: vec_str }, output_value);
 }
 
 #[test]
@@ -72,16 +56,8 @@ fn deserialize_option() {
         Arc::from("bar") => FieldValue::Null,
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
-    assert_eq!(
-        Output {
-            foo: vec_int,
-            bar: None,
-        },
-        output_value
-    );
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
+    assert_eq!(Output { foo: vec_int, bar: None }, output_value);
 }
 
 #[test]
@@ -98,16 +74,8 @@ fn deserialize_extra_keys_in_query_result() {
         Arc::from("extra") => FieldValue::Null,
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
-    assert_eq!(
-        Output {
-            foo: 42,
-            bar: "the answer to everything".into(),
-        },
-        output_value
-    );
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
+    assert_eq!(Output { foo: 42, bar: "the answer to everything".into() }, output_value);
 }
 
 #[test]
@@ -126,16 +94,8 @@ fn deserialize_serde_rename() {
         Arc::from("renamed_bar") => FieldValue::String("the answer to everything".into()),
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
-    assert_eq!(
-        Output {
-            foo: 42,
-            bar: "the answer to everything".into(),
-        },
-        output_value
-    );
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
+    assert_eq!(Output { foo: 42, bar: "the answer to everything".into() }, output_value);
 }
 
 #[test]
@@ -159,20 +119,8 @@ fn deserialize_narrower_types() {
         Arc::from("u8") => FieldValue::Uint64(8),
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
-    assert_eq!(
-        Output {
-            i32: -32,
-            i16: -16,
-            i8: 8,
-            u32: 32,
-            u16: 16,
-            u8: 8,
-        },
-        output_value
-    );
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
+    assert_eq!(Output { i32: -32, i16: -16, i8: 8, u32: 32, u16: 16, u8: 8 }, output_value);
 }
 
 #[test]
@@ -186,9 +134,7 @@ fn deserialize_narrower_type_f32() {
         Arc::from("f32") => FieldValue::Float64(1.234),
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
     assert_eq!(Output { f32: 1.234f32 }, output_value);
 }
 
@@ -217,9 +163,7 @@ fn deserialize_adjust_numeric_type_signedness() {
         Arc::from("u8") => FieldValue::Int64(i8::MAX.into()),
     };
 
-    let output_value = value
-        .try_into_struct::<Output>()
-        .expect("failed to create struct");
+    let output_value = value.try_into_struct::<Output>().expect("failed to create struct");
     assert_eq!(
         Output {
             i64: i64::MAX,

--- a/trustfall_core/src/util.rs
+++ b/trustfall_core/src/util.rs
@@ -25,11 +25,8 @@ where
 {
     fn try_collect_unique(&mut self) -> Result<BTreeMap<K, V>, BTreeMap<K, Vec<V>>> {
         let size_hint = self.size_hint().0;
-        let mut map = if size_hint > 0 {
-            HashMap::with_capacity(size_hint)
-        } else {
-            HashMap::new()
-        };
+        let mut map =
+            if size_hint > 0 { HashMap::with_capacity(size_hint) } else { HashMap::new() };
 
         let mut maybe_duplicate: Option<(K, V)> = None;
         for (key, value) in &mut *self {
@@ -51,10 +48,7 @@ where
             for (key, value) in map.drain() {
                 duplicate_map.entry(key).or_default().push(value);
             }
-            duplicate_map
-                .get_mut(&first_duplicate_key)
-                .unwrap()
-                .push(first_duplicate_value);
+            duplicate_map.get_mut(&first_duplicate_key).unwrap().push(first_duplicate_value);
 
             for (key, value) in &mut *self {
                 duplicate_map.entry(key).or_default().push(value);

--- a/trustfall_derive/src/lib.rs
+++ b/trustfall_derive/src/lib.rs
@@ -169,12 +169,7 @@ fn impl_typename_derive(ast: &syn::DeriveInput) -> syn::Result<proc_macro2::Toke
 
     let variants = match &ast.data {
         syn::Data::Enum(d) => &d.variants,
-        _ => {
-            return Err(syn::Error::new_spanned(
-                ast,
-                "only enums can derive Typename",
-            ))
-        }
+        _ => return Err(syn::Error::new_spanned(ast, "only enums can derive Typename")),
     };
 
     let arms = variants
@@ -208,12 +203,7 @@ fn impl_trustfall_enum_vertex(ast: &syn::DeriveInput) -> syn::Result<proc_macro2
 
     let variants = match &ast.data {
         syn::Data::Enum(d) => &d.variants,
-        _ => {
-            return Err(syn::Error::new_spanned(
-                ast,
-                "only enums can derive TrustfallEnumVertex",
-            ))
-        }
+        _ => return Err(syn::Error::new_spanned(ast, "only enums can derive TrustfallEnumVertex")),
     };
 
     let conversions = variants
@@ -324,10 +314,8 @@ fn generate_conversion_method(variant: &syn::Variant) -> syn::Result<proc_macro2
             if named_fields.named.len() == 1 {
                 // Struct variants with only a single field return `Option<&ThatField>`.
                 let named_arg = &named_fields.named[0];
-                let field_name = named_arg
-                    .ident
-                    .as_ref()
-                    .expect("struct variant field had no name");
+                let field_name =
+                    named_arg.ident.as_ref().expect("struct variant field had no name");
                 let field_type = &named_arg.ty;
                 Ok(syn::parse_quote! {
                     pub(crate) fn #conversion_name(&self) -> Option<&#field_type> {
@@ -346,10 +334,8 @@ fn generate_conversion_method(variant: &syn::Variant) -> syn::Result<proc_macro2
 
                 let mut fields = syn::punctuated::Punctuated::<_, syn::Token![,]>::new();
                 for field in named_fields.named.iter() {
-                    let field_name = field
-                        .ident
-                        .as_ref()
-                        .expect("struct variant field had no name");
+                    let field_name =
+                        field.ident.as_ref().expect("struct variant field had no name");
                     fields.push(field_name);
                 }
                 Ok(syn::parse_quote! {
@@ -420,10 +406,7 @@ fn tuple_of_field_types(
         }
         quote!((#punct))
     } else {
-        panic!(
-            "list of fields had {} field(s), which is not more than one field",
-            fields.len()
-        );
+        panic!("list of fields had {} field(s), which is not more than one field", fields.len());
     }
 }
 

--- a/trustfall_derive/tests/uses.rs
+++ b/trustfall_derive/tests/uses.rs
@@ -103,44 +103,26 @@ fn mixed_variants() {
     let second = TwoVariants::Second(["fixed", "strings"], vec![1, 2]);
     assert_eq!("Second", second.typename());
     assert_eq!(None, second.as_first());
-    assert_eq!(
-        Some((&["fixed", "strings"], &vec![1, 2])),
-        second.as_second()
-    );
+    assert_eq!(Some((&["fixed", "strings"], &vec![1, 2])), second.as_second());
 }
 
 #[test]
 fn struct_variant() {
     #[derive(Debug, Clone, TrustfallEnumVertex)]
     enum TwoVariants {
-        FirstVariant {
-            snake_case: String,
-        },
-        SecondVariant {
-            a: i64,
-            b: [&'static str; 2],
-            c: Vec<usize>,
-        },
+        FirstVariant { snake_case: String },
+        SecondVariant { a: i64, b: [&'static str; 2], c: Vec<usize> },
     }
 
-    let first = TwoVariants::FirstVariant {
-        snake_case: "value".into(),
-    };
+    let first = TwoVariants::FirstVariant { snake_case: "value".into() };
     assert_eq!("FirstVariant", first.typename());
     assert_eq!(Some(&("value".into())), first.as_first_variant());
     assert_eq!(None, first.as_second_variant());
 
-    let second = TwoVariants::SecondVariant {
-        a: 42,
-        b: ["fixed", "strings"],
-        c: vec![1, 2],
-    };
+    let second = TwoVariants::SecondVariant { a: 42, b: ["fixed", "strings"], c: vec![1, 2] };
     assert_eq!("SecondVariant", second.typename());
     assert_eq!(None, second.as_first_variant());
-    assert_eq!(
-        Some((&42, &["fixed", "strings"], &vec![1, 2])),
-        second.as_second_variant()
-    );
+    assert_eq!(Some((&42, &["fixed", "strings"], &vec![1, 2])), second.as_second_variant());
 }
 
 #[test]

--- a/trustfall_filetests_macros/src/lib.rs
+++ b/trustfall_filetests_macros/src/lib.rs
@@ -26,14 +26,8 @@ impl Parse for ParameterizeArgs {
         let vars_vec: Vec<_> = vars.into_iter().collect();
 
         match vars_vec.len() {
-            1 => Ok(Self {
-                path: vars_vec[0].value(),
-                glob: "*.graphql.ron".to_string(),
-            }),
-            2 => Ok(Self {
-                path: vars_vec[0].value(),
-                glob: vars_vec[1].value(),
-            }),
+            1 => Ok(Self { path: vars_vec[0].value(), glob: "*.graphql.ron".to_string() }),
+            2 => Ok(Self { path: vars_vec[0].value(), glob: vars_vec[1].value() }),
             _ => Err(syn::Error::new(
                 input.span(),
                 "Expected a path string literal and an optional glob string literal.",

--- a/trustfall_stubgen/src/adapter_creator.rs
+++ b/trustfall_stubgen/src/adapter_creator.rs
@@ -28,16 +28,10 @@ pub(super) fn make_adapter_file(
         pub struct Adapter {}
     };
 
-    adapter_file
-        .builtin_imports
-        .insert(parse_import("std::sync::OnceLock"));
-    adapter_file
-        .external_imports
-        .insert(parse_import("trustfall::Schema"));
+    adapter_file.builtin_imports.insert(parse_import("std::sync::OnceLock"));
+    adapter_file.external_imports.insert(parse_import("trustfall::Schema"));
 
-    adapter_file
-        .internal_imports
-        .insert(parse_import("super::vertex::Vertex"));
+    adapter_file.internal_imports.insert(parse_import("super::vertex::Vertex"));
 
     let adapter_impl = quote! {
         impl Adapter {
@@ -148,18 +142,13 @@ fn emit_property_handling(
     let mut arms = proc_macro2::TokenStream::new();
     let mut rows: Vec<_> = trustfall::execute_query(querying_schema, adapter, query, variables)
         .expect("invalid query")
-        .map(|x| {
-            x.try_into_struct::<ResultRow>()
-                .expect("invalid conversion")
-        })
+        .map(|x| x.try_into_struct::<ResultRow>().expect("invalid conversion"))
         .collect();
     rows.sort_unstable();
     for row in rows {
         let name = &row.name;
-        let ident = syn::Ident::new(
-            &property_resolver_fn_name(name),
-            proc_macro2::Span::call_site(),
-        );
+        let ident =
+            syn::Ident::new(&property_resolver_fn_name(name), proc_macro2::Span::call_site());
         arms.extend(quote! {
             #name => super::properties::#ident(contexts, property_name.as_ref(), resolve_info),
         });
@@ -213,18 +202,13 @@ fn emit_edge_handling(
     let mut arms = proc_macro2::TokenStream::new();
     let mut rows: Vec<_> = trustfall::execute_query(querying_schema, adapter, query, variables)
         .expect("invalid query")
-        .map(|x| {
-            x.try_into_struct::<ResultRow>()
-                .expect("invalid conversion")
-        })
+        .map(|x| x.try_into_struct::<ResultRow>().expect("invalid conversion"))
         .collect();
     rows.sort_unstable();
     for row in rows {
         let name = &row.name;
-        let ident = syn::Ident::new(
-            &type_edge_resolver_fn_name(name),
-            proc_macro2::Span::call_site(),
-        );
+        let ident =
+            syn::Ident::new(&type_edge_resolver_fn_name(name), proc_macro2::Span::call_site());
         arms.extend(quote! {
             #name => super::edges::#ident(contexts, edge_name.as_ref(), parameters, resolve_info),
         });
@@ -263,9 +247,7 @@ fn emit_coercion_handling(
     external_imports.insert(parse_import("trustfall::provider::ContextIterator"));
     external_imports.insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
     external_imports.insert(parse_import("trustfall::provider::ResolveInfo"));
-    external_imports.insert(parse_import(
-        "trustfall::provider::resolve_coercion_using_schema",
-    ));
+    external_imports.insert(parse_import("trustfall::provider::resolve_coercion_using_schema"));
 
     quote! {
         fn resolve_coercion(

--- a/trustfall_stubgen/src/edges_creator.rs
+++ b/trustfall_stubgen/src/edges_creator.rs
@@ -46,21 +46,14 @@ pub(super) fn make_edges_file(
 
     let mut rows: Vec<_> = trustfall::execute_query(querying_schema, adapter, query, variables)
         .expect("invalid query")
-        .map(|x| {
-            x.try_into_struct::<ResultRow>()
-                .expect("invalid conversion")
-        })
+        .map(|x| x.try_into_struct::<ResultRow>().expect("invalid conversion"))
         .collect();
     rows.sort_unstable();
     for row in rows {
         let mut edges: Vec<(String, Vec<(String, String)>)> = row
             .edge_name
             .into_iter()
-            .zip(
-                row.parameter_name
-                    .into_iter()
-                    .zip(row.parameter_type.into_iter()),
-            )
+            .zip(row.parameter_name.into_iter().zip(row.parameter_type.into_iter()))
             .map(|(edge, (param, ty))| (edge, param.into_iter().zip(ty.into_iter()).collect()))
             .collect();
         edges.sort_unstable();
@@ -70,25 +63,13 @@ pub(super) fn make_edges_file(
         edges_file.top_level_items.push(type_edge_mod);
     }
 
-    edges_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::ContextIterator"));
-    edges_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
-    edges_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::EdgeParameters"));
-    edges_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::ResolveEdgeInfo"));
-    edges_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::VertexIterator"));
+    edges_file.external_imports.insert(parse_import("trustfall::provider::ContextIterator"));
+    edges_file.external_imports.insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
+    edges_file.external_imports.insert(parse_import("trustfall::provider::EdgeParameters"));
+    edges_file.external_imports.insert(parse_import("trustfall::provider::ResolveEdgeInfo"));
+    edges_file.external_imports.insert(parse_import("trustfall::provider::VertexIterator"));
 
-    edges_file
-        .internal_imports
-        .insert(parse_import("super::vertex::Vertex"));
+    edges_file.internal_imports.insert(parse_import("super::vertex::Vertex"));
 }
 
 fn make_type_edge_resolver(
@@ -147,13 +128,12 @@ fn make_edge_resolver_and_call(
     parameters: &[(String, String)],
     mod_name: &proc_macro2::Ident,
 ) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
-    let FnCall {
-        fn_params,
-        fn_args,
-        fn_arg_prep,
-    } = prepare_call_parameters(parameters, |parameter_name| {
-        format!("failed to find parameter '{parameter_name}' for edge '{edge_name}' on type '{type_name}'")
-    });
+    let FnCall { fn_params, fn_args, fn_arg_prep } = prepare_call_parameters(
+        parameters,
+        |parameter_name| {
+            format!("failed to find parameter '{parameter_name}' for edge '{edge_name}' on type '{type_name}'")
+        },
+    );
 
     let resolver_fn_name = to_lower_snake_case(edge_name);
     let resolver_fn_ident = syn::Ident::new(&resolver_fn_name, proc_macro2::Span::call_site());
@@ -225,9 +205,5 @@ pub(super) fn prepare_call_parameters(
         });
     }
 
-    FnCall {
-        fn_params,
-        fn_args,
-        fn_arg_prep,
-    }
+    FnCall { fn_params, fn_args, fn_arg_prep }
 }

--- a/trustfall_stubgen/src/entrypoints_creator.rs
+++ b/trustfall_stubgen/src/entrypoints_creator.rs
@@ -41,47 +41,34 @@ pub(super) fn make_entrypoints_file(
 
     let mut rows: Vec<_> = trustfall::execute_query(querying_schema, adapter, query, variables)
         .expect("invalid query")
-        .map(|x| {
-            x.try_into_struct::<ResultRow>()
-                .expect("invalid conversion")
-        })
+        .map(|x| x.try_into_struct::<ResultRow>().expect("invalid conversion"))
         .collect();
     rows.sort_unstable();
     for row in rows {
-        let parameters: Vec<_> = row
-            .parameter_name
-            .into_iter()
-            .zip(row.parameter_type.into_iter())
-            .collect();
+        let parameters: Vec<_> =
+            row.parameter_name.into_iter().zip(row.parameter_type.into_iter()).collect();
 
         let (match_arm, entrypoint_fn) = make_entrypoint_fn(&row.name, &parameters);
         entrypoints_file.top_level_items.push(entrypoint_fn);
         entrypoints_match_arms.extend(match_arm);
     }
 
-    entrypoints_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::VertexIterator"));
-    entrypoints_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::ResolveInfo"));
+    entrypoints_file.external_imports.insert(parse_import("trustfall::provider::VertexIterator"));
+    entrypoints_file.external_imports.insert(parse_import("trustfall::provider::ResolveInfo"));
 
-    entrypoints_file
-        .internal_imports
-        .insert(parse_import("super::vertex::Vertex"));
+    entrypoints_file.internal_imports.insert(parse_import("super::vertex::Vertex"));
 }
 
 fn make_entrypoint_fn(
     entrypoint: &str,
     parameters: &[(String, String)],
 ) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
-    let FnCall {
-        fn_params,
-        fn_args,
-        fn_arg_prep,
-    } = prepare_call_parameters(parameters, |parameter_name| {
-        format!("failed to find parameter '{parameter_name}' when resolving '{entrypoint}' starting vertices")
-    });
+    let FnCall { fn_params, fn_args, fn_arg_prep } = prepare_call_parameters(
+        parameters,
+        |parameter_name| {
+            format!("failed to find parameter '{parameter_name}' when resolving '{entrypoint}' starting vertices")
+        },
+    );
 
     let entrypoint_fn_name = to_lower_snake_case(entrypoint);
     let ident = syn::Ident::new(&entrypoint_fn_name, proc_macro2::Span::call_site());

--- a/trustfall_stubgen/src/main.rs
+++ b/trustfall_stubgen/src/main.rs
@@ -39,10 +39,7 @@ fn main() -> Result<(), anyhow::Error> {
         );
     }
     if !schema_is_file {
-        anyhow::bail!(
-            "schema path {} does not point to a file",
-            cli.schema.display()
-        );
+        anyhow::bail!("schema path {} does not point to a file", cli.schema.display());
     }
     if target_is_file {
         anyhow::bail!(

--- a/trustfall_stubgen/src/properties_creator.rs
+++ b/trustfall_stubgen/src/properties_creator.rs
@@ -51,22 +51,14 @@ pub(super) fn make_properties_file(
         properties_file.top_level_items.push(resolver);
     }
 
-    properties_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::ContextIterator"));
+    properties_file.external_imports.insert(parse_import("trustfall::provider::ContextIterator"));
     properties_file
         .external_imports
         .insert(parse_import("trustfall::provider::ContextOutcomeIterator"));
-    properties_file
-        .external_imports
-        .insert(parse_import("trustfall::provider::ResolveInfo"));
-    properties_file
-        .external_imports
-        .insert(parse_import("trustfall::FieldValue"));
+    properties_file.external_imports.insert(parse_import("trustfall::provider::ResolveInfo"));
+    properties_file.external_imports.insert(parse_import("trustfall::FieldValue"));
 
-    properties_file
-        .internal_imports
-        .insert(parse_import("super::vertex::Vertex"));
+    properties_file.internal_imports.insert(parse_import("super::vertex::Vertex"));
 }
 
 fn make_resolver_fn(type_name: &str, properties: &[String]) -> proc_macro2::TokenStream {

--- a/trustfall_stubgen/src/root.rs
+++ b/trustfall_stubgen/src/root.rs
@@ -59,11 +59,7 @@ pub fn generate_rust_stub(schema: &str, target: &Path) -> anyhow::Result<()> {
         &mut stub.entrypoints,
         &mut entrypoint_match_arms,
     );
-    make_properties_file(
-        &querying_schema,
-        schema_adapter.clone(),
-        &mut stub.properties,
-    );
+    make_properties_file(&querying_schema, schema_adapter.clone(), &mut stub.properties);
     make_edges_file(&querying_schema, schema_adapter.clone(), &mut stub.edges);
     make_adapter_file(
         &querying_schema,
@@ -346,13 +342,11 @@ impl<'a> AdapterStub<'a> {
 }
 
 fn make_tests_file(tests_file: &mut RustFile) {
-    tests_file.external_imports.insert(parse_import(
-        "trustfall::provider::check_adapter_invariants",
-    ));
-
     tests_file
-        .internal_imports
-        .insert(parse_import("super::Adapter"));
+        .external_imports
+        .insert(parse_import("trustfall::provider::check_adapter_invariants"));
+
+    tests_file.internal_imports.insert(parse_import("super::Adapter"));
 
     tests_file.top_level_items.push(quote! {
         #[test]
@@ -385,10 +379,7 @@ fn make_vertex_file(
     let mut variants = proc_macro2::TokenStream::new();
     let mut rows: Vec<_> = trustfall::execute_query(querying_schema, adapter, query, variables)
         .expect("invalid query")
-        .map(|x| {
-            x.try_into_struct::<ResultRow>()
-                .expect("invalid conversion")
-        })
+        .map(|x| x.try_into_struct::<ResultRow>().expect("invalid conversion"))
         .collect();
     rows.sort_unstable();
     for row in rows {

--- a/trustfall_stubgen/src/tests.rs
+++ b/trustfall_stubgen/src/tests.rs
@@ -9,10 +9,7 @@ use super::generate_rust_stub;
 /// Write the given contents to a file, asserting that the file did not previously exist.
 fn write_new_file(path: &Path, contents: &str) {
     match path.try_exists() {
-        Ok(true) => panic!(
-            "file at path unexpectedly already exists: {}",
-            path.display()
-        ),
+        Ok(true) => panic!("file at path unexpectedly already exists: {}", path.display()),
         Ok(false) => std::fs::write(path, contents).expect("failed to write file"),
         Err(e) => panic!("{e}"),
     }
@@ -86,15 +83,10 @@ fn get_relevant_files_from_dir(path: &Path) -> BTreeMap<PathBuf, PathBuf> {
                 return None;
             }
 
-            let extension = pathbuf
-                .extension()
-                .and_then(|x| x.to_str())
-                .unwrap_or_default();
+            let extension = pathbuf.extension().and_then(|x| x.to_str()).unwrap_or_default();
             if matches!(extension, "rs" | "graphql") {
                 let mut matched_filepath = pathbuf.to_str().expect("failed to make str");
-                matched_filepath = matched_filepath
-                    .strip_prefix("./")
-                    .unwrap_or(matched_filepath);
+                matched_filepath = matched_filepath.strip_prefix("./").unwrap_or(matched_filepath);
 
                 let key = matched_filepath
                     .strip_prefix(&base)
@@ -120,10 +112,7 @@ fn assert_generated_code_is_unchanged(test_dir: &Path, expected_dir: &Path) {
     let mut missing_expected_files = expected_files.clone();
     missing_expected_files.retain(|k, _| !test_files.contains_key(k));
 
-    for key in test_files
-        .keys()
-        .filter(|k| expected_files.contains_key(*k))
-    {
+    for key in test_files.keys().filter(|k| expected_files.contains_key(*k)) {
         let expected_filepath = &expected_files[key];
         let test_filepath = &test_files[key];
         println!("{expected_filepath:?} {test_filepath:?}");
@@ -134,10 +123,7 @@ fn assert_generated_code_is_unchanged(test_dir: &Path, expected_dir: &Path) {
         similar_asserts::assert_eq!(expected, actual);
     }
 
-    assert!(
-        unexpected_files.is_empty(),
-        "unexpected files found: {unexpected_files:?}"
-    );
+    assert!(unexpected_files.is_empty(), "unexpected files found: {unexpected_files:?}");
     assert!(
         missing_expected_files.is_empty(),
         "expected files were missing: {missing_expected_files:?}"

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -39,10 +39,9 @@ use trustfall_core::{
 };
 
 fn get_schema_by_name(schema_name: &str) -> Schema {
-    let schema_text = fs::read_to_string(format!(
-        "../trustfall_core/test_data/schemas/{schema_name}.graphql",
-    ))
-    .unwrap();
+    let schema_text =
+        fs::read_to_string(format!("../trustfall_core/test_data/schemas/{schema_name}.graphql",))
+            .unwrap();
     let schema_document = parse_schema(schema_text).unwrap();
     Schema::new(schema_document).unwrap()
 }
@@ -116,11 +115,7 @@ where
 {
     let query: Arc<IndexedQuery> = Arc::new(test_query.ir_query.clone().try_into().unwrap());
     let arguments: Arc<BTreeMap<_, _>> = Arc::new(
-        test_query
-            .arguments
-            .iter()
-            .map(|(k, v)| (Arc::from(k.to_owned()), v.clone()))
-            .collect(),
+        test_query.arguments.iter().map(|(k, v)| (Arc::from(k.to_owned()), v.clone())).collect(),
     );
 
     let outputs = query.outputs.clone();
@@ -141,11 +136,8 @@ where
                 );
             }
 
-            let data = TestInterpreterOutputData {
-                schema_name: test_query.schema_name,
-                outputs,
-                results,
-            };
+            let data =
+                TestInterpreterOutputData { schema_name: test_query.schema_name, outputs, results };
 
             println!("{}", serialize_to_ron(&data));
         }
@@ -181,17 +173,11 @@ fn trace_with_adapter<'a, AdapterT>(
 {
     let query = Arc::new(test_query.ir_query.clone().try_into().unwrap());
     let arguments: Arc<BTreeMap<_, _>> = Arc::new(
-        test_query
-            .arguments
-            .iter()
-            .map(|(k, v)| (Arc::from(k.to_owned()), v.clone()))
-            .collect(),
+        test_query.arguments.iter().map(|(k, v)| (Arc::from(k.to_owned()), v.clone())).collect(),
     );
 
-    let tracer = Rc::new(RefCell::new(Trace::new(
-        test_query.ir_query.clone(),
-        test_query.arguments,
-    )));
+    let tracer =
+        Rc::new(RefCell::new(Trace::new(test_query.ir_query.clone(), test_query.arguments)));
     let mut adapter_tap = Arc::new(AdapterTap::new(adapter, tracer));
 
     let execution_result = execution::interpret_ir(adapter_tap.clone(), query, arguments);
@@ -204,10 +190,7 @@ fn trace_with_adapter<'a, AdapterT>(
             );
 
             let trace = Arc::make_mut(&mut adapter_tap).clone().finish();
-            let data = TestInterpreterOutputTrace {
-                schema_name: test_query.schema_name,
-                trace,
-            };
+            let data = TestInterpreterOutputTrace { schema_name: test_query.schema_name, trace };
 
             println!("{}", serialize_to_ron(&data));
         }
@@ -223,11 +206,7 @@ fn trace(path: &str) {
     let test_query = test_query_result.unwrap();
 
     let mut outputs_path = PathBuf::from_str(path).unwrap();
-    let ir_file_name = outputs_path
-        .file_name()
-        .expect("not a file")
-        .to_str()
-        .unwrap();
+    let ir_file_name = outputs_path.file_name().expect("not a file").to_str().unwrap();
     let outputs_file_name = ir_file_name.replace(".ir.ron", ".output.ron");
     outputs_path.pop();
     outputs_path.push(&outputs_file_name);

--- a/trustfall_wasm/src/shim.rs
+++ b/trustfall_wasm/src/shim.rs
@@ -29,12 +29,9 @@ impl From<JsFieldValue> for FieldValue {
             JsFieldValue::Integer(i) => FieldValue::Int64(i),
             JsFieldValue::Float(n) => FieldValue::Float64(n),
             JsFieldValue::Boolean(b) => FieldValue::Boolean(b),
-            JsFieldValue::List(v) => FieldValue::List(
-                v.iter()
-                    .map(|x| x.clone().into())
-                    .collect::<Vec<_>>()
-                    .into(),
-            ),
+            JsFieldValue::List(v) => {
+                FieldValue::List(v.iter().map(|x| x.clone().into()).collect::<Vec<_>>().into())
+            }
         }
     }
 }
@@ -51,12 +48,9 @@ impl From<FieldValue> for JsFieldValue {
             },
             FieldValue::Float64(n) => JsFieldValue::Float(n),
             FieldValue::Boolean(b) => JsFieldValue::Boolean(b),
-            FieldValue::List(v) => JsFieldValue::List(
-                v.iter()
-                    .map(|x| x.clone().into())
-                    .collect::<Vec<_>>()
-                    .into(),
-            ),
+            FieldValue::List(v) => {
+                JsFieldValue::List(v.iter().map(|x| x.clone().into()).collect::<Vec<_>>().into())
+            }
             _ => unimplemented!("unsupported value: {v:#?}"),
         }
     }
@@ -71,10 +65,7 @@ pub struct JsEdgeParameters {
 #[wasm_bindgen]
 impl JsEdgeParameters {
     pub fn get(&self, name: &str) -> JsValue {
-        let value = self
-            .values
-            .get(name)
-            .expect("no edge parameter by that name");
+        let value = self.values.get(name).expect("no edge parameter by that name");
 
         JsValue::from_serde(&value).expect("serde conversion failed")
     }
@@ -92,12 +83,7 @@ impl From<trustfall_core::ir::EdgeParameters> for JsEdgeParameters {
 
 impl From<&trustfall_core::ir::EdgeParameters> for JsEdgeParameters {
     fn from(p: &trustfall_core::ir::EdgeParameters) -> Self {
-        Self {
-            values: p
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.clone().into()))
-                .collect(),
-        }
+        Self { values: p.iter().map(|(k, v)| (k.to_string(), v.clone().into())).collect() }
     }
 }
 
@@ -112,10 +98,7 @@ pub struct JsContext {
 #[wasm_bindgen]
 impl JsContext {
     pub(super) fn new(local_id: u32, active_vertex: Option<JsValue>) -> Self {
-        Self {
-            local_id,
-            active_vertex,
-        }
+        Self { local_id, active_vertex }
     }
 
     #[wasm_bindgen(getter, js_name = "activeVertex")]
@@ -134,10 +117,7 @@ pub(super) struct JsStringConstants {
 
 impl JsStringConstants {
     pub(super) fn new() -> Self {
-        Self {
-            local_id: JsValue::from_str("localId"),
-            neighbors: JsValue::from_str("neighbors"),
-        }
+        Self { local_id: JsValue::from_str("localId"), neighbors: JsValue::from_str("neighbors") }
     }
 }
 
@@ -177,11 +157,7 @@ impl ContextIteratorItem {
 #[wasm_bindgen]
 impl JsContextIterator {
     pub(super) fn new(iter: VertexIterator<'static, DataContext<JsValue>>) -> Self {
-        Self {
-            iter,
-            registry: Rc::from(RefCell::new(Default::default())),
-            next_item: 0,
-        }
+        Self { iter, registry: Rc::from(RefCell::new(Default::default())), next_item: 0 }
     }
 
     #[wasm_bindgen(js_name = "next")]
@@ -193,10 +169,7 @@ impl JsContextIterator {
             let current_vertex = ctx.active_vertex().cloned();
 
             let existing = self.registry.borrow_mut().insert(next_item, ctx);
-            assert!(
-                existing.is_none(),
-                "id {next_item} already inserted with value {existing:?}",
-            );
+            assert!(existing.is_none(), "id {next_item} already inserted with value {existing:?}",);
 
             ContextIteratorItem::new_item(JsContext::new(next_item, current_vertex))
         } else {

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -158,18 +158,10 @@ pub fn run_numbers_query(
     let results: Vec<_> = trustfall_core::interpreter::execution::interpret_ir(
         wrapped_adapter,
         query,
-        Arc::new(
-            args.into_iter()
-                .map(|(k, v)| (Arc::from(k), v.into()))
-                .collect(),
-        ),
+        Arc::new(args.into_iter().map(|(k, v)| (Arc::from(k), v.into())).collect()),
     )
     .map_err(|e| e.to_string())?
-    .map(|res| {
-        res.into_iter()
-            .map(|(k, v)| (k.to_string(), v.into()))
-            .collect()
-    })
+    .map(|res| res.into_iter().map(|(k, v)| (k.to_string(), v.into())).collect())
     .collect();
 
     Ok(results)


### PR DESCRIPTION
This makes formatting take more advantage of the same line, reducing the number of lines used.

I find that this tends to improve readability when:
- Passing closures to chained functions
- Pattern matching is in a heavily indented context
- There is opportunity for vertical alignment in neighboring code