### PR TITLE
Weekly `cargo update` of fuzzing dependencies

### DIFF
--- a/trustfall_core/fuzz/Cargo.lock
+++ b/trustfall_core/fuzz/Cargo.lock
@@ -144,6 +144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,9 +198,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
@@ -361,7 +370,7 @@ version = "0.7.1"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
- "itertools",
+ "itertools 0.13.0",
  "maplit",
  "regex",
  "serde",
@@ -378,7 +387,7 @@ dependencies = [
  "async-graphql-value",
  "byteorder",
  "globset",
- "itertools",
+ "itertools 0.12.1",
  "libfuzzer-sys",
  "maplit",
  "regex",


### PR DESCRIPTION
Weekly `cargo update` of fuzzing dependencies
```txt
     Locking 2 packages to latest compatible versions
      Adding itertools v0.13.0
    Updating memchr v2.7.2 -> v2.7.4
note: pass `--verbose` to see 2 unchanged dependencies behind latest
```
