### PR TITLE
Make stubgen emit `move` closures by default.

### DIFF
--- a/trustfall_stubgen/src/edges_creator.rs
+++ b/trustfall_stubgen/src/edges_creator.rs
@@ -156,7 +156,7 @@ fn make_edge_resolver_and_call(
             #fn_params
             _resolve_info: &ResolveEdgeInfo,
         ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
-            resolve_neighbors_with(contexts, |vertex| {
+            resolve_neighbors_with(contexts, move |vertex| {
                 let vertex = vertex.#conversion_fn_ident().expect(#expect_msg);
                 todo!(#todo_msg)
             })

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/edges.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/edges.rs
@@ -35,7 +35,7 @@ mod comment {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_comment()
                     .expect("conversion failed, vertex was not a Comment");
@@ -50,7 +50,7 @@ mod comment {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_comment()
                     .expect("conversion failed, vertex was not a Comment");
@@ -65,7 +65,7 @@ mod comment {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_comment()
                     .expect("conversion failed, vertex was not a Comment");
@@ -80,7 +80,7 @@ mod comment {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_comment()
                     .expect("conversion failed, vertex was not a Comment");
@@ -120,7 +120,7 @@ mod job {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_job()
                     .expect("conversion failed, vertex was not a Job");
@@ -162,7 +162,7 @@ mod story {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_story()
                     .expect("conversion failed, vertex was not a Story");
@@ -177,7 +177,7 @@ mod story {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_story()
                     .expect("conversion failed, vertex was not a Story");
@@ -192,7 +192,7 @@ mod story {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_story()
                     .expect("conversion failed, vertex was not a Story");
@@ -233,7 +233,7 @@ mod user {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_user()
                     .expect("conversion failed, vertex was not a User");
@@ -248,7 +248,7 @@ mod user {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_user()
                     .expect("conversion failed, vertex was not a User");

--- a/trustfall_stubgen/test_data/expected_outputs/use_reserved_rust_names_in_schema/adapter/edges.rs
+++ b/trustfall_stubgen/test_data/expected_outputs/use_reserved_rust_names_in_schema/adapter/edges.rs
@@ -32,7 +32,7 @@ mod const_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_const()
                     .expect("conversion failed, vertex was not a const");
@@ -72,7 +72,7 @@ mod continue_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_continue()
                     .expect("conversion failed, vertex was not a continue");
@@ -112,7 +112,7 @@ mod dyn_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_dyn()
                     .expect("conversion failed, vertex was not a dyn");
@@ -152,7 +152,7 @@ mod if_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_if()
                     .expect("conversion failed, vertex was not a if");
@@ -192,7 +192,7 @@ mod mod_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_mod()
                     .expect("conversion failed, vertex was not a mod");
@@ -232,7 +232,7 @@ mod self_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_self_()
                     .expect("conversion failed, vertex was not a self");
@@ -272,7 +272,7 @@ mod type_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_type()
                     .expect("conversion failed, vertex was not a type");
@@ -312,7 +312,7 @@ mod unsafe_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_unsafe()
                     .expect("conversion failed, vertex was not a unsafe");
@@ -352,7 +352,7 @@ mod where_ {
     ) -> ContextOutcomeIterator<'a, V, VertexIterator<'a, Vertex>> {
         resolve_neighbors_with(
             contexts,
-            |vertex| {
+            move |vertex| {
                 let vertex = vertex
                     .as_where()
                     .expect("conversion failed, vertex was not a where");


### PR DESCRIPTION
We almost never want a non-move closure when passing it to Trustfall helpers. This is the better default, since the alternative is practically guaranteed to expose users to tricky lifetime errors.
