### PR TITLE
Run doctests in CI and fix failures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,17 +188,26 @@ jobs:
 
       - uses: r7kamura/rust-problem-matchers@v1
 
-      # Test everything except trustfall_stubgen,
+      # Test all crates except trustfall_stubgen,
       # which is only tested if it has changed since its tests are a bit long.
+      #
+      # `--all-targets` also tests example and bench targets, but explicitly excludes doctests.
+      # We'll test doctests separately in their own step.
+      # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test
         run: cargo test --workspace --all-targets --all-features --exclude trustfall_stubgen
+
+      # Run doctests separately, since `--all-targets` above explicitly excludes doctests.
+      # https://github.com/rust-lang/cargo/issues/6669
+      - name: run doctests
+        run: cargo test --workspace --all-features --doc
 
       - name: test trustfall_stubgen if it has changed
         run: |
           git fetch origin main
 
           # `git diff --quiet` exits non-zero if there are changes
-          git diff --quiet HEAD origin/main -- ./trustfall_stubgen || (cd trustfall_stubgen/ && cargo test --all-targets --all-features)
+          git diff --quiet HEAD origin/main -- ./trustfall_stubgen || (cd trustfall_stubgen/ && cargo test --all-features)
 
   rust-fuzz:
     name: Check fuzz targets

--- a/trustfall_core/src/ir/types.rs
+++ b/trustfall_core/src/ir/types.rs
@@ -190,11 +190,11 @@ pub fn intersect_types(left: &Type, right: &Type) -> Option<Type> {
 /// use trustfall_core::ir::{FieldValue, types::is_argument_type_valid};
 ///
 /// let variable_type = Type::new("[Int]").unwrap();
-/// let argument_value = FieldValue::List(vec![
+/// let argument_value = FieldValue::List([
 ///     FieldValue::Int64(-1),
 ///     FieldValue::Uint64(1),
 ///     FieldValue::Null,
-/// ]);
+/// ].as_slice().into());
 /// assert!(is_argument_type_valid(&variable_type, &argument_value));
 /// ```
 pub fn is_argument_type_valid(variable_type: &Type, argument_value: &FieldValue) -> bool {

--- a/trustfall_core/src/serialization/mod.rs
+++ b/trustfall_core/src/serialization/mod.rs
@@ -51,7 +51,7 @@ mod tests;
 /// # fn run_query() -> Result<Box<dyn Iterator<Item = BTreeMap<Arc<str>, FieldValue>>>, ()> {
 /// #     Ok(Box::new(vec![
 /// #        btreemap! {
-/// #           Arc::from("item_name") => FieldValue::String("widget".to_string()),
+/// #           Arc::from("item_name") => FieldValue::String("widget".into()),
 /// #           Arc::from("quantity") => FieldValue::Int64(42),
 /// #        }
 /// #     ].into_iter()))


### PR DESCRIPTION
Unfortunately, adding `--all-targets` to `cargo test` causes doctests to
be de-selected: https://github.com/rust-lang/cargo/issues/6669
