### PR TITLE
Cleanup `Argument` type use by adding `evaluate_statically` method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0"
 

--- a/trustfall_core/src/interpreter/hints/tests/mod.rs
+++ b/trustfall_core/src/interpreter/hints/tests/mod.rs
@@ -1719,8 +1719,10 @@ mod dynamic_property_values {
 
                 let destination = info.destination();
 
-                let expected_values =
-                    [CandidateValue::Range(Range::with_end(Bound::Excluded("two".into()), true))];
+                let expected_values = [CandidateValue::Range(Range::with_end(
+                    Bound::Excluded(FieldValue::String("two".into())),
+                    true,
+                ))];
                 let candidate = destination.dynamically_required_property("name");
                 Box::new(
                     candidate
@@ -1817,7 +1819,7 @@ mod dynamic_property_values {
                         let destination = info.destination();
 
                         let expected_values = [CandidateValue::Range(Range::with_end(
-                            Bound::Excluded("two".into()),
+                            Bound::Excluded(FieldValue::String("two".into())),
                             true,
                         ))];
                         let candidate = destination.dynamically_required_property("name");

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -1,6 +1,7 @@
 //! Trustfall intermediate representation (IR)
 
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     collections::BTreeMap,
     fmt::Debug,
@@ -339,6 +340,18 @@ impl Argument {
         match self {
             Argument::Tag(t) => Some(t),
             Argument::Variable(_) => None,
+        }
+    }
+
+    pub(crate) fn evaluate_statically<'a>(
+        &self,
+        query_variables: &'a BTreeMap<Arc<str>, FieldValue>,
+    ) -> Option<Cow<'a, FieldValue>> {
+        match self {
+            Argument::Tag(..) => None,
+            Argument::Variable(var) => {
+                Some(Cow::Borrowed(&query_variables[var.variable_name.as_ref()]))
+            }
         }
     }
 }


### PR DESCRIPTION
Minor refactor and cleanup to support future quality-of-life improvements for Trustfall users, such as a new `Argument::Constant` variant that will enable shorthand to replace `@fold @transform(op: "count") @filter(...)` uses.