### PR TITLE
Accept `FieldRef` for fold-specific field outputs in IR.

### DIFF
--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -1309,7 +1309,7 @@ where
             };
 
             let prior_output_by_that_name =
-                fold_specific_outputs.insert(final_output_name.clone(), fold_specific_field.kind);
+                fold_specific_outputs.insert(final_output_name.clone(), field_ref.clone());
             if let Some(prior_output_kind) = prior_output_by_that_name {
                 errors.push(FrontendError::MultipleOutputsWithSameName(DuplicatedNamesConflict {
                     duplicates: btreemap! {
@@ -1324,9 +1324,7 @@ where
         for tag_directive in &transform_group.tag {
             let tag_name = tag_directive.name.as_ref().map(|x| x.as_ref());
             if let Some(tag_name) = tag_name {
-                let field = FieldRef::FoldSpecificField(fold_specific_field.clone());
-
-                if let Err(e) = tags.register_tag(tag_name, field, component_path) {
+                if let Err(e) = tags.register_tag(tag_name, field_ref.clone(), component_path) {
                     errors.push(FrontendError::MultipleTagsWithSameName(tag_name.to_string()));
                 }
             } else {

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -210,8 +210,12 @@ pub struct IRFold {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub imported_tags: Vec<FieldRef>,
 
+    /// Outputs from this fold that are derived from fold-specific fields.
+    ///
+    /// All [`FieldRef`] values in the map are guaranteed to have
+    /// `[FieldRef].refers_to_fold_specific_field().is_some() == true`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub fold_specific_outputs: BTreeMap<Arc<str>, FoldSpecificFieldKind>,
+    pub fold_specific_outputs: BTreeMap<Arc<str>, FieldRef>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub post_filters: Vec<Operation<FoldSpecificFieldKind, Argument>>,
@@ -324,6 +328,13 @@ impl FieldRef {
         match self {
             FieldRef::ContextField(c) => c.vertex_id,
             FieldRef::FoldSpecificField(f) => f.fold_root_vid,
+        }
+    }
+
+    pub fn refers_to_fold_specific_field(&self) -> Option<&FoldSpecificField> {
+        match self {
+            FieldRef::ContextField(_) => None,
+            FieldRef::FoldSpecificField(fold_specific) => Some(fold_specific),
         }
     }
 }

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
@@ -49,7 +49,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "primeFactorcount": Count,
+            "primeFactorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
           post_filters: [
             Equals(Count, Variable(VariableRef(

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -473,7 +473,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "primeFactorcount": Count,
+              "primeFactorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
             post_filters: [
               Equals(Count, Variable(VariableRef(

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "factor_count": Count,
+            "factor_count": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_prefixed_output_name.trace.ron
@@ -171,7 +171,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "factor_count": Count,
+              "factor_count": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.ir.ron
@@ -74,7 +74,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "count": Count,
+            "count": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(3),
+              fold_root_vid: Vid(4),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.trace.ron
@@ -521,7 +521,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "count": Count,
+              "count": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(3),
+                fold_root_vid: Vid(4),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.ir.ron
@@ -41,7 +41,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "predecessorcount": Count,
+            "predecessorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )),
           },
           post_filters: [
             Equals(Count, Tag(FoldSpecificField(FoldSpecificField(

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
@@ -196,7 +196,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "predecessorcount": Count,
+              "predecessorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )),
             },
             post_filters: [
               Equals(Count, Tag(FoldSpecificField(FoldSpecificField(

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "primeFactorcount": Count,
+            "primeFactorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
           post_filters: [
             GreaterThanOrEqual(Count, Variable(VariableRef(

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.trace.ron
@@ -304,7 +304,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "primeFactorcount": Count,
+              "primeFactorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
             post_filters: [
               GreaterThanOrEqual(Count, Variable(VariableRef(

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "primeFactorcount": Count,
+            "primeFactorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
         ),
         Eid(2): IRFold(
@@ -70,7 +74,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "multiplecount": Count,
+            "multiplecount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_fold_count_outputs.trace.ron
@@ -722,7 +722,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "primeFactorcount": Count,
+              "primeFactorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
           ),
           Eid(2): IRFold(
@@ -752,7 +756,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "multiplecount": Count,
+              "multiplecount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.ir.ron
@@ -59,7 +59,11 @@ Ok(TestIRQuery(
                   },
                 ),
                 fold_specific_outputs: {
-                  "multiplecount": Count,
+                  "multiplecount": FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(2),
+                    fold_root_vid: Vid(3),
+                    kind: Count,
+                  )),
                 },
               ),
             },
@@ -72,7 +76,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "primeFactorcount": Count,
+            "primeFactorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_count_output.trace.ron
@@ -980,7 +980,11 @@ TestInterpreterOutputTrace(
                     },
                   ),
                   fold_specific_outputs: {
-                    "multiplecount": Count,
+                    "multiplecount": FoldSpecificField(FoldSpecificField(
+                      fold_eid: Eid(2),
+                      fold_root_vid: Vid(3),
+                      kind: Count,
+                    )),
                   },
                 ),
               },
@@ -993,7 +997,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "primeFactorcount": Count,
+              "primeFactorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.ir.ron
@@ -46,7 +46,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "successor_counts": Count,
+            "successor_counts": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_nested_fold.trace.ron
@@ -299,7 +299,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "successor_counts": Count,
+              "successor_counts": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "primeFactorcount": Count,
+            "primeFactorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count.trace.ron
@@ -257,7 +257,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "primeFactorcount": Count,
+              "primeFactorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           fold_specific_outputs: {
-            "primeFactorcount": Count,
+            "primeFactorcount": FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )),
           },
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/output_fold_count_multiple.trace.ron
@@ -921,7 +921,11 @@ TestInterpreterOutputTrace(
               },
             ),
             fold_specific_outputs: {
-              "primeFactorcount": Count,
+              "primeFactorcount": FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )),
             },
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.ir.ron
@@ -61,7 +61,11 @@ Ok(TestIRQuery(
                         },
                       ),
                       fold_specific_outputs: {
-                        "next_successor_counts": Count,
+                        "next_successor_counts": FoldSpecificField(FoldSpecificField(
+                          fold_eid: Eid(3),
+                          fold_root_vid: Vid(4),
+                          kind: Count,
+                        )),
                       },
                     ),
                   },
@@ -74,7 +78,11 @@ Ok(TestIRQuery(
                   },
                 ),
                 fold_specific_outputs: {
-                  "successor_counts": Count,
+                  "successor_counts": FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(2),
+                    fold_root_vid: Vid(3),
+                    kind: Count,
+                  )),
                 },
               ),
             },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_doubly_nested_folds.trace.ron
@@ -226,7 +226,11 @@ TestInterpreterOutputTrace(
                           },
                         ),
                         fold_specific_outputs: {
-                          "next_successor_counts": Count,
+                          "next_successor_counts": FoldSpecificField(FoldSpecificField(
+                            fold_eid: Eid(3),
+                            fold_root_vid: Vid(4),
+                            kind: Count,
+                          )),
                         },
                       ),
                     },
@@ -239,7 +243,11 @@ TestInterpreterOutputTrace(
                     },
                   ),
                   fold_specific_outputs: {
-                    "successor_counts": Count,
+                    "successor_counts": FoldSpecificField(FoldSpecificField(
+                      fold_eid: Eid(2),
+                      fold_root_vid: Vid(3),
+                      kind: Count,
+                    )),
                   },
                 ),
               },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.ir.ron
@@ -47,7 +47,11 @@ Ok(TestIRQuery(
                   },
                 ),
                 fold_specific_outputs: {
-                  "successor_counts": Count,
+                  "successor_counts": FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(2),
+                    fold_root_vid: Vid(3),
+                    kind: Count,
+                  )),
                 },
               ),
             },

--- a/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/zero_element_fold_with_nested_fold.trace.ron
@@ -206,7 +206,11 @@ TestInterpreterOutputTrace(
                     },
                   ),
                   fold_specific_outputs: {
-                    "successor_counts": Count,
+                    "successor_counts": FoldSpecificField(FoldSpecificField(
+                      fold_eid: Eid(2),
+                      fold_root_vid: Vid(3),
+                      kind: Count,
+                    )),
                   },
                 ),
               },


### PR DESCRIPTION
This lays the groundwork for allowing us to transform those values before outputting them.
