### PR TITLE
Add information to unimplemented! messages

### DIFF
--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -124,7 +124,7 @@ directive @transform(op: String!) on FIELD
                 TypeSystemDefinition::Schema(s) => {
                     assert!(schema.is_none());
                     if s.node.extend {
-                        unimplemented!();
+                        unimplemented!("Trustfall does not support extending schemas");
                     }
 
                     schema = Some(s.node);
@@ -140,7 +140,7 @@ directive @transform(op: String!) on FIELD
                     assert!(!get_builtin_scalars().contains(type_name.as_ref()));
 
                     if node.extend {
-                        unimplemented!();
+                        unimplemented!("Trustfall does not support extending schemas");
                     }
 
                     match &node.kind {
@@ -160,9 +160,9 @@ directive @transform(op: String!) on FIELD
                                 }
                             }
                         }
-                        TypeKind::Enum(_) => unimplemented!(),
-                        TypeKind::Union(_) => unimplemented!(),
-                        TypeKind::InputObject(_) => unimplemented!(),
+                        TypeKind::Enum(_) => unimplemented!("Trustfall does not support enum's"),
+                        TypeKind::Union(_) => unimplemented!("Trustfall does not support unions's"),
+                        TypeKind::InputObject(_) => unimplemented!("Trustfall does not support input objects's"),
                     }
 
                     let field_defs = match node.kind {

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -162,7 +162,9 @@ directive @transform(op: String!) on FIELD
                         }
                         TypeKind::Enum(_) => unimplemented!("Trustfall does not support enum's"),
                         TypeKind::Union(_) => unimplemented!("Trustfall does not support unions's"),
-                        TypeKind::InputObject(_) => unimplemented!("Trustfall does not support input objects's"),
+                        TypeKind::InputObject(_) => {
+                            unimplemented!("Trustfall does not support input objects's")
+                        }
                     }
 
                     let field_defs = match node.kind {


### PR DESCRIPTION
The first time I ran `trustfall_stubgen` this is what I saw:
```
thread 'main' panicked at~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/trustfall_core-0.7.1/src/schema/mod.rs:163:46:
not implemented
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This should alleviate that a bit. At some point, we should also have a reference detailing the difference between Trustfall and GraphQl schemas.