### PR TITLE
Fix the error message if `@recurse` is used on a property.

### DIFF
--- a/trustfall_core/src/frontend/mod.rs
+++ b/trustfall_core/src/frontend/mod.rs
@@ -981,7 +981,7 @@ where
             // @recurse is not allowed on a property
             if connection.recurse.is_some() {
                 errors.push(FrontendError::UnsupportedDirectiveOnProperty(
-                    "@optional".into(),
+                    "@recurse".into(),
                     subfield.name.to_string(),
                 ));
             }

--- a/trustfall_core/test_data/tests/frontend_errors/recurse_used_on_property.frontend-error.ron
+++ b/trustfall_core/test_data/tests/frontend_errors/recurse_used_on_property.frontend-error.ron
@@ -1,1 +1,1 @@
-Err(UnsupportedDirectiveOnProperty("@optional", "vowelsInName"))
+Err(UnsupportedDirectiveOnProperty("@recurse", "vowelsInName"))


### PR DESCRIPTION
It used to incorrectly say the problematic directive is `@optional`, not `@recurse`.
