### PR TITLE
WIP: Initial exploration of custom scalars / filters / transforms.

### DIFF
--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -16,6 +16,7 @@ use crate::frontend::error::FilterTypeError;
 pub use self::indexed::{EdgeKind, IndexedQuery, InvalidIRQueryError, Output};
 pub use self::types::{NamedTypedValue, Type};
 pub use self::value::{FieldValue, TransparentValue};
+pub(crate) use self::types::OperandType;
 
 mod indexed;
 mod types;

--- a/trustfall_core/src/ir/types/mod.rs
+++ b/trustfall_core/src/ir/types/mod.rs
@@ -2,4 +2,5 @@ mod base;
 mod named_typed;
 
 pub use base::Type;
+pub(crate) use base::OperandType;
 pub use named_typed::NamedTypedValue;

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -38,6 +38,23 @@ pub struct Schema {
     pub(crate) vertex_types: HashMap<Arc<str>, TypeDefinition>,
     pub(crate) fields: HashMap<(Arc<str>, Arc<str>), FieldDefinition>,
     pub(crate) field_origins: BTreeMap<(Arc<str>, Arc<str>), FieldOrigin>,
+    pub(crate) custom_filters: BTreeMap<Arc<str>, CustomFilter>,
+    pub(crate) custom_scalars: BTreeMap<Arc<str>, CustomScalar>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CustomScalar {
+    name: Arc<str>,
+    uuid: Arc<str>,
+    allowed_operators: BTreeSet<Arc<str>>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CustomFilter {
+    operator: Arc<str>,
+    operands: Vec<crate::ir::OperandType>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -248,6 +265,8 @@ directive @transform(op: String!) on FIELD
                 vertex_types,
                 fields,
                 field_origins: field_origins.expect("no field origins but also no errors"),
+                custom_filters: Default::default(),
+                custom_scalars: Default::default(),
             })
         } else {
             Err(errors.into())

--- a/trustfall_core/test_data/schemas/custom_scalars_transforms_and_filters.graphql
+++ b/trustfall_core/test_data/schemas/custom_scalars_transforms_and_filters.graphql
@@ -1,0 +1,94 @@
+directive @define_filter(op: String!, on_type: String!, operands: [String!]!) repeatable on SCHEMA | SCALAR
+directive @define_transform(op: String, on_type: String!, produces: String!) repeatable on SCHEMA | SCALAR
+
+directive @define_scalar(storage: String!, builtin_filters: [String!]) on SCALAR
+
+schema
+    @define_filter(op: "is_prime", on_type: "Int!", operands: [])
+    @define_filter(op: "is_prime_or_null", on_type: "Int", operands: [])
+    @define_filter(op: "list_size", on_type: "[_]!", operands: ["Int", "Int"])  # no variadics
+    @define_filter(op: "between", on_type: "String | Int | Float", operands: ["_", "_"])
+{
+    query: RootSchemaQuery
+}
+directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
+directive @tag(name: String) on FIELD
+directive @output(name: String) on FIELD
+directive @optional on FIELD
+directive @recurse(depth: Int!) on FIELD
+directive @fold on FIELD
+directive @transform(op: String!) on FIELD
+
+scalar DateTimeTz
+    @define_scalar(storage: "String!", builtin_filters: ["=", "!=", "<", ">", "<=", ">="])
+    # the below filter will unify with the one above defined over `String | Int | Float`
+    @define_filter(op: "between", on_type: "_", operands: ["_", "_"])
+    # the below can be applied to nullable types, and will produce null --
+    # can disallow this default by making `on_type: "_!"`;
+    # they will also automatically allow mapping the transform operator over a list of that type
+    @define_transform(op: "year", on_type: "_", produces: "Int!")
+    @define_transform(op: "month", on_type: "_", produces: "String!")
+    @define_transform(op: "day", on_type: "_", produces: "Int!")
+
+type RootSchemaQuery {
+    Number(min: Int! = 0, max: Int!): [Number!]
+
+    # same as Number(min, max), just testing
+    # the "implicit null default" behavior for nullable edge parameters
+    NumberImplicitNullDefault(min: Int, max: Int!): [Number!]
+
+    Zero: Number!
+    One: Number!
+    Two: Prime!
+    Four: Composite!
+}
+
+interface Named {
+    name: String
+}
+
+interface Number implements Named {
+    name: String
+    value: Int
+    vowelsInName: [String]
+
+    predecessor: Number
+    successor: Number!
+    multiple(max: Int!): [Composite!]
+}
+
+type Neither implements Number & Named {
+    name: String
+    value: Int
+    vowelsInName: [String]
+
+    predecessor: Number
+    successor: Number!
+    multiple(max: Int!): [Composite!]
+}
+
+type Prime implements Number & Named {
+    name: String
+    value: Int
+    vowelsInName: [String]
+
+    predecessor: Number
+    successor: Number!
+    multiple(max: Int!): [Composite!]
+}
+
+type Composite implements Number & Named {
+    name: String
+    value: Int
+    vowelsInName: [String]
+
+    predecessor: Number
+    successor: Number!
+    multiple(max: Int!): [Composite!]
+    divisor: [Number!]!
+    primeFactor: [Prime!]!
+}
+
+type Letter implements Named {
+    name: String
+}


### PR DESCRIPTION
We'll eventually want to allow schemas to define custom scalar types, custom filters for both built-in and custom scalar types, and custom transform operations on properties of all types.

This PR is a very early-stage exploration of what that could look like, both in terms of notation in the schema, and in underlying implementation.
