### PR TITLE
Does not allow properties to use fold

### DIFF
--- a/trustfall_core/src/frontend/error.rs
+++ b/trustfall_core/src/frontend/error.rs
@@ -109,6 +109,12 @@ pub enum FrontendError {
     #[error("The query failed to validate against the schema: {0}")]
     ValidationError(#[from] ValidationError),
 
+    #[error(
+        "The field \"{0}\" is a property but the query uses @fold.\
+     Only edges can be used with @fold."
+    )]
+    FoldOnProperty(String),
+
     #[error("Unexpected error: {0}")]
     OtherError(String),
 }

--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -1009,7 +1009,6 @@ where
             subfield_post_coercion_type,
             subfield_raw_type,
         ) = get_field_name_and_type_from_schema(defined_fields, subfield);
-
         if schema.vertex_types.contains_key(subfield_post_coercion_type.as_ref()) {
             // Processing an edge.
 
@@ -1103,6 +1102,11 @@ where
             || subfield_name.as_ref() == TYPENAME_META_FIELD
         {
             // Processing a property.
+
+            // @fold is not allowed on a property
+            if let Some(fold_group) = &connection.fold {
+                errors.push(FrontendError::FoldOnProperty(subfield.name.to_string()));
+            }
 
             let subfield_name: Arc<str> = subfield_name.as_ref().to_owned().into();
             let key = (current_vid, subfield_name.clone());

--- a/trustfall_core/test_data/tests/frontend_errors/fold_used_on_property.frontend-error.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/fold_used_on_property.frontend-error.ron
@@ -1,0 +1,1 @@
+Err(FoldOnProperty("vowelsInName"))

--- a/trustfall_core/test_data/tests/frontend_errors/fold_used_on_property.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/fold_used_on_property.graphql-parsed.ron
@@ -1,0 +1,53 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          output: [
+            OutputDirective(),
+          ],
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 5,
+            column: 9,
+          ),
+          name: "vowelsInName",
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 5,
+            column: 9,
+          ),
+          name: "vowelsInName",
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/frontend_errors/fold_used_on_property.graphql.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/fold_used_on_property.graphql.ron
@@ -1,0 +1,11 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        value @output
+        vowelsInName @fold
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/frontend_errors/transform_used_on_property.frontend-error.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/transform_used_on_property.frontend-error.ron
@@ -1,0 +1,1 @@
+Err(FoldOnProperty("vowelsInName"))

--- a/trustfall_core/test_data/tests/frontend_errors/transform_used_on_property.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/transform_used_on_property.graphql-parsed.ron
@@ -1,0 +1,63 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Two",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          output: [
+            OutputDirective(),
+          ],
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 5,
+            column: 9,
+          ),
+          name: "vowelsInName",
+          fold: Some(FoldGroup(
+            fold: FoldDirective(),
+            transform: Some(TransformGroup(
+              transform: TransformDirective(
+                kind: Count,
+              ),
+            )),
+          )),
+        ), FieldNode(
+          position: Pos(
+            line: 5,
+            column: 9,
+          ),
+          name: "vowelsInName",
+          transform_group: Some(TransformGroup(
+            transform: TransformDirective(
+              kind: Count,
+            ),
+          )),
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/frontend_errors/transform_used_on_property.graphql.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/transform_used_on_property.graphql.ron
@@ -1,0 +1,11 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Two {
+        value @output
+        vowelsInName @fold @transform(op: "count")
+    }
+}"#,
+    arguments: {},
+)


### PR DESCRIPTION
Fix https://github.com/obi1kenobi/trustfall/issues/450

Validates on the frontend if the query is doing `@fold` on a property.