### PR TITLE
Add error for filter where value argument is just ["$"] or ["%"]

### DIFF
--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -87,8 +87,8 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
                     .iter()
                     .map(|v| match v {
                         Value::String(s) => {
-                            let name = if s.starts_with('$') || s.starts_with('%') {
-                                s.split_at(1).1
+                            let (prefix, name) = if s.starts_with('$') || s.starts_with('%') {
+                                s.split_at(1)
                             } else {
                                 return Err(ParseError::OtherError(
                                     format!("Filter argument was expected to start with '$' or '%' but did not: {s}"),
@@ -96,8 +96,12 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
                                 ));
                             };
 
-                            // Empty names handled above already.
-                            assert!(!name.is_empty());
+                            if name.is_empty() {
+                                return Err(ParseError::OtherError(
+                                    format!("Filter argument is empty after '{}' prefix.", prefix),
+                                    value_argument.pos,
+                                ));
+                            }
 
                             let first_char = name.chars().next().unwrap();
                             if  !first_char.is_ascii_alphabetic() && first_char != '_' {

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_dollar_sign.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_dollar_sign.parse-error.ron
@@ -1,0 +1,4 @@
+Err(OtherError("Filter argument is empty after \'$\' prefix.", Pos(
+  line: 4,
+  column: 39,
+)))

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_dollar_sign.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_dollar_sign.ron
@@ -1,0 +1,11 @@
+TestGraphQLQuery (
+    // Purposefully use a string of just '$' to ensure that we handle that.
+    schema_name: "numbers",
+    query: r#"
+{
+    Zero {
+        value @filter(op: "=", value: ["$"])
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_percent_sign.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_percent_sign.parse-error.ron
@@ -1,0 +1,4 @@
+Err(OtherError("Filter argument is empty after \'%\' prefix.", Pos(
+  line: 4,
+  column: 39,
+)))

--- a/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_percent_sign.ron
+++ b/trustfall_core/test_data/tests/parse_errors/filter_with_value_of_just_percent_sign.ron
@@ -1,0 +1,11 @@
+TestGraphQLQuery (
+    // Purposefully use a string of just '%' to ensure that we handle that.
+    schema_name: "numbers",
+    query: r#"
+{
+    Zero {
+        value @filter(op: "=", value: ["%"])
+    }
+}"#,
+    arguments: {},
+)


### PR DESCRIPTION
Currently it panics, so let's just return an error instead.