### PR TITLE
Refactor IR to allow transformed values on the LHS of filter operations.

### DIFF
--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -17,8 +17,8 @@ use crate::{
     ir::{
         get_typename_meta_field, Argument, ContextField, EdgeParameters, Eid, FieldRef, FieldValue,
         FoldSpecificField, FoldSpecificFieldKind, IREdge, IRFold, IRQuery, IRQueryComponent,
-        IRVertex, IndexedQuery, LocalField, Operation, Recursive, TransformationKind, Type, Vid,
-        TYPENAME_META_FIELD,
+        IRVertex, IndexedQuery, LocalField, Operation, OperationSubject, Recursive,
+        TransformationKind, Type, Vid, TYPENAME_META_FIELD,
     },
     schema::{get_builtin_scalars, FieldOrigin, Schema},
     util::{BTreeMapTryInsertExt, TryCollectUniqueKey},
@@ -232,7 +232,7 @@ fn make_local_field_filter_expr(
     property_name: &Arc<str>,
     property_type: &Type,
     filter_directive: &FilterDirective,
-) -> Result<Operation<LocalField, Argument>, Vec<FrontendError>> {
+) -> Result<Operation<OperationSubject, Argument>, Vec<FrontendError>> {
     let left = LocalField { field_name: property_name.clone(), field_type: property_type.clone() };
 
     filters::make_filter_expr(
@@ -240,7 +240,7 @@ fn make_local_field_filter_expr(
         component_path,
         tags,
         current_vertex_vid,
-        left,
+        OperationSubject::LocalField(left),
         filter_directive,
     )
 }

--- a/trustfall_core/src/interpreter/hints/vertex_info.rs
+++ b/trustfall_core/src/interpreter/hints/vertex_info.rs
@@ -10,7 +10,7 @@ use crate::{
     interpreter::InterpretedQuery,
     ir::{
         Argument, FieldRef, FieldValue, IREdge, IRFold, IRQueryComponent, IRVertex, LocalField,
-        Operation, Vid,
+        Operation, OperationSubject, Vid,
     },
 };
 
@@ -169,12 +169,12 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
             .filter(|c| c.vertex_id == current_vertex.vid)
             .map(|c| RequiredProperty::new(c.field_name.clone()));
 
-        let properties = properties.chain(
-            current_vertex
-                .filters
-                .iter()
-                .map(|f| RequiredProperty::new(f.left().field_name.clone())),
-        );
+        let properties = properties.chain(current_vertex.filters.iter().map(|f| {
+            RequiredProperty::new(match f.left() {
+                OperationSubject::LocalField(field) => field.field_name.clone(),
+                OperationSubject::TransformedField(_) => todo!(),
+            })
+        }));
 
         let properties = properties.chain(current_component.vertices.values().flat_map(|v| {
             v.filters
@@ -210,11 +210,12 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
         }
 
         let query_variables = self.query_variables();
+        let vertex = self.current_vertex();
 
         // We only care about filtering operations that are both:
         // - on the requested property of this vertex, and
         // - statically-resolvable, i.e. do not depend on tagged arguments
-        let mut relevant_filters = filters_on_local_property(self.current_vertex(), property)
+        let mut relevant_filters = filters_on_local_property(vertex, property)
             .filter(|op| {
                 // Either there's no "right-hand side" in the operator (as in "is_not_null"),
                 // or the right-hand side is a variable.
@@ -223,10 +224,24 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
             .peekable();
 
         // Early-return in case there are no filters that apply here.
-        let field = relevant_filters.peek()?.left();
+        let first_filter = relevant_filters.peek()?;
+
+        // We currently ignore filters applied to transformed values of local properties.
+        // This is sound because each filter we consider only *narrows* the set of possible values,
+        // meaning that non-evaluated filters are a lost optimization opportunity,
+        // not a correctness problem.
+        //
+        // If tweaking this logic, make sure to tweak the logic in `filters_on_local_property`
+        // as well -- their behaviors have to match!
+        //
+        // TODO: This is an optimization opportunity for the future.
+        let local_field = match first_filter.left() {
+            OperationSubject::LocalField(field) => field,
+            OperationSubject::TransformedField(_) => return None,
+        };
 
         let candidate =
-            compute_statically_known_candidate(field, relevant_filters, query_variables)
+            compute_statically_known_candidate(local_field, relevant_filters, query_variables)
                 .map(|x| x.into_owned());
         debug_assert!(
             // Ensure we never return a range variant with a completely unrestricted range.
@@ -288,8 +303,22 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
         // Early-return in case there are no filters that apply here.
         let first_filter = relevant_filters.first()?;
 
+        // We currently ignore filters applied to transformed values of local properties.
+        // This is sound because each filter we consider only *narrows* the set of possible values,
+        // meaning that non-evaluated filters are a lost optimization opportunity,
+        // not a correctness problem.
+        //
+        // If tweaking this logic, make sure to tweak the logic in `filters_on_local_property`
+        // as well -- their behaviors have to match!
+        //
+        // TODO: This is an optimization opportunity for the future.
+        let local_field = match first_filter.left() {
+            OperationSubject::LocalField(field) => field,
+            OperationSubject::TransformedField(_) => return None,
+        };
+
         let initial_candidate = self.statically_required_property(property).unwrap_or_else(|| {
-            if first_filter.left().field_type.nullable() {
+            if local_field.field_type.nullable() {
                 CandidateValue::All
             } else {
                 CandidateValue::Range(Range::full_non_null())
@@ -390,13 +419,27 @@ impl<T: InternalVertexInfo + super::sealed::__Sealed> VertexInfo for T {
 fn filters_on_local_property<'a: 'b, 'b>(
     vertex: &'a IRVertex,
     property_name: &'b str,
-) -> impl Iterator<Item = &'a Operation<LocalField, Argument>> + 'b {
-    vertex.filters.iter().filter(move |op| op.left().field_name.as_ref() == property_name)
+) -> impl Iterator<Item = &'a Operation<OperationSubject, Argument>> + 'b {
+    vertex.filters.iter().filter(move |op| {
+        let left = op.left();
+        match left {
+            OperationSubject::LocalField(field) => field.field_name.as_ref() == property_name,
+            OperationSubject::TransformedField(..) => {
+                // We are currently ignoring field transformations for purposes of determining
+                // required property values. This is sound because every new filter we account for
+                // can only *reduce* the set of values that are allowed, so skipping filters
+                // means we lose out on optimization opportunities without harming correctness.
+                //
+                // TODO: This is an opportunity for further optimization.
+                false
+            }
+        }
+    })
 }
 
 fn compute_statically_known_candidate<'a, 'b>(
     field: &'a LocalField,
-    relevant_filters: impl Iterator<Item = &'a Operation<LocalField, Argument>>,
+    relevant_filters: impl Iterator<Item = &'a Operation<OperationSubject, Argument>>,
     query_variables: &'b BTreeMap<Arc<str>, FieldValue>,
 ) -> Option<CandidateValue<Cow<'b, FieldValue>>> {
     let is_subject_field_nullable = field.field_type.nullable();
@@ -467,16 +510,16 @@ mod tests {
             // Both `= 1` and `!= 1` are impossible to satisfy simultaneously.
             (
                 vec![
-                    Operation::NotEquals(local_field.clone(), first_var.clone()),
-                    Operation::Equals(local_field.clone(), first_var.clone()),
+                    Operation::NotEquals(local_field.clone().into(), first_var.clone()),
+                    Operation::Equals(local_field.clone().into(), first_var.clone()),
                 ],
                 Some(CandidateValue::Impossible),
             ),
             // `= 2` and `!= 1` means the value must be 2.
             (
                 vec![
-                    Operation::NotEquals(local_field.clone(), first_var.clone()),
-                    Operation::Equals(local_field.clone(), second_var.clone()),
+                    Operation::NotEquals(local_field.clone().into(), first_var.clone()),
+                    Operation::Equals(local_field.clone().into(), second_var.clone()),
                 ],
                 Some(CandidateValue::Single(&variables["second"])),
             ),
@@ -484,8 +527,8 @@ mod tests {
             // `one_of [1, 2]` and `!= 1` allows only `2`.
             (
                 vec![
-                    Operation::OneOf(local_field.clone(), list_var.clone()),
-                    Operation::NotEquals(local_field.clone(), first_var.clone()),
+                    Operation::OneOf(local_field.clone().into(), list_var.clone()),
+                    Operation::NotEquals(local_field.clone().into(), first_var.clone()),
                 ],
                 Some(CandidateValue::Single(&variables["second"])),
             ),
@@ -493,8 +536,8 @@ mod tests {
             // `one_of [1, 2, 3]` and `not_one_of [1, 2]` allows only `3`.
             (
                 vec![
-                    Operation::OneOf(local_field.clone(), longer_list_var.clone()),
-                    Operation::NotOneOf(local_field.clone(), list_var.clone()),
+                    Operation::OneOf(local_field.clone().into(), longer_list_var.clone()),
+                    Operation::NotOneOf(local_field.clone().into(), list_var.clone()),
                 ],
                 Some(CandidateValue::Single(&variables["third"])),
             ),
@@ -502,8 +545,8 @@ mod tests {
             // `>= 2` and `not_one_of [1, 2]` produces the exclusive > 2 range
             (
                 vec![
-                    Operation::GreaterThanOrEqual(local_field.clone(), second_var.clone()),
-                    Operation::NotOneOf(local_field.clone(), list_var.clone()),
+                    Operation::GreaterThanOrEqual(local_field.clone().into(), second_var.clone()),
+                    Operation::NotOneOf(local_field.clone().into(), list_var.clone()),
                 ],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Excluded(&variables["second"]),
@@ -514,9 +557,9 @@ mod tests {
             // `>= 2` and `is_not_null` and `not_one_of [1, 2]` produces the exclusive non-null > 2 range
             (
                 vec![
-                    Operation::GreaterThanOrEqual(local_field.clone(), second_var.clone()),
-                    Operation::NotOneOf(local_field.clone(), list_var.clone()),
-                    Operation::IsNotNull(local_field.clone()),
+                    Operation::GreaterThanOrEqual(local_field.clone().into(), second_var.clone()),
+                    Operation::NotOneOf(local_field.clone().into(), list_var.clone()),
+                    Operation::IsNotNull(local_field.clone().into()),
                 ],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Excluded(&variables["second"]),
@@ -527,8 +570,8 @@ mod tests {
             // `> 2` and `is_not_null` produces the exclusive non-null > 2 range
             (
                 vec![
-                    Operation::GreaterThan(local_field.clone(), second_var.clone()),
-                    Operation::IsNotNull(local_field.clone()),
+                    Operation::GreaterThan(local_field.clone().into(), second_var.clone()),
+                    Operation::IsNotNull(local_field.clone().into()),
                 ],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Excluded(&variables["second"]),
@@ -539,9 +582,9 @@ mod tests {
             // `<= 2` and `!= 2` and `is_not_null` produces the exclusive non-null < 2 range
             (
                 vec![
-                    Operation::LessThanOrEqual(local_field.clone(), second_var.clone()),
-                    Operation::NotEquals(local_field.clone(), second_var.clone()),
-                    Operation::IsNotNull(local_field.clone()),
+                    Operation::LessThanOrEqual(local_field.clone().into(), second_var.clone()),
+                    Operation::NotEquals(local_field.clone().into(), second_var.clone()),
+                    Operation::IsNotNull(local_field.clone().into()),
                 ],
                 Some(CandidateValue::Range(Range::with_end(
                     Bound::Excluded(&variables["second"]),
@@ -552,8 +595,8 @@ mod tests {
             // `< 2` and `is_not_null` produces the exclusive non-null < 2 range
             (
                 vec![
-                    Operation::LessThan(local_field.clone(), second_var.clone()),
-                    Operation::IsNotNull(local_field.clone()),
+                    Operation::LessThan(local_field.clone().into(), second_var.clone()),
+                    Operation::IsNotNull(local_field.clone().into()),
                 ],
                 Some(CandidateValue::Range(Range::with_end(
                     Bound::Excluded(&variables["second"]),
@@ -563,21 +606,21 @@ mod tests {
             //
             // `is_not_null` by itself only eliminates null
             (
-                vec![Operation::IsNotNull(local_field.clone())],
+                vec![Operation::IsNotNull(local_field.clone().into())],
                 Some(CandidateValue::Range(Range::full_non_null())),
             ),
             //
             // `!= null` also elminates null
             (
-                vec![Operation::NotEquals(local_field.clone(), null_var.clone())],
+                vec![Operation::NotEquals(local_field.clone().into(), null_var.clone())],
                 Some(CandidateValue::Range(Range::full_non_null())),
             ),
             //
             // `!= 1` by itself doesn't produce any candidates
-            (vec![Operation::NotEquals(local_field.clone(), first_var.clone())], None),
+            (vec![Operation::NotEquals(local_field.clone().into(), first_var.clone())], None),
             //
             // `not_one_of [1, 2]` by itself doesn't produce any candidates
-            (vec![Operation::NotEquals(local_field.clone(), list_var.clone())], None),
+            (vec![Operation::NotEquals(local_field.clone().into(), list_var.clone())], None),
         ];
 
         for (filters, expected_output) in test_data {
@@ -625,28 +668,28 @@ mod tests {
             // The local field is non-nullable.
             // When we apply a range bound on the field, the range must be non-nullable too.
             (
-                vec![Operation::GreaterThanOrEqual(local_field.clone(), first_var.clone())],
+                vec![Operation::GreaterThanOrEqual(local_field.clone().into(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Included(&variables["first"]),
                     false,
                 ))),
             ),
             (
-                vec![Operation::GreaterThan(local_field.clone(), first_var.clone())],
+                vec![Operation::GreaterThan(local_field.clone().into(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_start(
                     Bound::Excluded(&variables["first"]),
                     false,
                 ))),
             ),
             (
-                vec![Operation::LessThan(local_field.clone(), first_var.clone())],
+                vec![Operation::LessThan(local_field.clone().into(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_end(
                     Bound::Excluded(&variables["first"]),
                     false,
                 ))),
             ),
             (
-                vec![Operation::LessThanOrEqual(local_field.clone(), first_var.clone())],
+                vec![Operation::LessThanOrEqual(local_field.clone().into(), first_var.clone())],
                 Some(CandidateValue::Range(Range::with_end(
                     Bound::Included(&variables["first"]),
                     false,

--- a/trustfall_core/src/ir/mod.rs
+++ b/trustfall_core/src/ir/mod.rs
@@ -50,6 +50,18 @@ impl Eid {
     }
 }
 
+/// Unique ID of a value term in a Trustfall query, such as a vertex property
+/// or a computed value like the number of elements in a `@fold`.
+#[doc(alias("term"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Tid(pub(crate) NonZeroUsize);
+
+impl Tid {
+    pub fn new(id: NonZeroUsize) -> Tid {
+        Tid(id)
+    }
+}
+
 /// Parameter values for an edge expansion.
 ///
 /// Passed as an argument to the [`Adapter::resolve_starting_vertices`] and
@@ -189,7 +201,7 @@ pub struct IRVertex {
     pub coerced_from_type: Option<Arc<str>>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub filters: Vec<Operation<LocalField, Argument>>,
+    pub filters: Vec<Operation<OperationSubject, Argument>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -327,6 +339,16 @@ impl FieldRef {
     }
 }
 
+/// The right-hand side of a Trustfall operation.
+///
+/// In a Trustfall query, the `@filter` directive produces [`Operation`] values.
+/// The right-hand side of [`Operation`] is usually [`Argument`].
+///
+/// For example:
+/// ```graphql
+/// name @filter(op: "=", value: ["$input"])
+/// ```
+/// produces a value like `Operation::Equals(..., Argument::Variable(...))`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Argument {
     Tag(FieldRef),
@@ -354,13 +376,42 @@ impl Argument {
     }
 }
 
-/// Operations that can be made in the graph.
+/// The left-hand side of a Trustfall operation.
 ///
-/// In a Trustfall query, the `@filter` directive produces `Operation` values:
+/// In a Trustfall query, the `@filter` directive produces [`Operation`] values.
+/// The left-hand side of [`Operation`] is usually [`OperationSubject`].
+///
+/// For example:
 /// ```graphql
 /// name @filter(op: "=", value: ["$input"])
 /// ```
-/// would produce the `Operation::Equals` variant, for example.
+/// produces a value like `Operation::Equals(OperationSubject::LocalField(...), ...)`.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OperationSubject {
+    LocalField(LocalField),
+    TransformedField(TransformedField),
+}
+
+impl From<LocalField> for OperationSubject {
+    fn from(value: LocalField) -> Self {
+        Self::LocalField(value)
+    }
+}
+
+impl From<TransformedField> for OperationSubject {
+    fn from(value: TransformedField) -> Self {
+        Self::TransformedField(value)
+    }
+}
+
+/// Operations that can be made in the graph.
+///
+/// In a Trustfall query, the `@filter` directive produces [`Operation`] values:
+/// ```graphql
+/// name @filter(op: "=", value: ["$input"])
+/// ```
+/// would produce the [`Operation::Equals`] variant, for example.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Operation<LeftT, RightT>
@@ -468,6 +519,29 @@ where
             Operation::RegexMatches(..) => "regex",
             Operation::NotRegexMatches(..) => "not_regex",
         }
+    }
+
+    pub(crate) fn map_left<'a, LeftF, LeftOutT>(
+        &'a self,
+        map_left: LeftF,
+    ) -> Operation<LeftOutT, &RightT>
+    where
+        LeftOutT: Debug + Clone + PartialEq + Eq,
+        LeftF: FnOnce(&'a LeftT) -> LeftOutT,
+    {
+        self.map(map_left, |x| x)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn map_right<'a, RightF, RightOutT>(
+        &'a self,
+        map_right: RightF,
+    ) -> Operation<&LeftT, RightOutT>
+    where
+        RightOutT: Debug + Clone + PartialEq + Eq,
+        RightF: FnOnce(&'a RightT) -> RightOutT,
+    {
+        self.map(|x| x, map_right)
     }
 
     pub(crate) fn map<'a, LeftF, LeftOutT, RightF, RightOutT>(
@@ -618,6 +692,20 @@ pub struct ContextField {
 pub struct LocalField {
     pub field_name: Arc<str>,
 
+    pub field_type: Type,
+}
+
+/// The outcome of a `@transform` operation applied to a vertex property or property-like value
+/// such as the element count of a fold.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransformedField {
+    /// Which vertex's field is this a transformation of.
+    pub vertex_id: Vid,
+
+    /// The unique identifier of the transformation this represents.
+    pub tid: Tid,
+
+    /// The resulting type of the value produced by this transformation.
     pub field_type: Type,
 }
 

--- a/trustfall_core/src/ir/types/named_typed.rs
+++ b/trustfall_core/src/ir/types/named_typed.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use super::{
     super::{
         Argument, ContextField, FieldRef, FoldSpecificField, FoldSpecificFieldKind, LocalField,
-        VariableRef,
+        OperationSubject, VariableRef,
     },
     Type,
 };
@@ -12,6 +12,22 @@ pub trait NamedTypedValue: Debug + Clone + PartialEq + Eq {
     fn typed(&self) -> &Type;
 
     fn named(&self) -> &str;
+}
+
+impl NamedTypedValue for OperationSubject {
+    fn typed(&self) -> &Type {
+        match self {
+            OperationSubject::LocalField(inner) => inner.typed(),
+            OperationSubject::TransformedField(_) => todo!(),
+        }
+    }
+
+    fn named(&self) -> &str {
+        match self {
+            OperationSubject::LocalField(inner) => inner.named(),
+            OperationSubject::TransformedField(_) => todo!(),
+        }
+    }
 }
 
 impl NamedTypedValue for LocalField {

--- a/trustfall_core/test_data/tests/execution_errors/both_missing_and_unused.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/both_missing_and_unused.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSubstring(LocalField(
+            HasSubstring(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "substr",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/execution_errors/invalid_argument_types.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/invalid_argument_types.ir.ron
@@ -15,17 +15,17 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSubstring(LocalField(
+            HasSubstring(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "substr",
               variable_type: "String!",
             ))),
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/execution_errors/invalid_null_argument_values.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/invalid_null_argument_values.ir.ron
@@ -15,17 +15,17 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSubstring(LocalField(
+            HasSubstring(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "substr",
               variable_type: "String!",
             ))),
-            OneOf(LocalField(
+            OneOf(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "numbers",
               variable_type: "[Int]!",
             ))),

--- a/trustfall_core/test_data/tests/execution_errors/missing_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/missing_argument.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSubstring(LocalField(
+            HasSubstring(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "substr",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/execution_errors/missing_unused_and_invalid_arguments.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/missing_unused_and_invalid_arguments.ir.ron
@@ -15,24 +15,24 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSubstring(LocalField(
+            HasSubstring(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "substr",
               variable_type: "String!",
             ))),
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int",
             ))),
-            LessThan(LocalField(
+            LessThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "max",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_list_with_null_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_list_with_null_argument.ir.ron
@@ -9,17 +9,17 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "MainType",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "nonNullIntList",
               field_type: "[Int!]",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "arg",
               variable_type: "[Int!]",
             ))),
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "intNonNullList",
               field_type: "[Int]!",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "arg",
               variable_type: "[Int]!",
             ))),

--- a/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_null_argument.ir.ron
+++ b/trustfall_core/test_data/tests/execution_errors/type_narrowing_prevents_null_argument.ir.ron
@@ -9,17 +9,17 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "MainType",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "nonNullIntList",
               field_type: "[Int!]",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "arg",
               variable_type: "[Int!]",
             ))),
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "intNonNullList",
               field_type: "[Int]!",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "arg",
               variable_type: "[Int]!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/alias_driven_tag_and_output_names.trace.ron
@@ -296,10 +296,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.ir.ron
@@ -28,10 +28,10 @@ Ok(TestIRQuery(
                 vid: Vid(2),
                 type_name: "Composite",
                 filters: [
-                  LessThan(LocalField(
+                  LessThan(LocalField(LocalField(
                     field_name: "name",
                     field_type: "String",
-                  ), Tag(ContextField(ContextField(
+                  )), Tag(ContextField(ContextField(
                     vertex_id: Vid(1),
                     field_name: "name",
                     field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_fold_using_external_tag.trace.ron
@@ -398,10 +398,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(2),
                   type_name: "Composite",
                   filters: [
-                    LessThan(LocalField(
+                    LessThan(LocalField(LocalField(
                       field_name: "name",
                       field_type: "String",
-                    ), Tag(ContextField(ContextField(
+                    )), Tag(ContextField(ContextField(
                       vertex_id: Vid(1),
                       field_name: "name",
                       field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.ir.ron
@@ -47,10 +47,10 @@ Ok(TestIRQuery(
                       vid: Vid(3),
                       type_name: "Composite",
                       filters: [
-                        LessThan(LocalField(
+                        LessThan(LocalField(LocalField(
                           field_name: "name",
                           field_type: "String",
-                        ), Tag(ContextField(ContextField(
+                        )), Tag(ContextField(ContextField(
                           vertex_id: Vid(1),
                           field_name: "name",
                           field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_in_nested_fold_using_external_tag.trace.ron
@@ -649,10 +649,10 @@ TestInterpreterOutputTrace(
                         vid: Vid(3),
                         type_name: "Composite",
                         filters: [
-                          LessThan(LocalField(
+                          LessThan(LocalField(LocalField(
                             field_name: "name",
                             field_type: "String",
-                          ), Tag(ContextField(ContextField(
+                          )), Tag(ContextField(ContextField(
                             vertex_id: Vid(1),
                             field_name: "name",
                             field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            Contains(LocalField(
+            Contains(LocalField(LocalField(
               field_name: "vowelsInName",
               field_type: "[String]",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "vowel",
               variable_type: "String",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_contains.trace.ron
@@ -397,10 +397,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              Contains(LocalField(
+              Contains(LocalField(LocalField(
                 field_name: "vowelsInName",
                 field_type: "[String]",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "vowel",
                 variable_type: "String",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Composite",
           filters: [
-            GreaterThanOrEqual(LocalField(
+            GreaterThanOrEqual(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_or_equal.trace.ron
@@ -1358,10 +1358,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Composite",
             filters: [
-              GreaterThanOrEqual(LocalField(
+              GreaterThanOrEqual(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "num",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Composite",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_greater_than.trace.ron
@@ -1260,10 +1260,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Composite",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "num",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasPrefix(LocalField(
+            HasPrefix(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "prefix",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_prefix.trace.ron
@@ -492,10 +492,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              HasPrefix(LocalField(
+              HasPrefix(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "prefix",
                 variable_type: "String!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSubstring(LocalField(
+            HasSubstring(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "substr",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_substring.trace.ron
@@ -266,10 +266,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              HasSubstring(LocalField(
+              HasSubstring(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "substr",
                 variable_type: "String!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            HasSuffix(LocalField(
+            HasSuffix(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "suffix",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_has_suffix.trace.ron
@@ -621,10 +621,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              HasSuffix(LocalField(
+              HasSuffix(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "suffix",
                 variable_type: "String!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            LessThanOrEqual(LocalField(
+            LessThanOrEqual(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_or_equal.trace.ron
@@ -172,10 +172,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              LessThanOrEqual(LocalField(
+              LessThanOrEqual(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "num",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            LessThan(LocalField(
+            LessThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_less_than.trace.ron
@@ -172,10 +172,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              LessThan(LocalField(
+              LessThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "num",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            NotEquals(LocalField(
+            NotEquals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "num",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_not_equal.trace.ron
@@ -172,10 +172,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              NotEquals(LocalField(
+              NotEquals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "num",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            OneOf(LocalField(
+            OneOf(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "options",
               variable_type: "[String]!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_one_of.trace.ron
@@ -319,10 +319,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              OneOf(LocalField(
+              OneOf(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "options",
                 variable_type: "[String]!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            RegexMatches(LocalField(
+            RegexMatches(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "pattern",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_op_regex.trace.ron
@@ -319,10 +319,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              RegexMatches(LocalField(
+              RegexMatches(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "pattern",
                 variable_type: "String!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            IsNotNull(LocalField(
+            IsNotNull(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            )),
+            ))),
           ],
         ),
       },

--- a/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_with_omitted_value_arg.trace.ron
@@ -1895,10 +1895,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              IsNotNull(LocalField(
+              IsNotNull(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              )),
+              ))),
             ],
           ),
         },

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.ir.ron
@@ -28,10 +28,10 @@ Ok(TestIRQuery(
                 vid: Vid(2),
                 type_name: "Composite",
                 filters: [
-                  GreaterThan(LocalField(
+                  GreaterThan(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Variable(VariableRef(
+                  )), Variable(VariableRef(
                     variable_name: "bound",
                     variable_type: "Int!",
                   ))),

--- a/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/filter_within_fold.trace.ron
@@ -315,10 +315,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(2),
                   type_name: "Composite",
                   filters: [
-                    GreaterThan(LocalField(
+                    GreaterThan(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Variable(VariableRef(
+                    )), Variable(VariableRef(
                       variable_name: "bound",
                       variable_type: "Int!",
                     ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Composite",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "six",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_on_a_tag.trace.ron
@@ -373,10 +373,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Composite",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "six",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.ir.ron
@@ -30,10 +30,10 @@ Ok(TestIRQuery(
                 vid: Vid(2),
                 type_name: "Prime",
                 filters: [
-                  GreaterThan(LocalField(
+                  GreaterThan(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Variable(VariableRef(
+                  )), Variable(VariableRef(
                     variable_name: "two",
                     variable_type: "Int!",
                   ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_filter_with_inner_filter.trace.ron
@@ -454,10 +454,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(2),
                   type_name: "Prime",
                   filters: [
-                    GreaterThan(LocalField(
+                    GreaterThan(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Variable(VariableRef(
+                    )), Variable(VariableRef(
                       variable_name: "two",
                       variable_type: "Int!",
                     ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(FoldSpecificField(FoldSpecificField(
+            )), Tag(FoldSpecificField(FoldSpecificField(
               fold_eid: Eid(1),
               fold_root_vid: Vid(2),
               kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_explicitly_named.trace.ron
@@ -300,10 +300,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(FoldSpecificField(FoldSpecificField(
+              )), Tag(FoldSpecificField(FoldSpecificField(
                 fold_eid: Eid(1),
                 fold_root_vid: Vid(2),
                 kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.ir.ron
@@ -21,10 +21,10 @@ Ok(TestIRQuery(
           vid: Vid(5),
           type_name: "Number",
           filters: [
-            LessThan(LocalField(
+            LessThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(FoldSpecificField(FoldSpecificField(
+            )), Tag(FoldSpecificField(FoldSpecificField(
               fold_eid: Eid(3),
               fold_root_vid: Vid(4),
               kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_on_nonexistent_optional.trace.ron
@@ -468,10 +468,10 @@ TestInterpreterOutputTrace(
             vid: Vid(5),
             type_name: "Number",
             filters: [
-              LessThan(LocalField(
+              LessThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(FoldSpecificField(FoldSpecificField(
+              )), Tag(FoldSpecificField(FoldSpecificField(
                 fold_eid: Eid(3),
                 fold_root_vid: Vid(4),
                 kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.ir.ron
@@ -38,10 +38,10 @@ Ok(TestIRQuery(
                 vid: Vid(3),
                 type_name: "Number",
                 filters: [
-                  Equals(LocalField(
+                  Equals(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Tag(FoldSpecificField(FoldSpecificField(
+                  )), Tag(FoldSpecificField(FoldSpecificField(
                     fold_eid: Eid(1),
                     fold_root_vid: Vid(2),
                     kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_count_tag_used_inside_sibling_fold.trace.ron
@@ -357,10 +357,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(3),
                   type_name: "Number",
                   filters: [
-                    Equals(LocalField(
+                    Equals(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Tag(FoldSpecificField(FoldSpecificField(
+                    )), Tag(FoldSpecificField(FoldSpecificField(
                       fold_eid: Eid(1),
                       fold_root_vid: Vid(2),
                       kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.ir.ron
@@ -35,10 +35,10 @@ Ok(TestIRQuery(
                 vid: Vid(3),
                 type_name: "Number",
                 filters: [
-                  Equals(LocalField(
+                  Equals(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Tag(ContextField(ContextField(
+                  )), Tag(ContextField(ContextField(
                     vertex_id: Vid(1),
                     field_name: "value",
                     field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_both_count_and_nested_filter_dependent_on_tag.trace.ron
@@ -534,10 +534,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(3),
                   type_name: "Number",
                   filters: [
-                    Equals(LocalField(
+                    Equals(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Tag(ContextField(ContextField(
+                    )), Tag(ContextField(ContextField(
                       vertex_id: Vid(1),
                       field_name: "value",
                       field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.ir.ron
@@ -35,10 +35,10 @@ Ok(TestIRQuery(
                 vid: Vid(3),
                 type_name: "Number",
                 filters: [
-                  Equals(LocalField(
+                  Equals(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Variable(VariableRef(
+                  )), Variable(VariableRef(
                     variable_name: "one",
                     variable_type: "Int",
                   ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter.trace.ron
@@ -338,10 +338,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(3),
                   type_name: "Number",
                   filters: [
-                    Equals(LocalField(
+                    Equals(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Variable(VariableRef(
+                    )), Variable(VariableRef(
                       variable_name: "one",
                       variable_type: "Int",
                     ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.ir.ron
@@ -35,10 +35,10 @@ Ok(TestIRQuery(
                 vid: Vid(3),
                 type_name: "Number",
                 filters: [
-                  Equals(LocalField(
+                  Equals(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Tag(ContextField(ContextField(
+                  )), Tag(ContextField(ContextField(
                     vertex_id: Vid(1),
                     field_name: "value",
                     field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_count_filter_and_nested_filter_with_tag.trace.ron
@@ -441,10 +441,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(3),
                   type_name: "Number",
                   filters: [
-                    Equals(LocalField(
+                    Equals(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Tag(ContextField(ContextField(
+                    )), Tag(ContextField(ContextField(
                       vertex_id: Vid(1),
                       field_name: "value",
                       field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.ir.ron
@@ -35,10 +35,10 @@ Ok(TestIRQuery(
                 vid: Vid(3),
                 type_name: "Number",
                 filters: [
-                  Equals(LocalField(
+                  Equals(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Variable(VariableRef(
+                  )), Variable(VariableRef(
                     variable_name: "one",
                     variable_type: "Int",
                   ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter.trace.ron
@@ -260,10 +260,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(3),
                   type_name: "Number",
                   filters: [
-                    Equals(LocalField(
+                    Equals(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Variable(VariableRef(
+                    )), Variable(VariableRef(
                       variable_name: "one",
                       variable_type: "Int",
                     ))),

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.ir.ron
@@ -35,10 +35,10 @@ Ok(TestIRQuery(
                 vid: Vid(3),
                 type_name: "Number",
                 filters: [
-                  Equals(LocalField(
+                  Equals(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Tag(ContextField(ContextField(
+                  )), Tag(ContextField(ContextField(
                     vertex_id: Vid(1),
                     field_name: "value",
                     field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_nested_filter_and_tag.trace.ron
@@ -441,10 +441,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(3),
                   type_name: "Number",
                   filters: [
-                    Equals(LocalField(
+                    Equals(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Tag(ContextField(ContextField(
+                    )), Tag(ContextField(ContextField(
                       vertex_id: Vid(1),
                       field_name: "value",
                       field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.ir.ron
@@ -20,10 +20,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(FoldSpecificField(FoldSpecificField(
+            )), Tag(FoldSpecificField(FoldSpecificField(
               fold_eid: Eid(1),
               fold_root_vid: Vid(2),
               kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/fold_with_no_inner_output_with_count_tag.trace.ron
@@ -1123,10 +1123,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(FoldSpecificField(FoldSpecificField(
+              )), Tag(FoldSpecificField(FoldSpecificField(
                 fold_eid: Eid(1),
                 fold_root_vid: Vid(2),
                 kind: Count,

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.ir.ron
@@ -47,10 +47,10 @@ Ok(TestIRQuery(
                       vid: Vid(3),
                       type_name: "Composite",
                       filters: [
-                        LessThan(LocalField(
+                        LessThan(LocalField(LocalField(
                           field_name: "name",
                           field_type: "String",
-                        ), Tag(ContextField(ContextField(
+                        )), Tag(ContextField(ContextField(
                           vertex_id: Vid(2),
                           field_name: "name",
                           field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/folded_filter_in_fold_using_external_tag.trace.ron
@@ -545,10 +545,10 @@ TestInterpreterOutputTrace(
                         vid: Vid(3),
                         type_name: "Composite",
                         filters: [
-                          LessThan(LocalField(
+                          LessThan(LocalField(LocalField(
                             field_name: "name",
                             field_type: "String",
-                          ), Tag(ContextField(ContextField(
+                          )), Tag(ContextField(ContextField(
                             vertex_id: Vid(2),
                             field_name: "name",
                             field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/implicit_tag_and_output_names.trace.ron
@@ -296,10 +296,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Composite",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "min_value",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/multiple_copies_of_field.trace.ron
@@ -242,10 +242,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Composite",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "min_value",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.ir.ron
@@ -17,10 +17,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "one",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_and_filter.trace.ron
@@ -214,10 +214,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "one",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.ir.ron
@@ -17,10 +17,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_edge_with_filter_and_tag.trace.ron
@@ -273,10 +273,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThanOrEqual(LocalField(
+            GreaterThanOrEqual(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "two",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_semantics.trace.ron
@@ -171,10 +171,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThanOrEqual(LocalField(
+              GreaterThanOrEqual(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "two",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.ir.ron
@@ -13,10 +13,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThanOrEqual(LocalField(
+            GreaterThanOrEqual(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/optional_with_nested_filter_with_tag_semantics.trace.ron
@@ -228,10 +228,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThanOrEqual(LocalField(
+              GreaterThanOrEqual(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "bound",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_one.trace.ron
@@ -715,10 +715,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "bound",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "bound",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_depth_two.trace.ron
@@ -1318,10 +1318,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "bound",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "bound",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_intermediate.trace.ron
@@ -2069,10 +2069,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "bound",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "bound",
               variable_type: "Int!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_leaves.trace.ron
@@ -1969,10 +1969,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "bound",
                 variable_type: "Int!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_one.trace.ron
@@ -1391,10 +1391,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            GreaterThan(LocalField(
+            GreaterThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/recurse_then_filter_on_tag_depth_two.trace.ron
@@ -2412,10 +2412,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              GreaterThan(LocalField(
+              GreaterThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/required_properties.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "__typename",
               field_type: "String!",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "type",
               variable_type: "String!",
             ))),
@@ -28,10 +28,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Composite",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "name",
               field_type: "String",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "name",
               field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/required_properties.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties.trace.ron
@@ -898,10 +898,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "__typename",
                 field_type: "String!",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "type",
                 variable_type: "String!",
               ))),
@@ -911,10 +911,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Composite",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "name",
                 field_type: "String",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "name",
                 field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.ir.ron
@@ -15,17 +15,17 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "__typename",
               field_type: "String!",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "type",
               variable_type: "String!",
             ))),
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "val",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/required_properties_filter_and_output.trace.ron
@@ -181,17 +181,17 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "__typename",
                 field_type: "String!",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "type",
                 variable_type: "String!",
               ))),
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "val",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "value",
               variable_type: "Int",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/simple_filter.trace.ron
@@ -204,10 +204,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "value",
                 variable_type: "Int",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.ir.ron
@@ -19,17 +19,17 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            OneOf(LocalField(
+            OneOf(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "collection",
               variable_type: "[Int]!",
             ))),
-            GreaterThanOrEqual(LocalField(
+            GreaterThanOrEqual(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/static_and_dynamic_filter.trace.ron
@@ -506,17 +506,17 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              OneOf(LocalField(
+              OneOf(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "collection",
                 variable_type: "[Int]!",
               ))),
-              GreaterThanOrEqual(LocalField(
+              GreaterThanOrEqual(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.ir.ron
@@ -27,10 +27,10 @@ Ok(TestIRQuery(
           vid: Vid(4),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_and_filter_directives.trace.ron
@@ -1082,10 +1082,10 @@ TestInterpreterOutputTrace(
             vid: Vid(4),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.ir.ron
@@ -9,10 +9,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            Contains(LocalField(
+            Contains(LocalField(LocalField(
               field_name: "vowelsInName",
               field_type: "[String]",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "name",
               field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_before_filter_in_same_scope.trace.ron
@@ -144,10 +144,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              Contains(LocalField(
+              Contains(LocalField(LocalField(
                 field_name: "vowelsInName",
                 field_type: "[String]",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "name",
                 field_type: "String",

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.ir.ron
@@ -23,10 +23,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Composite",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(2),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_name_in_prefixed_vertex.trace.ron
@@ -1600,10 +1600,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Composite",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(2),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.ir.ron
@@ -23,10 +23,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Prime",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "prime",
               variable_type: "Int",
             ))),
@@ -48,10 +48,10 @@ Ok(TestIRQuery(
           vid: Vid(7),
           type_name: "Number",
           filters: [
-            LessThan(LocalField(
+            LessThan(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(6),
               field_name: "value",
               field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional.trace.ron
@@ -2126,10 +2126,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Prime",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "prime",
                 variable_type: "Int",
               ))),
@@ -2151,10 +2151,10 @@ TestInterpreterOutputTrace(
             vid: Vid(7),
             type_name: "Number",
             filters: [
-              LessThan(LocalField(
+              LessThan(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(6),
                 field_name: "value",
                 field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.ir.ron
@@ -23,10 +23,10 @@ Ok(TestIRQuery(
           vid: Vid(3),
           type_name: "Prime",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "value",
               field_type: "Int",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "prime",
               variable_type: "Int",
             ))),
@@ -96,10 +96,10 @@ Ok(TestIRQuery(
                 vid: Vid(7),
                 type_name: "Number",
                 filters: [
-                  LessThan(LocalField(
+                  LessThan(LocalField(LocalField(
                     field_name: "value",
                     field_type: "Int",
-                  ), Tag(ContextField(ContextField(
+                  )), Tag(ContextField(ContextField(
                     vertex_id: Vid(6),
                     field_name: "value",
                     field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/tag_within_non_existent_optional_used_in_fold.trace.ron
@@ -2424,10 +2424,10 @@ TestInterpreterOutputTrace(
             vid: Vid(3),
             type_name: "Prime",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "value",
                 field_type: "Int",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "prime",
                 variable_type: "Int",
               ))),
@@ -2497,10 +2497,10 @@ TestInterpreterOutputTrace(
                   vid: Vid(7),
                   type_name: "Number",
                   filters: [
-                    LessThan(LocalField(
+                    LessThan(LocalField(LocalField(
                       field_name: "value",
                       field_type: "Int",
-                    ), Tag(ContextField(ContextField(
+                    )), Tag(ContextField(ContextField(
                       vertex_id: Vid(6),
                       field_name: "value",
                       field_type: "Int",

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.ir.ron
@@ -15,10 +15,10 @@ Ok(TestIRQuery(
           vid: Vid(1),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "__typename",
               field_type: "String!",
-            ), Variable(VariableRef(
+            )), Variable(VariableRef(
               variable_name: "type",
               variable_type: "String!",
             ))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_filter.trace.ron
@@ -152,10 +152,10 @@ TestInterpreterOutputTrace(
             vid: Vid(1),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "__typename",
                 field_type: "String!",
-              ), Variable(VariableRef(
+              )), Variable(VariableRef(
                 variable_name: "type",
                 variable_type: "String!",
               ))),

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.ir.ron
@@ -19,10 +19,10 @@ Ok(TestIRQuery(
           vid: Vid(2),
           type_name: "Number",
           filters: [
-            Equals(LocalField(
+            Equals(LocalField(LocalField(
               field_name: "__typename",
               field_type: "String!",
-            ), Tag(ContextField(ContextField(
+            )), Tag(ContextField(ContextField(
               vertex_id: Vid(1),
               field_name: "__typename",
               field_type: "String!",

--- a/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/typename_tag_and_filter.trace.ron
@@ -350,10 +350,10 @@ TestInterpreterOutputTrace(
             vid: Vid(2),
             type_name: "Number",
             filters: [
-              Equals(LocalField(
+              Equals(LocalField(LocalField(
                 field_name: "__typename",
                 field_type: "String!",
-              ), Tag(ContextField(ContextField(
+              )), Tag(ContextField(ContextField(
                 vertex_id: Vid(1),
                 field_name: "__typename",
                 field_type: "String!",


### PR DESCRIPTION
After this PR, the IR in principle supports constructs like `my_list @transform(op: "length") @filter(op: "=", value: ["$zero"])`.

We still need to update the parser, frontend, and interpreter execution to allow those as well.
