### PR TITLE
Allow any script to be executed anywhere inside the repo

### DIFF
--- a/scripts/create_execution_error_data.sh
+++ b/scripts/create_execution_error_data.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # Get the absolute path of the repo.
 REPO="$(git rev-parse --show-toplevel)"
 
+INPUT_FILES=()
+
 for INPUT_FILE in "$@"; do
+    # makes sure we are always using absolute path
+    INPUT_FILES+=("$(cd "$(dirname "$1")"; pwd)/$(basename "$1")")
+done
+
+# Move relative to the top of the repo, so this script can be run from anywhere.
+cd "$(git rev-parse --show-toplevel)/trustfall_testbin"
+
+for INPUT_FILE in $INPUT_FILES; do
     echo "> Starting on file $INPUT_FILE"
 
     DIR_NAME="$(dirname "$INPUT_FILE")"

--- a/scripts/create_execution_error_data.sh
+++ b/scripts/create_execution_error_data.sh
@@ -14,7 +14,7 @@ for INPUT_FILE in "$@"; do
 done
 
 # Move relative to the top of the repo, so this script can be run from anywhere.
-cd "$(git rev-parse --show-toplevel)/trustfall_testbin"
+cd "$REPO/trustfall_testbin"
 
 for INPUT_FILE in $INPUT_FILES; do
     echo "> Starting on file $INPUT_FILE"

--- a/scripts/create_frontend_error_data.sh
+++ b/scripts/create_frontend_error_data.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # Get the absolute path of the repo.
 REPO="$(git rev-parse --show-toplevel)"
 
+INPUT_FILES=()
+
 for INPUT_FILE in "$@"; do
+    # makes sure we are always using absolute path
+    INPUT_FILES+=("$(cd "$(dirname "$1")"; pwd)/$(basename "$1")")
+done
+
+# Move relative to the top of the repo, so this script can be run from anywhere.
+cd "$REPO/trustfall_testbin"
+
+for INPUT_FILE in $INPUT_FILES; do
     echo "> Starting on file $INPUT_FILE"
 
     DIR_NAME="$(dirname "$INPUT_FILE")"

--- a/scripts/create_parse_error_data.sh
+++ b/scripts/create_parse_error_data.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # Get the absolute path of the repo.
 REPO="$(git rev-parse --show-toplevel)"
 
+INPUT_FILES=()
+
 for INPUT_FILE in "$@"; do
+    # makes sure we are always using absolute path
+    INPUT_FILES+=("$(cd "$(dirname "$1")"; pwd)/$(basename "$1")")
+done
+
+# Move relative to the top of the repo, so this script can be run from anywhere.
+cd "$REPO/trustfall_testbin"
+
+for INPUT_FILE in $INPUT_FILES; do
     echo "> Starting on file $INPUT_FILE"
 
     DIR_NAME="$(dirname "$INPUT_FILE")"

--- a/scripts/create_schema_error_data.sh
+++ b/scripts/create_schema_error_data.sh
@@ -6,6 +6,16 @@ set -euo pipefail
 # Get the absolute path of the repo.
 REPO="$(git rev-parse --show-toplevel)"
 
+INPUT_FILES=()
+
+for INPUT_FILE in "$@"; do
+    # makes sure we are always using absolute path
+    INPUT_FILES+=("$(cd "$(dirname "$1")"; pwd)/$(basename "$1")")
+done
+
+# Move relative to the top of the repo, so this script can be run from anywhere.
+cd "$REPO/trustfall_testbin"
+
 for INPUT_FILE in "$@"; do
     echo "> Starting on file $INPUT_FILE"
 

--- a/scripts/create_valid_query_data.sh
+++ b/scripts/create_valid_query_data.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # Get the absolute path of the repo.
 REPO="$(git rev-parse --show-toplevel)"
 
+INPUT_FILES=()
+
 for INPUT_FILE in "$@"; do
+    # makes sure we are always using absolute path 
+    INPUT_FILES+=("$(cd "$(dirname "$1")"; pwd)/$(basename "$1")")
+done
+
+# Move relative to the top of the repo, so this script can be run from anywhere.
+cd "$REPO/trustfall_testbin"
+
+for INPUT_FILE in $INPUT_FILES; do
     echo "> Starting on file $INPUT_FILE"
 
     DIR_NAME="$(dirname "$INPUT_FILE")"

--- a/trustfall_core/test_data/README.md
+++ b/trustfall_core/test_data/README.md
@@ -89,4 +89,3 @@ create `*.graphql-parsed.ron` and `*.frontend-error.ron` files.
 If you want to create a new valid query test, you can run:
 `./create_valid_query_data.sh ../trustfall_core/test_data/tests/valid_queries/my_test.graphql.ron`.
 
-Scripts must be run inside the `scripts` folder.


### PR DESCRIPTION
I noticed most tests were doing `cd "$(git rev-parse --show-toplevel)/trustfall_testbin"`, except those that receive paths as parameters. My guess is those scripts were not doing that because the user may give relative paths and changing the directory will break user assumptions about it.

For those scripts, I transform any path the user set as arguments into an absolute path, so we can safely move directories.

I tested this by passing absolute paths and relative paths on Linux.