### PR TITLE
Add better filter error message for string instead of array.

### DIFF
--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -72,6 +72,11 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
         {
             let value_list = match &value_argument.node {
                 Value::List(list) => Ok(list),
+                Value::String(argument_value) => Err(ParseError::FilterExpectsListNotString(
+                    op.to_owned(),
+                    argument_value.to_owned(),
+                    value_argument.pos,
+                )),
                 _ => Err(ParseError::InappropriateTypeForDirectiveArgument(
                     "@filter".to_owned(),
                     "value".to_owned(),

--- a/trustfall_core/src/graphql_query/error.rs
+++ b/trustfall_core/src/graphql_query/error.rs
@@ -24,6 +24,12 @@ pub enum ParseError {
     #[error("Directive {0} received value of inappropriate type for argument {1}")]
     InappropriateTypeForDirectiveArgument(String, String, Pos),
 
+    #[error(
+        "Directive @filter received a string instead of a list. \
+        Did you mean to put '@filter(op: \"{0}\", value: [\"{1}\"])' instead?"
+    )]
+    FilterExpectsListNotString(String, String, Pos),
+
     #[error("Field {0} received an invalid value for argument {1}: {2}")]
     InvalidFieldArgument(String, String, Value, Pos),
 

--- a/trustfall_core/src/graphql_query/error.rs
+++ b/trustfall_core/src/graphql_query/error.rs
@@ -25,7 +25,7 @@ pub enum ParseError {
     InappropriateTypeForDirectiveArgument(String, String, Pos),
 
     #[error(
-        "Directive @filter received a string instead of a list. \
+        "Value argument in @filter directive is a string instead of a list. \
         Did you mean to put '@filter(op: \"{0}\", value: [\"{1}\"])' instead?"
     )]
     FilterExpectsListNotString(String, String, Pos),

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_instead_of_array.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_instead_of_array.parse-error.ron
@@ -1,0 +1,4 @@
+Err(InappropriateTypeForDirectiveArgument("@filter", "value", Pos(
+  line: 4,
+  column: 39,
+)))

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_instead_of_array.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_instead_of_array.parse-error.ron
@@ -1,4 +1,4 @@
-Err(InappropriateTypeForDirectiveArgument("@filter", "value", Pos(
+Err(FilterExpectsListNotString("=", "$zero", Pos(
   line: 4,
   column: 39,
 )))

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_instead_of_array.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_instead_of_array.ron
@@ -1,0 +1,14 @@
+TestGraphQLQuery (
+    // The `value` in a filter expects an array with a single value instead of
+    // just a single value.
+    schema_name: "numbers",
+    query: r#"
+{
+    Zero {
+        value @filter(op: "=", value: "$zero")
+    }
+}"#,
+    arguments: {
+        "zero": Uint64(0)
+    },
+)


### PR DESCRIPTION
This is a common mistake for me so I can only imagine how many beginners fall into this trap, let's give a gentler error message for this case.

Example of the new error message: `Directive @filter received a string instead of a list. Did you mean to put '@filter(op: "!=", value: ["$empty_string"])' instead?`