### PR TITLE
Allow query outputs to refer to a `FieldRef`.

### DIFF
--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -731,10 +731,7 @@ where
     // TODO: fixme, temporary hack to avoid changing the IRQueryComponent struct
     let hacked_outputs = component_outputs
         .into_iter()
-        .filter_map(|(k, v)| match v {
-            FieldRef::ContextField(c) => Some((k, c)),
-            FieldRef::FoldSpecificField(_) => None,
-        })
+        .filter(|(k, v)| !matches!(&v, FieldRef::FoldSpecificField(..)))
         .collect();
 
     Ok(IRQueryComponent {

--- a/trustfall_core/src/interpreter/helpers/correctness.rs
+++ b/trustfall_core/src/interpreter/helpers/correctness.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, fmt::Debug, num::NonZeroUsize, sync::Arc};
 use crate::{
     interpreter::{Adapter, DataContext, InterpretedQuery, ResolveEdgeInfo, ResolveInfo},
     ir::{
-        ContextField, EdgeParameters, Eid, FieldValue, IREdge, IRQuery, IRQueryComponent, IRVertex,
-        TransparentValue, Type, Vid,
+        ContextField, EdgeParameters, Eid, FieldRef, FieldValue, IREdge, IRQuery, IRQueryComponent,
+        IRVertex, TransparentValue, Type, Vid,
     },
     schema::{Schema, SchemaAdapter},
     TryIntoStruct,
@@ -166,11 +166,11 @@ fn make_resolve_info_for_property_check(
             edges: Default::default(),
             folds: Default::default(),
             outputs: btreemap! {
-                property_name.clone() => ContextField {
+                property_name.clone() => FieldRef::ContextField(ContextField {
                     vertex_id: vid,
                     field_name: property_name.clone(),
                     field_type: Type::parse(property_type).expect("not a valid type"),
-                }
+                })
             },
         }),
         variables: Default::default(),
@@ -324,11 +324,11 @@ fn make_resolve_edge_info_for_edge_check(
             },
             folds: Default::default(),
             outputs: btreemap! {
-                property_name.clone() => ContextField {
+                property_name.clone() => FieldRef::ContextField(ContextField {
                     vertex_id: vid,
                     field_name: property_name,
                     field_type: Type::parse("String!").expect("not a valid type"),
-                }
+                })
             },
         }),
         variables: Default::default(),
@@ -493,11 +493,11 @@ fn make_resolve_info_for_type_coercion(
             edges: Default::default(),
             folds: Default::default(),
             outputs: btreemap! {
-                typename_property.clone() => ContextField {
+                typename_property.clone() => FieldRef::ContextField(ContextField {
                     vertex_id: vid,
                     field_name: typename_property.clone(),
                     field_type: Type::parse("String!").expect("not a valid type"),
-                }
+                })
             },
         }),
         variables: Default::default(),

--- a/trustfall_core/src/interpreter/hints/vertex_info.rs
+++ b/trustfall_core/src/interpreter/hints/vertex_info.rs
@@ -165,8 +165,8 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
         let properties = current_component
             .outputs
             .values()
-            .filter(|c| c.vertex_id == current_vertex.vid)
-            .map(|c| RequiredProperty::new(c.field_name.clone()));
+            .filter(|c| c.defined_at() == current_vertex.vid)
+            .map(|c| RequiredProperty::new(c.field_name_arc()));
 
         let properties = properties.chain(
             current_vertex

--- a/trustfall_core/src/ir/indexed.rs
+++ b/trustfall_core/src/ir/indexed.rs
@@ -154,7 +154,7 @@ fn add_data_from_component(
     }
 
     for (output_name, field) in component.outputs.iter() {
-        let output_vid = field.vertex_id;
+        let output_vid = field.defined_at();
 
         // the output must be from a vertex in this component
         let output_component =
@@ -166,7 +166,7 @@ fn add_data_from_component(
         let output_name = output_name.clone();
         let output_type = get_output_type(
             output_vid,
-            &field.field_type,
+            field.field_type(),
             &component_optional_vertices,
             are_folds_optional,
         );

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -118,7 +118,7 @@ pub struct IRQueryComponent {
     pub folds: BTreeMap<Eid, Arc<IRFold>>,
 
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub outputs: BTreeMap<Arc<str>, ContextField>,
+    pub outputs: BTreeMap<Arc<str>, FieldRef>,
 }
 
 /// Intermediate representation of a query
@@ -316,6 +316,13 @@ impl FieldRef {
         match self {
             FieldRef::ContextField(c) => c.field_name.as_ref(),
             FieldRef::FoldSpecificField(f) => f.kind.field_name(),
+        }
+    }
+
+    pub fn field_name_arc(&self) -> Arc<str> {
+        match self {
+            FieldRef::ContextField(c) => c.field_name.clone(),
+            FieldRef::FoldSpecificField(f) => f.kind.field_name().into(),
         }
     }
 

--- a/trustfall_core/test_data/tests/execution_errors/both_missing_and_unused.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/both_missing_and_unused.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/invalid_argument_types.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/invalid_argument_types.ir.ron
@@ -33,11 +33,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/invalid_null_argument_values.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/invalid_null_argument_values.ir.ron
@@ -33,11 +33,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/missing_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/missing_argument.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/missing_unused_and_invalid_arguments.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/missing_unused_and_invalid_arguments.ir.ron
@@ -40,11 +40,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_list_with_null_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_list_with_null_argument.ir.ron
@@ -27,16 +27,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "intNonNullList": ContextField(
+        "intNonNullList": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "intNonNullList",
           field_type: "[Int]!",
-        ),
-        "nonNullIntList": ContextField(
+        )),
+        "nonNullIntList": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "nonNullIntList",
           field_type: "[Int!]",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_null_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_null_argument.ir.ron
@@ -27,16 +27,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "intNonNullList": ContextField(
+        "intNonNullList": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "intNonNullList",
           field_type: "[Int]!",
-        ),
-        "nonNullIntList": ContextField(
+        )),
+        "nonNullIntList": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "nonNullIntList",
           field_type: "[Int!]",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/execution_errors/unused_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/unused_argument.ir.ron
@@ -17,16 +17,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.ir.ron
@@ -23,16 +23,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "succ_is_named": ContextField(
+        "succ_is_named": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "name",
           field_type: "String",
-        ),
-        "zero": ContextField(
+        )),
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_and_prefix_output_names.trace.ron
@@ -204,16 +204,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "succ_is_named": ContextField(
+          "succ_is_named": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "name",
             field_type: "String",
-          ),
-          "zero": ContextField(
+          )),
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.ir.ron
@@ -23,16 +23,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "succ_value": ContextField(
+        "succ_value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "zero": ContextField(
+        )),
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_output_names.trace.ron
@@ -204,16 +204,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "succ_value": ContextField(
+          "succ_value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "zero": ContextField(
+          )),
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.ir.ron
@@ -33,16 +33,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "one": ContextField(
+        "one": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "successor": ContextField(
+        )),
+        "successor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
@@ -316,16 +316,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "one": ContextField(
+          "one": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "successor": ContextField(
+          )),
+          "successor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.ir.ron
@@ -23,16 +23,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "successor": ContextField(
+        "successor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/avoid_output_name_conflict_with_alias_name.trace.ron
@@ -204,16 +204,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "successor": ContextField(
+          "successor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.ir.ron
@@ -32,21 +32,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "prime": ContextField(
+              "prime": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_allows_additional_edge.trace.ron
@@ -1896,21 +1896,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "prime": ContextField(
+                "prime": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.ir.ron
@@ -30,16 +30,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "prime": ContextField(
+        "prime": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_edge.trace.ron
@@ -1346,16 +1346,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "prime": ContextField(
+          "prime": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.ir.ron
@@ -32,21 +32,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "prime": ContextField(
+              "prime": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_folded_edge.trace.ron
@@ -1187,21 +1187,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "prime": ContextField(
+                "prime": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.ir.ron
@@ -31,16 +31,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "prime": ContextField(
+        "prime": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
@@ -849,16 +849,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "prime": ContextField(
+          "prime": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.ir.ron
@@ -33,16 +33,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "prime": ContextField(
+        "prime": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_recursed_edge.trace.ron
@@ -2430,16 +2430,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "prime": ContextField(
+          "prime": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.ir.ron
@@ -65,21 +65,21 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "top_bottom_mult_value": ContextField(
+        "top_bottom_mult_value": ContextField(ContextField(
           vertex_id: Vid(5),
           field_name: "value",
           field_type: "Int",
-        ),
-        "top_bottom_value": ContextField(
+        )),
+        "top_bottom_value": ContextField(ContextField(
           vertex_id: Vid(4),
           field_name: "value",
           field_type: "Int",
-        ),
-        "top_value": ContextField(
+        )),
+        "top_value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/deep_optional.trace.ron
@@ -1979,21 +1979,21 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "top_bottom_mult_value": ContextField(
+          "top_bottom_mult_value": ContextField(ContextField(
             vertex_id: Vid(5),
             field_name: "value",
             field_type: "Int",
-          ),
-          "top_bottom_value": ContextField(
+          )),
+          "top_bottom_value": ContextField(ContextField(
             vertex_id: Vid(4),
             field_name: "value",
             field_type: "Int",
-          ),
-          "top_value": ContextField(
+          )),
+          "top_value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/duplicated_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/duplicated_edge.ir.ron
@@ -33,16 +33,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "one": ContextField(
+        "one": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "one2": ContextField(
+        )),
+        "one2": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/duplicated_edge.trace.ron
@@ -275,16 +275,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "one": ContextField(
+          "one": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "one2": ContextField(
+          )),
+          "one2": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.ir.ron
@@ -17,11 +17,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameter.trace.ron
@@ -517,11 +517,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.ir.ron
@@ -34,16 +34,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "multiple": ContextField(
+        "multiple": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/edge_parameters_on_non_root.trace.ron
@@ -609,16 +609,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "multiple": ContextField(
+          "multiple": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.ir.ron
@@ -30,21 +30,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "mult": ContextField(
+              "mult": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/empty_fold_output.trace.ron
@@ -163,21 +163,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "mult": ContextField(
+                "mult": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.ir.ron
@@ -52,21 +52,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "mult": ContextField(
+              "mult": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "succ": ContextField(
+        "succ": ContextField(ContextField(
           vertex_id: Vid(4),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/execute_fold_before_traverse.trace.ron
@@ -527,21 +527,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "mult": ContextField(
+                "mult": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "succ": ContextField(
+          "succ": ContextField(ContextField(
             vertex_id: Vid(4),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.ir.ron
@@ -23,21 +23,21 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "one": ContextField(
+        "one": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "succ_name": ContextField(
+        )),
+        "succ_name": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "name",
           field_type: "String",
-        ),
-        "two": ContextField(
+        )),
+        "two": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/explicit_output_overrides_alias.trace.ron
@@ -260,21 +260,21 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "one": ContextField(
+          "one": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "succ_name": ContextField(
+          )),
+          "succ_name": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "name",
             field_type: "String",
-          ),
-          "two": ContextField(
+          )),
+          "two": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.ir.ron
@@ -40,11 +40,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "value": ContextField(
+              "value": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           imported_tags: [

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -410,11 +410,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "value": ContextField(
+                "value": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             imported_tags: [

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
@@ -59,21 +59,21 @@ Ok(TestIRQuery(
                     ),
                   },
                   outputs: {
-                    "second": ContextField(
+                    "second": ContextField(ContextField(
                       vertex_id: Vid(3),
                       field_name: "value",
                       field_type: "Int",
-                    ),
+                    )),
                   },
                 ),
               ),
             },
             outputs: {
-              "first": ContextField(
+              "first": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           imported_tags: [

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -661,21 +661,21 @@ TestInterpreterOutputTrace(
                       ),
                     },
                     outputs: {
-                      "second": ContextField(
+                      "second": ContextField(ContextField(
                         vertex_id: Vid(3),
                         field_name: "value",
                         field_type: "Int",
-                      ),
+                      )),
                     },
                   ),
                 ),
               },
               outputs: {
-                "first": ContextField(
+                "first": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             imported_tags: [

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.ir.ron
@@ -26,16 +26,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "vowelsInName": ContextField(
+        )),
+        "vowelsInName": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "vowelsInName",
           field_type: "[String]",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
@@ -408,16 +408,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "vowelsInName": ContextField(
+          )),
+          "vowelsInName": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "vowelsInName",
             field_type: "[String]",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.ir.ron
@@ -43,16 +43,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "mult": ContextField(
+        "mult": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
@@ -1382,16 +1382,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "mult": ContextField(
+          "mult": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.ir.ron
@@ -43,16 +43,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "mult": ContextField(
+        "mult": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
@@ -1284,16 +1284,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "mult": ContextField(
+          "mult": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
@@ -503,11 +503,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
@@ -277,11 +277,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
@@ -632,11 +632,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
@@ -183,11 +183,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
@@ -183,11 +183,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
@@ -183,11 +183,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
@@ -330,11 +330,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
@@ -330,11 +330,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.ir.ron
@@ -23,16 +23,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
@@ -1903,16 +1903,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.ir.ron
@@ -39,11 +39,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "name": ContextField(
+              "name": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "name",
                 field_type: "String",
-              ),
+              )),
             },
           ),
         ),

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
@@ -326,11 +326,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "name": ContextField(
+                "name": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "name",
                   field_type: "String",
-                ),
+                )),
               },
             ),
           ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
@@ -455,11 +455,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -471,11 +471,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -413,11 +413,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -429,11 +429,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -413,11 +413,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -429,11 +429,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -413,11 +413,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -429,11 +429,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -413,11 +413,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -429,11 +429,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.trace.ron
@@ -278,11 +278,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -294,11 +294,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.trace.ron
@@ -573,11 +573,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -589,11 +589,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.trace.ron
@@ -573,11 +573,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -589,11 +589,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.trace.ron
@@ -573,11 +573,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -589,11 +589,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.trace.ron
@@ -278,11 +278,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -294,11 +294,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.trace.ron
@@ -278,11 +278,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -294,11 +294,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.trace.ron
@@ -573,11 +573,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -589,11 +589,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.trace.ron
@@ -573,11 +573,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -589,11 +589,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.ir.ron
@@ -65,11 +65,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.trace.ron
@@ -425,11 +425,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.trace.ron
@@ -278,11 +278,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -294,11 +294,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.ir.ron
@@ -45,11 +45,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.trace.ron
@@ -217,11 +217,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.ir.ron
@@ -45,11 +45,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.trace.ron
@@ -207,11 +207,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.ir.ron
@@ -45,11 +45,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.trace.ron
@@ -217,11 +217,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -60,11 +60,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -465,11 +465,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -484,11 +484,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.ir.ron
@@ -25,11 +25,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factor_numbers": ContextField(
+              "factor_numbers": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
@@ -163,11 +163,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factor_numbers": ContextField(
+                "factor_numbers": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.ir.ron
@@ -50,11 +50,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
@@ -337,11 +337,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.ir.ron
@@ -79,16 +79,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "start": ContextField(
+        "start": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "succ": ContextField(
+        )),
+        "succ": ContextField(ContextField(
           vertex_id: Vid(5),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.trace.ron
@@ -526,16 +526,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "start": ContextField(
+          "start": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "succ": ContextField(
+          )),
+          "succ": ContextField(ContextField(
             vertex_id: Vid(5),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.ir.ron
@@ -60,11 +60,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
@@ -379,11 +379,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.ir.ron
@@ -30,11 +30,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "value": ContextField(
+              "value": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_directive.trace.ron
@@ -213,11 +213,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "value": ContextField(
+                "value": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.ir.ron
@@ -47,11 +47,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "inner": ContextField(
+              "inner": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           imported_tags: [
@@ -71,11 +71,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.trace.ron
@@ -546,11 +546,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "inner": ContextField(
+                "inner": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             imported_tags: [
@@ -570,11 +570,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.ir.ron
@@ -46,11 +46,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "inner": ContextField(
+              "inner": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -62,11 +62,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.trace.ron
@@ -349,11 +349,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "inner": ContextField(
+                "inner": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -365,11 +365,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.ir.ron
@@ -47,11 +47,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "inner": ContextField(
+              "inner": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           imported_tags: [
@@ -70,11 +70,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.trace.ron
@@ -453,11 +453,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "inner": ContextField(
+                "inner": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             imported_tags: [
@@ -476,11 +476,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.ir.ron
@@ -46,11 +46,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "value": ContextField(
+              "value": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.trace.ron
@@ -271,11 +271,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "value": ContextField(
+                "value": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.ir.ron
@@ -47,11 +47,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "inner": ContextField(
+              "inner": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           imported_tags: [
@@ -64,11 +64,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.trace.ron
@@ -453,11 +453,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "inner": ContextField(
+                "inner": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             imported_tags: [
@@ -470,11 +470,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.ir.ron
@@ -44,11 +44,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.trace.ron
@@ -315,11 +315,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.ir.ron
@@ -63,16 +63,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "composite_value": ContextField(
+        "composite_value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "prime_factors": ContextField(
+        )),
+        "prime_factors": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.trace.ron
@@ -1166,16 +1166,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "composite_value": ContextField(
+          "composite_value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "prime_factors": ContextField(
+          )),
+          "prime_factors": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
@@ -283,11 +283,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
@@ -283,11 +283,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.trace.ron
@@ -283,11 +283,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.trace.ron
@@ -364,11 +364,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.trace.ron
@@ -203,11 +203,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.ir.ron
@@ -38,16 +38,16 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "value": ContextField(
+              "value": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
-              "zero": ContextField(
+              )),
+              "zero": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nonexistent_optional.trace.ron
@@ -273,16 +273,16 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "value": ContextField(
+                "value": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
-                "zero": ContextField(
+                )),
+                "zero": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "prime": ContextField(
+              "prime": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.trace.ron
@@ -410,11 +410,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "prime": ContextField(
+                "prime": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -426,11 +426,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "prime": ContextField(
+              "prime": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           post_filters: [
@@ -48,11 +48,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.trace.ron
@@ -194,11 +194,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "prime": ContextField(
+                "prime": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             post_filters: [
@@ -210,11 +210,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
@@ -59,11 +59,11 @@ Ok(TestIRQuery(
                     ),
                   },
                   outputs: {
-                    "second": ContextField(
+                    "second": ContextField(ContextField(
                       vertex_id: Vid(3),
                       field_name: "value",
                       field_type: "Int",
-                    ),
+                    )),
                   },
                 ),
                 imported_tags: [
@@ -76,11 +76,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "first": ContextField(
+              "first": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -557,11 +557,11 @@ TestInterpreterOutputTrace(
                       ),
                     },
                     outputs: {
-                      "second": ContextField(
+                      "second": ContextField(ContextField(
                         vertex_id: Vid(3),
                         field_name: "value",
                         field_type: "Int",
-                      ),
+                      )),
                     },
                   ),
                   imported_tags: [
@@ -574,11 +574,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "first": ContextField(
+                "first": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.ir.ron
@@ -34,16 +34,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "base": ContextField(
+        "base": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_coercion_in_recurse_to_supertype.trace.ron
@@ -2501,16 +2501,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "base": ContextField(
+          "base": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.ir.ron
@@ -17,11 +17,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_null_for_nullable_edge_parameter.trace.ron
@@ -124,11 +124,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.ir.ron
@@ -33,16 +33,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "successor_value": ContextField(
+        "successor_value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
@@ -316,16 +316,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "successor_value": ContextField(
+          "successor_value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.ir.ron
@@ -37,11 +37,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
@@ -266,11 +266,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -62,11 +62,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "multiples": ContextField(
+              "multiples": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -75,11 +75,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -714,11 +714,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -744,11 +744,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "multiples": ContextField(
+                "multiples": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -757,11 +757,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.ir.ron
@@ -30,16 +30,16 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "name": ContextField(
+              "name": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "name",
                 field_type: "String",
-              ),
-              "value": ContextField(
+              )),
+              "value": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_outputs.trace.ron
@@ -580,16 +580,16 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "name": ContextField(
+                "name": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "name",
                   field_type: "String",
-                ),
-                "value": ContextField(
+                )),
+                "value": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.ir.ron
@@ -30,11 +30,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "mult": ContextField(
+              "mult": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
@@ -52,21 +52,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "div": ContextField(
+              "div": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_folds.trace.ron
@@ -570,11 +570,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "mult": ContextField(
+                "mult": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
@@ -592,21 +592,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "div": ContextField(
+                "div": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.ir.ron
@@ -55,31 +55,31 @@ Ok(TestIRQuery(
                     ),
                   },
                   outputs: {
-                    "mult": ContextField(
+                    "mult": ContextField(ContextField(
                       vertex_id: Vid(3),
                       field_name: "value",
                       field_type: "Int",
-                    ),
+                    )),
                   },
                 ),
               ),
             },
             outputs: {
-              "value": ContextField(
+              "value": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "base": ContextField(
+        "base": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold.trace.ron
@@ -3884,31 +3884,31 @@ TestInterpreterOutputTrace(
                       ),
                     },
                     outputs: {
-                      "mult": ContextField(
+                      "mult": ContextField(ContextField(
                         vertex_id: Vid(3),
                         field_name: "value",
                         field_type: "Int",
-                      ),
+                      )),
                     },
                   ),
                 ),
               },
               outputs: {
-                "value": ContextField(
+                "value": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "base": ContextField(
+          "base": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.ir.ron
@@ -51,11 +51,11 @@ Ok(TestIRQuery(
                     ),
                   },
                   outputs: {
-                    "multiples": ContextField(
+                    "multiples": ContextField(ContextField(
                       vertex_id: Vid(3),
                       field_name: "value",
                       field_type: "Int",
-                    ),
+                    )),
                   },
                 ),
                 fold_specific_outputs: {
@@ -64,11 +64,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -77,11 +77,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
@@ -972,11 +972,11 @@ TestInterpreterOutputTrace(
                       ),
                     },
                     outputs: {
-                      "multiples": ContextField(
+                      "multiples": ContextField(ContextField(
                         vertex_id: Vid(3),
                         field_name: "value",
                         field_type: "Int",
-                      ),
+                      )),
                     },
                   ),
                   fold_specific_outputs: {
@@ -985,11 +985,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -998,11 +998,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.ir.ron
@@ -65,11 +65,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
@@ -567,11 +567,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.ir.ron
@@ -29,16 +29,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "successor": ContextField(
+        "successor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_query.trace.ron
@@ -548,16 +548,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "successor": ContextField(
+          "successor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/no_op_fragment.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/no_op_fragment.ir.ron
@@ -23,11 +23,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/no_op_fragment.trace.ron
@@ -150,11 +150,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.ir.ron
@@ -38,11 +38,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "successors": ContextField(
+              "successors": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -51,16 +51,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "predecessor": ContextField(
+        "predecessor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "zero": ContextField(
+        )),
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
@@ -291,11 +291,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "successors": ContextField(
+                "successors": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -304,16 +304,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "predecessor": ContextField(
+          "predecessor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "zero": ContextField(
+          )),
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.ir.ron
@@ -35,21 +35,21 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "predecessor": ContextField(
+        "predecessor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "successors": ContextField(
+        )),
+        "successors": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
-        "zero": ContextField(
+        )),
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_optional.trace.ron
@@ -325,21 +325,21 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "predecessor": ContextField(
+          "predecessor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "successors": ContextField(
+          )),
+          "successors": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
-          "zero": ContextField(
+          )),
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.ir.ron
@@ -35,16 +35,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "mult": ContextField(
+        "mult": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_directive.trace.ron
@@ -1095,16 +1095,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "mult": ContextField(
+          "mult": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.ir.ron
@@ -43,11 +43,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.trace.ron
@@ -240,11 +240,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.ir.ron
@@ -44,11 +44,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.trace.ron
@@ -300,11 +300,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.ir.ron
@@ -33,16 +33,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "predecessor": ContextField(
+        "predecessor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.trace.ron
@@ -191,16 +191,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "predecessor": ContextField(
+          "predecessor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.ir.ron
@@ -34,16 +34,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "predecessor": ContextField(
+        "predecessor": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.trace.ron
@@ -249,16 +249,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "predecessor": ContextField(
+          "predecessor": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_required_edge_semantics.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_required_edge_semantics.ir.ron
@@ -34,11 +34,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_required_edge_semantics.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_required_edge_semantics.trace.ron
@@ -179,11 +179,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.ir.ron
@@ -25,11 +25,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -38,11 +38,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
@@ -249,11 +249,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -262,11 +262,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.ir.ron
@@ -32,11 +32,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "factors": ContextField(
+              "factors": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           fold_specific_outputs: {
@@ -45,11 +45,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
@@ -913,11 +913,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "factors": ContextField(
+                "factors": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             fold_specific_outputs: {
@@ -926,11 +926,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.ir.ron
@@ -36,21 +36,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "multiple": ContextField(
+              "multiple": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/outputs_both_inside_and_outside_fold.trace.ron
@@ -649,21 +649,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "multiple": ContextField(
+                "multiple": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.ir.ron
@@ -47,21 +47,21 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "base": ContextField(
+        "base": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "mult": ContextField(
+        )),
+        "mult": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_and_traverse.trace.ron
@@ -4132,21 +4132,21 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "base": ContextField(
+          "base": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "mult": ContextField(
+          )),
+          "mult": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.ir.ron
@@ -32,16 +32,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "next": ContextField(
+        "next": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "value": ContextField(
+        )),
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_directive.trace.ron
@@ -2012,16 +2012,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "next": ContextField(
+          "next": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "value": ContextField(
+          )),
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.ir.ron
@@ -31,11 +31,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_on_parameterized_edge.trace.ron
@@ -1305,11 +1305,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.trace.ron
@@ -737,11 +737,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.trace.ron
@@ -1340,11 +1340,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -2091,11 +2091,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.ir.ron
@@ -41,11 +41,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -1991,11 +1991,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.ir.ron
@@ -42,11 +42,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.trace.ron
@@ -1414,11 +1414,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.ir.ron
@@ -42,11 +42,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.trace.ron
@@ -2435,11 +2435,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.ir.ron
@@ -46,11 +46,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(4),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_nested_required_edge_depth_two.trace.ron
@@ -616,11 +616,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(4),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.ir.ron
@@ -36,11 +36,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_required_edge_depth_one.trace.ron
@@ -295,11 +295,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/required_properties.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties.ir.ron
@@ -67,21 +67,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "name": ContextField(
+              "name": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "name",
                 field_type: "String",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/required_properties.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties.trace.ron
@@ -950,21 +950,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "name": ContextField(
+                "name": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "name",
                   field_type: "String",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.ir.ron
@@ -33,16 +33,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "vowelsInName": ContextField(
+        )),
+        "vowelsInName": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "vowelsInName",
           field_type: "[String]",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.trace.ron
@@ -199,16 +199,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "vowelsInName": ContextField(
+          )),
+          "vowelsInName": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "vowelsInName",
             field_type: "[String]",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.ir.ron
@@ -18,11 +18,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/root_coercion.trace.ron
@@ -521,11 +521,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "number_name": ContextField(
+        "number_name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
@@ -215,11 +215,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "number_name": ContextField(
+          "number_name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.ir.ron
@@ -17,11 +17,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "number_name": ContextField(
+        "number_name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_query.trace.ron
@@ -198,11 +198,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "number_name": ContextField(
+          "number_name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.ir.ron
@@ -46,11 +46,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.trace.ron
@@ -533,11 +533,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.ir.ron
@@ -64,16 +64,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "start": ContextField(
+        "start": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "target": ContextField(
+        )),
+        "target": ContextField(ContextField(
           vertex_id: Vid(4),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -1119,16 +1119,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "start": ContextField(
+          "start": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "target": ContextField(
+          )),
+          "target": ContextField(ContextField(
             vertex_id: Vid(4),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.ir.ron
@@ -21,11 +21,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "name": ContextField(
+        "name": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "name",
           field_type: "String",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
@@ -156,11 +156,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "name": ContextField(
+          "name": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "name",
             field_type: "String",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.ir.ron
@@ -59,16 +59,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "m1_value": ContextField(
+        "m1_value": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "m2_value": ContextField(
+        )),
+        "m2_value": ContextField(ContextField(
           vertex_id: Vid(3),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -1636,16 +1636,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "m1_value": ContextField(
+          "m1_value": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "m2_value": ContextField(
+          )),
+          "m2_value": ContextField(ContextField(
             vertex_id: Vid(3),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.ir.ron
@@ -104,21 +104,21 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "mult": ContextField(
+        "mult": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "start": ContextField(
+        )),
+        "start": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
-        "succ": ContextField(
+        )),
+        "succ": ContextField(ContextField(
           vertex_id: Vid(7),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -2207,21 +2207,21 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "mult": ContextField(
+          "mult": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "start": ContextField(
+          )),
+          "start": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
-          "succ": ContextField(
+          )),
+          "succ": ContextField(ContextField(
             vertex_id: Vid(7),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.ir.ron
@@ -108,11 +108,11 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "succ": ContextField(
+              "succ": ContextField(ContextField(
                 vertex_id: Vid(7),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
           imported_tags: [
@@ -125,16 +125,16 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "mult": ContextField(
+        "mult": ContextField(ContextField(
           vertex_id: Vid(2),
           field_name: "value",
           field_type: "Int",
-        ),
-        "start": ContextField(
+        )),
+        "start": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.trace.ron
@@ -2509,11 +2509,11 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "succ": ContextField(
+                "succ": ContextField(ContextField(
                   vertex_id: Vid(7),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
             imported_tags: [
@@ -2526,16 +2526,16 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "mult": ContextField(
+          "mult": ContextField(ContextField(
             vertex_id: Vid(2),
             field_name: "value",
             field_type: "Int",
-          ),
-          "start": ContextField(
+          )),
+          "start": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.ir.ron
@@ -26,11 +26,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
     variables: {

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
@@ -163,11 +163,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
       variables: {

--- a/trustfall_core/test_data/tests/valid_queries/typename_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output.ir.ron
@@ -11,11 +11,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "__typename": ContextField(
+        "__typename": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "__typename",
           field_type: "String!",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output.trace.ron
@@ -81,11 +81,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "__typename": ContextField(
+          "__typename": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "__typename",
             field_type: "String!",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/typename_output_on_final_type.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output_on_final_type.ir.ron
@@ -11,11 +11,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "__typename": ContextField(
+        "__typename": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "__typename",
           field_type: "String!",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/typename_output_on_final_type.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_output_on_final_type.trace.ron
@@ -81,11 +81,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "__typename": ContextField(
+          "__typename": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "__typename",
             field_type: "String!",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.ir.ron
@@ -39,11 +39,11 @@ Ok(TestIRQuery(
         ),
       },
       outputs: {
-        "value": ContextField(
+        "value": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -370,11 +370,11 @@ TestInterpreterOutputTrace(
           ),
         },
         outputs: {
-          "value": ContextField(
+          "value": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.ir.ron
@@ -53,11 +53,11 @@ Ok(TestIRQuery(
                           ),
                         },
                         outputs: {
-                          "next_successors": ContextField(
+                          "next_successors": ContextField(ContextField(
                             vertex_id: Vid(4),
                             field_name: "value",
                             field_type: "Int",
-                          ),
+                          )),
                         },
                       ),
                       fold_specific_outputs: {
@@ -66,11 +66,11 @@ Ok(TestIRQuery(
                     ),
                   },
                   outputs: {
-                    "successors": ContextField(
+                    "successors": ContextField(ContextField(
                       vertex_id: Vid(3),
                       field_name: "value",
                       field_type: "Int",
-                    ),
+                    )),
                   },
                 ),
                 fold_specific_outputs: {
@@ -79,21 +79,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "predecessor": ContextField(
+              "predecessor": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "zero": ContextField(
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
@@ -218,11 +218,11 @@ TestInterpreterOutputTrace(
                             ),
                           },
                           outputs: {
-                            "next_successors": ContextField(
+                            "next_successors": ContextField(ContextField(
                               vertex_id: Vid(4),
                               field_name: "value",
                               field_type: "Int",
-                            ),
+                            )),
                           },
                         ),
                         fold_specific_outputs: {
@@ -231,11 +231,11 @@ TestInterpreterOutputTrace(
                       ),
                     },
                     outputs: {
-                      "successors": ContextField(
+                      "successors": ContextField(ContextField(
                         vertex_id: Vid(3),
                         field_name: "value",
                         field_type: "Int",
-                      ),
+                      )),
                     },
                   ),
                   fold_specific_outputs: {
@@ -244,21 +244,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "predecessor": ContextField(
+                "predecessor": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "zero": ContextField(
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.ir.ron
@@ -37,26 +37,26 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "predecessor": ContextField(
+              "predecessor": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
-              "successors": ContextField(
+              )),
+              "successors": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "zero": ContextField(
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_edge.trace.ron
@@ -193,26 +193,26 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "predecessor": ContextField(
+                "predecessor": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
-                "successors": ContextField(
+                )),
+                "successors": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "zero": ContextField(
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.ir.ron
@@ -39,11 +39,11 @@ Ok(TestIRQuery(
                     ),
                   },
                   outputs: {
-                    "successors": ContextField(
+                    "successors": ContextField(ContextField(
                       vertex_id: Vid(3),
                       field_name: "value",
                       field_type: "Int",
-                    ),
+                    )),
                   },
                 ),
                 fold_specific_outputs: {
@@ -52,21 +52,21 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "predecessor": ContextField(
+              "predecessor": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "zero": ContextField(
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
@@ -198,11 +198,11 @@ TestInterpreterOutputTrace(
                       ),
                     },
                     outputs: {
-                      "successors": ContextField(
+                      "successors": ContextField(ContextField(
                         vertex_id: Vid(3),
                         field_name: "value",
                         field_type: "Int",
-                      ),
+                      )),
                     },
                   ),
                   fold_specific_outputs: {
@@ -211,21 +211,21 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "predecessor": ContextField(
+                "predecessor": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "zero": ContextField(
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.ir.ron
@@ -38,26 +38,26 @@ Ok(TestIRQuery(
               ),
             },
             outputs: {
-              "predecessor": ContextField(
+              "predecessor": ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",
-              ),
-              "successors": ContextField(
+              )),
+              "successors": ContextField(ContextField(
                 vertex_id: Vid(3),
                 field_name: "value",
                 field_type: "Int",
-              ),
+              )),
             },
           ),
         ),
       },
       outputs: {
-        "zero": ContextField(
+        "zero": ContextField(ContextField(
           vertex_id: Vid(1),
           field_name: "value",
           field_type: "Int",
-        ),
+        )),
       },
     ),
   ),

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_optional_edge.trace.ron
@@ -194,26 +194,26 @@ TestInterpreterOutputTrace(
                 ),
               },
               outputs: {
-                "predecessor": ContextField(
+                "predecessor": ContextField(ContextField(
                   vertex_id: Vid(2),
                   field_name: "value",
                   field_type: "Int",
-                ),
-                "successors": ContextField(
+                )),
+                "successors": ContextField(ContextField(
                   vertex_id: Vid(3),
                   field_name: "value",
                   field_type: "Int",
-                ),
+                )),
               },
             ),
           ),
         },
         outputs: {
-          "zero": ContextField(
+          "zero": ContextField(ContextField(
             vertex_id: Vid(1),
             field_name: "value",
             field_type: "Int",
-          ),
+          )),
         },
       ),
     ),


### PR DESCRIPTION
First part of supporting `@transform` on properties.
