### PR TITLE
Fix new clippy lints.

### DIFF
--- a/trustfall_core/src/ir/indexed.rs
+++ b/trustfall_core/src/ir/indexed.rs
@@ -114,7 +114,7 @@ fn add_data_from_component(
     let component_optional_vertices = get_optional_vertices_in_component(component);
 
     // the root vertex Vid must belong to an existing vertex in the component
-    if component.vertices.get(&component.root).is_none() {
+    if !component.vertices.contains_key(&component.root) {
         return Err(InvalidIRQueryError::GetBetterVariant(-1));
     }
 

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -550,7 +550,7 @@ fn check_required_transitive_implementations(
                             // (`expected_impl_name != type_name`) since we have a dedicated
                             // check for those elsewhere.
                             if expected_impl_name != type_name.as_ref()
-                                && implementations.get(expected_impl_name).is_none()
+                                && !implementations.contains(expected_impl_name)
                             {
                                 errors.push(
                                     InvalidSchemaError::MissingTransitiveInterfaceImplementation(

--- a/trustfall_derive/tests/uses.rs
+++ b/trustfall_derive/tests/uses.rs
@@ -5,6 +5,7 @@ use trustfall_derive::TrustfallEnumVertex;
 
 #[test]
 fn empty_enum() {
+    #[allow(dead_code)]
     #[derive(Debug, Clone, TrustfallEnumVertex)]
     enum NoVariants {}
 }

--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -1,3 +1,7 @@
+// TODO: Remove this once new `wasm_bindgen` version is released.
+//       The lint is raised inside that macro. The fix is on the main branch but not released yet.
+#![allow(clippy::empty_docs)]
+
 use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
 
 use gloo_utils::format::JsValueSerdeExt;


### PR DESCRIPTION
The remaining `wasm_bindgen`-related lint is fixed on the main branch of that crate, and just needs a new release to be cut.
