### PR TITLE
Allow `FieldRef` in fold post-filtering operations.

### DIFF
--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -1273,7 +1273,7 @@ where
                 component_path,
                 tags,
                 starting_vid,
-                fold_specific_field.kind,
+                field_ref.clone(),
                 filter_directive,
             ) {
                 Ok(filter) => post_filters.push(filter),

--- a/trustfall_core/src/interpreter/hints/filters.rs
+++ b/trustfall_core/src/interpreter/hints/filters.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, fmt::Debug, ops::Bound, sync::Arc};
 
 use itertools::Itertools;
 
-use crate::ir::{Argument, FieldValue, FoldSpecificFieldKind, IRFold, Operation};
+use crate::ir::{Argument, FieldRef, FieldValue, FoldSpecificFieldKind, IRFold, Operation};
 
 use super::{candidates::NullableValue, CandidateValue, Range};
 
@@ -124,8 +124,11 @@ pub(super) fn fold_requires_at_least_one_element(
     query_variables: &BTreeMap<Arc<str>, FieldValue>,
     fold: &IRFold,
 ) -> bool {
-    let relevant_filters =
-        fold.post_filters.iter().filter(|op| matches!(op.left(), FoldSpecificFieldKind::Count));
+    // TODO: When we support applying `@transform` to property-like values, we can update this logic
+    //       to be smarter and less conservative.
+    let relevant_filters = fold.post_filters.iter().filter(|op| {
+        matches!(op.left(), FieldRef::FoldSpecificField(f) if f.kind == FoldSpecificFieldKind::Count)
+    });
     let is_subject_field_nullable = false; // the "count" value can't be null
     candidate_from_statically_evaluated_filters(
         relevant_filters,

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -213,12 +213,18 @@ pub struct IRFold {
     /// Outputs from this fold that are derived from fold-specific fields.
     ///
     /// All [`FieldRef`] values in the map are guaranteed to have
-    /// `[FieldRef].refers_to_fold_specific_field().is_some() == true`.
+    /// `FieldRef.refers_to_fold_specific_field().is_some() == true`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub fold_specific_outputs: BTreeMap<Arc<str>, FieldRef>,
 
+    /// Filters that are applied on the fold as a whole.
+    ///
+    /// For example, as in `@fold @transform(op: "count") @filter(op: "=", value: ["$zero"])`.
+    ///
+    /// All [`FieldRef`] values inside each [`Operation`] within the `Vec` are guaranteed to have
+    /// `FieldRef.refers_to_fold_specific_field().is_some() == true`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub post_filters: Vec<Operation<FoldSpecificFieldKind, Argument>>,
+    pub post_filters: Vec<Operation<FieldRef, Argument>>,
 }
 
 #[non_exhaustive]

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            Equals(Count, Variable(VariableRef(
+            Equals(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter.trace.ron
@@ -463,7 +463,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              Equals(Count, Variable(VariableRef(
+              Equals(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            Equals(Count, Variable(VariableRef(
+            Equals(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "one",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_equals.trace.ron
@@ -421,7 +421,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              Equals(Count, Variable(VariableRef(
+              Equals(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "one",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less.trace.ron
@@ -421,7 +421,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThanOrEqual(Count, Variable(VariableRef(
+            LessThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "one",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_less_equals.trace.ron
@@ -421,7 +421,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThanOrEqual(Count, Variable(VariableRef(
+              LessThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "one",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            OneOf(Count, Variable(VariableRef(
+            OneOf(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "counts",
               variable_type: "[Int!]!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_early_prune_max_fold_size_one_of.trace.ron
@@ -421,7 +421,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              OneOf(Count, Variable(VariableRef(
+              OneOf(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "counts",
                 variable_type: "[Int!]!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            Equals(Count, Variable(VariableRef(
+            Equals(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_eq_with_negative_arg.trace.ron
@@ -286,7 +286,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              Equals(Count, Variable(VariableRef(
+              Equals(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThan(Count, Variable(VariableRef(
+            GreaterThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gt_with_negative_arg.trace.ron
@@ -581,7 +581,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThan(Count, Variable(VariableRef(
+              GreaterThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_gte_with_negative_arg.trace.ron
@@ -581,7 +581,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "over_i64_max",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_over_i64_max.trace.ron
@@ -581,7 +581,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "over_i64_max",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lt_with_negative_arg.trace.ron
@@ -286,7 +286,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThanOrEqual(Count, Variable(VariableRef(
+            LessThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_lte_with_negative_arg.trace.ron
@@ -286,7 +286,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThanOrEqual(Count, Variable(VariableRef(
+              LessThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            NotEquals(Count, Variable(VariableRef(
+            NotEquals(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_eq_with_negative_arg.trace.ron
@@ -581,7 +581,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              NotEquals(Count, Variable(VariableRef(
+              NotEquals(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            NotOneOf(Count, Variable(VariableRef(
+            NotOneOf(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "[Int!]!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_not_one_of_with_negative_arg.trace.ron
@@ -581,7 +581,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              NotOneOf(Count, Variable(VariableRef(
+              NotOneOf(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "[Int!]!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.ir.ron
@@ -52,11 +52,19 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "zero",
               variable_type: "Int!",
             ))),
-            LessThan(Count, Tag(ContextField(ContextField(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.trace.ron
@@ -412,11 +412,19 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "zero",
                 variable_type: "Int!",
               ))),
-              LessThan(Count, Tag(ContextField(ContextField(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            OneOf(Count, Variable(VariableRef(
+            OneOf(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "neg_two",
               variable_type: "[Int!]!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_one_of_with_negative_arg.trace.ron
@@ -286,7 +286,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              OneOf(Count, Variable(VariableRef(
+              OneOf(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "neg_two",
                 variable_type: "[Int!]!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.ir.ron
@@ -33,11 +33,19 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThan(Count, Variable(VariableRef(
+            GreaterThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),
-            GreaterThan(Count, Variable(VariableRef(
+            GreaterThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "three",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_gt.trace.ron
@@ -205,11 +205,19 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThan(Count, Variable(VariableRef(
+              GreaterThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),
-              GreaterThan(Count, Variable(VariableRef(
+              GreaterThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "three",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.ir.ron
@@ -33,11 +33,19 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "four",
               variable_type: "Int!",
             ))),
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_dominated_filter_lt.trace.ron
@@ -195,11 +195,19 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "four",
                 variable_type: "Int!",
               ))),
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.ir.ron
@@ -33,11 +33,19 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThan(Count, Variable(VariableRef(
+            GreaterThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "six",
               variable_type: "Int!",
             ))),
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "five",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_impossible_filter.trace.ron
@@ -205,11 +205,19 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThan(Count, Variable(VariableRef(
+              GreaterThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "six",
                 variable_type: "Int!",
               ))),
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "five",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
@@ -56,7 +56,11 @@ Ok(TestIRQuery(
             )),
           },
           post_filters: [
-            Equals(Count, Variable(VariableRef(
+            Equals(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -480,7 +480,11 @@ TestInterpreterOutputTrace(
               )),
             },
             post_filters: [
-              Equals(Count, Variable(VariableRef(
+              Equals(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.ir.ron
@@ -48,7 +48,11 @@ Ok(TestIRQuery(
             )),
           },
           post_filters: [
-            Equals(Count, Tag(FoldSpecificField(FoldSpecificField(
+            Equals(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )), Tag(FoldSpecificField(FoldSpecificField(
               fold_eid: Eid(1),
               fold_root_vid: Vid(2),
               kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_then_filter_on_fold.trace.ron
@@ -203,7 +203,11 @@ TestInterpreterOutputTrace(
               )),
             },
             post_filters: [
-              Equals(Count, Tag(FoldSpecificField(FoldSpecificField(
+              Equals(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )), Tag(FoldSpecificField(FoldSpecificField(
                 fold_eid: Eid(1),
                 fold_root_vid: Vid(2),
                 kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.ir.ron
@@ -62,7 +62,11 @@ Ok(TestIRQuery(
             )),
           ],
           post_filters: [
-            GreaterThanOrEqual(Count, Tag(ContextField(ContextField(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.trace.ron
@@ -561,7 +561,11 @@ TestInterpreterOutputTrace(
               )),
             ],
             post_filters: [
-              GreaterThanOrEqual(Count, Tag(ContextField(ContextField(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.ir.ron
@@ -54,7 +54,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "one",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.trace.ron
@@ -357,7 +357,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "one",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.ir.ron
@@ -62,7 +62,11 @@ Ok(TestIRQuery(
             )),
           ],
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(2),
+              fold_root_vid: Vid(3),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "one",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.trace.ron
@@ -468,7 +468,11 @@ TestInterpreterOutputTrace(
               )),
             ],
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(2),
+                fold_root_vid: Vid(3),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "one",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             )),
           },
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_output.trace.ron
@@ -311,7 +311,11 @@ TestInterpreterOutputTrace(
               )),
             },
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.ir.ron
@@ -55,7 +55,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.trace.ron
@@ -1158,7 +1158,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs.trace.ron
@@ -275,7 +275,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_elided_braces.trace.ron
@@ -275,7 +275,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThan(Count, Variable(VariableRef(
+            GreaterThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_greater_than.trace.ron
@@ -275,7 +275,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThan(Count, Variable(VariableRef(
+              GreaterThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_less_than.trace.ron
@@ -356,7 +356,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.ir.ron
@@ -33,7 +33,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            OneOf(Count, Variable(VariableRef(
+            OneOf(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes_count",
               variable_type: "[Int!]!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_outputs_transform_and_filter_one_of.trace.ron
@@ -195,7 +195,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              OneOf(Count, Variable(VariableRef(
+              OneOf(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes_count",
                 variable_type: "[Int!]!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThan(Count, Variable(VariableRef(
+            GreaterThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_greater_than.trace.ron
@@ -418,7 +418,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThan(Count, Variable(VariableRef(
+              GreaterThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.ir.ron
@@ -40,7 +40,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            LessThan(Count, Variable(VariableRef(
+            LessThan(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "min_primes",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_outputs_transform_and_filter_less_than.trace.ron
@@ -202,7 +202,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              LessThan(Count, Variable(VariableRef(
+              LessThan(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "min_primes",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.ir.ron
@@ -48,7 +48,11 @@ Ok(TestIRQuery(
                   },
                 ),
                 post_filters: [
-                  GreaterThanOrEqual(Count, Variable(VariableRef(
+                  GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                    fold_eid: Eid(2),
+                    fold_root_vid: Vid(3),
+                    kind: Count,
+                  )), Variable(VariableRef(
                     variable_name: "two",
                     variable_type: "Int!",
                   ))),
@@ -57,7 +61,11 @@ Ok(TestIRQuery(
             },
           ),
           post_filters: [
-            GreaterThanOrEqual(Count, Variable(VariableRef(
+            GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+              fold_eid: Eid(1),
+              fold_root_vid: Vid(2),
+              kind: Count,
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nested_fold_with_no_outputs.trace.ron
@@ -550,7 +550,11 @@ TestInterpreterOutputTrace(
                     },
                   ),
                   post_filters: [
-                    GreaterThanOrEqual(Count, Variable(VariableRef(
+                    GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                      fold_eid: Eid(2),
+                      fold_root_vid: Vid(3),
+                      kind: Count,
+                    )), Variable(VariableRef(
                       variable_name: "two",
                       variable_type: "Int!",
                     ))),
@@ -559,7 +563,11 @@ TestInterpreterOutputTrace(
               },
             ),
             post_filters: [
-              GreaterThanOrEqual(Count, Variable(VariableRef(
+              GreaterThanOrEqual(FoldSpecificField(FoldSpecificField(
+                fold_eid: Eid(1),
+                fold_root_vid: Vid(2),
+                kind: Count,
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),


### PR DESCRIPTION
This lays the groundwork for `@fold @transform(op: "count")` followed by more `@transform` operations before a subsequent `@filter`.
