### PR TITLE
Adding information about the scripts for generating test data on readme

### DIFF
--- a/trustfall_core/test_data/README.md
+++ b/trustfall_core/test_data/README.md
@@ -74,8 +74,10 @@ Under [`scripts`](../../scripts) there are bash scripts to create the `ron` file
 In general, the scripts named `recreate_*` work as a "pipeline" where they take the
 output of a previous script and generate a `ron` file. For example
 `recreate_all_parsed_graphql.sh` takes all `*.graphql.ron` files under
-`trustfall_core/test_data/tests/valid_queries` and generates `*.graphql-parsed.ron`.
-While `recreate_all_ir.sh` takes all `*.graphql-parsed.ron` and generates the `*.ir.ron`.
+`trustfall_core/test_data/tests/valid_queries`, `trustfall_core/test_data/tests/execution_errors`,
+and `trustfall_core/test_data/tests/frontend_errors` and generates `*.graphql-parsed.ron` on
+those folders. While `recreate_all_ir.sh` takes all `*.graphql-parsed.ron`and generates
+the `*.ir.ron`.
 
 They are useful when you slightly modified a `*.graphql.ron` and want to update the other
 files based on that.

--- a/trustfall_core/test_data/README.md
+++ b/trustfall_core/test_data/README.md
@@ -81,10 +81,10 @@ They are useful when you slightly modified a `*.graphql.ron` and want to update 
 files based on that.
 
 The scripts named `create_*` receive as input a list of `graphql.ron` files and generate 
-all need files for a given test case. For example, `create_frontend_error_data.sh` will
-create `*.graphql-parsed.ron` and `*.frontend-error.ron` file.
+all needed files for a given test case. For example, `create_frontend_error_data.sh` will
+create `*.graphql-parsed.ron` and `*.frontend-error.ron` files.
 
-If I want to create a new valid query test, I can run:
+If you want to create a new valid query test, you can run:
 `./create_valid_query_data.sh ../trustfall_core/test_data/tests/valid_queries/my_test.graphql.ron`.
 
-Scripts must be run inside the `scripts folder`.
+Scripts must be run inside the `scripts` folder.

--- a/trustfall_core/test_data/README.md
+++ b/trustfall_core/test_data/README.md
@@ -70,10 +70,10 @@ errors are named `X.schema-error.ron`.
 
 ## Recreating the test files
 
-Under [`scripts`](../../scripts) there are bash scripts to create the  `ron` files.
-In general, the scripts named `recreate_*` work as a "pipeline" where they take the 
+Under [`scripts`](../../scripts) there are bash scripts to create the `ron` files.
+In general, the scripts named `recreate_*` work as a "pipeline" where they take the
 output of a previous script and generate a `ron` file. For example
-`recreate_all_parsed_graphql.sh` takes all `*.graphql.ron` files under 
+`recreate_all_parsed_graphql.sh` takes all `*.graphql.ron` files under
 `trustfall_core/test_data/tests/valid_queries` and generates `*.graphql-parsed.ron`.
 While `recreate_all_ir.sh` takes all `*.graphql-parsed.ron` and generates the `*.ir.ron`.
 

--- a/trustfall_core/test_data/README.md
+++ b/trustfall_core/test_data/README.md
@@ -67,3 +67,24 @@ or produce a specified error ([`schema_errors`](./tests/schema_errors/) director
 The naming scheme for schema files and their corresponding expected errors is
 similar to the one for queries: schemas are named like `X.graphql` while their
 errors are named `X.schema-error.ron`.
+
+## Recreating the test files
+
+Under [`scripts`](../../scripts) there are bash scripts to create the  `ron` files.
+In general, the scripts named `recreate_*` work as a "pipeline" where they take the 
+output of a previous script and generate a `ron` file. For example
+`recreate_all_parsed_graphql.sh` takes all `*.graphql.ron` files under 
+`trustfall_core/test_data/tests/valid_queries` and generates `*.graphql-parsed.ron`.
+While `recreate_all_ir.sh` takes all `*.graphql-parsed.ron` and generates the `*.ir.ron`.
+
+They are useful when you slightly modified a `*.graphql.ron` and want to update the other
+files based on that.
+
+The scripts named `create_*` receive as input a list of `graphql.ron` files and generate 
+all need files for a given test case. For example, `create_frontend_error_data.sh` will
+create `*.graphql-parsed.ron` and `*.frontend-error.ron` file.
+
+If I want to create a new valid query test, I can run:
+`./create_valid_query_data.sh ../trustfall_core/test_data/tests/valid_queries/my_test.graphql.ron`.
+
+Scripts must be run inside the `scripts folder`.

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![forbid(unused_lifetimes)]
 
+use anyhow::Context;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
@@ -39,9 +40,10 @@ use trustfall_core::{
 };
 
 fn get_schema_by_name(schema_name: &str) -> Schema {
-    let schema_text =
-        fs::read_to_string(format!("../trustfall_core/test_data/schemas/{schema_name}.graphql",))
-            .unwrap();
+    let schema_path = format!("../trustfall_core/test_data/schemas/{schema_name}.graphql",);
+    let schema_text = fs::read_to_string(&schema_path)
+        .context(format!("failed to read schema from {schema_path}"))
+        .unwrap();
     let schema_document = parse_schema(schema_text).unwrap();
     Schema::new(schema_document).unwrap()
 }

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 #![forbid(unused_lifetimes)]
 
-use anyhow::Context;
+use anyhow::Context as _;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},


### PR DESCRIPTION
This PR does two things:

1) While running the scripts, one of them failed because it could not find `../trustfall_core/test_data/schemas/{schema_name}.graphql` the error message was just a plain "could not find file" (`thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', trustfall_testbin/src/main.rs:44:14`) which forced me to open the file to discover which file was missing. I added a `context` to the error to make this easier in the future. I can remove it if you think is not needed.
2) I wrote a little bit about the scripts to generate test data. I didn't describe each one of them but wrote what they do. Let me know if I understood it wrong tho.