### PR TITLE
Return an error if `@filter` directive is passed an unexpected argument.

### DIFF
--- a/trustfall_core/src/graphql_query/directives.rs
+++ b/trustfall_core/src/graphql_query/directives.rs
@@ -67,6 +67,16 @@ impl TryFrom<&Positioned<Directive>> for FilterDirective {
             )),
         }?;
 
+        for (argument_name, _) in value.node.arguments.iter() {
+            if !matches!(argument_name.node.as_str(), "op" | "value") {
+                return Err(ParseError::UnrecognizedDirectiveArgument(
+                    "@filter".to_owned(),
+                    argument_name.node.to_string(),
+                    argument_name.pos,
+                ));
+            }
+        }
+
         let mut parsed_args: SmallVec<[OperatorArgument; 2]> = if let Some(value_argument) =
             value.node.get_argument("value")
         {

--- a/trustfall_core/test_data/tests/parse_errors/typo_in_filter_value_argument_name.graphql.ron
+++ b/trustfall_core/test_data/tests/parse_errors/typo_in_filter_value_argument_name.graphql.ron
@@ -1,0 +1,17 @@
+TestGraphQLQuery (
+    // This test ensures that calling `@filter` with a typo in the `value` parameter
+    // produces an `UnrecognizedDirectiveArgument` error.
+    //
+    // The `values` argument to `@filter` should be `value` instead.
+    // Related to: https://github.com/obi1kenobi/trustfall/discussions/587
+    schema_name: "numbers",
+    query: r#"
+{
+    Number(max: 5) {
+        value @output @filter(op: "<", values: ["$six"])
+    }
+}"#,
+    arguments: {
+        "six": Int64(6)
+    },
+)

--- a/trustfall_core/test_data/tests/parse_errors/typo_in_filter_value_argument_name.parse-error.ron
+++ b/trustfall_core/test_data/tests/parse_errors/typo_in_filter_value_argument_name.parse-error.ron
@@ -1,0 +1,4 @@
+Err(UnrecognizedDirectiveArgument("@filter", "values", Pos(
+  line: 4,
+  column: 40,
+)))


### PR DESCRIPTION
Resolves #587.
