### PR TITLE
Release Python trustfall v0.1.7 to get Python 3.12 wheels

### DIFF
--- a/pytrustfall/Cargo.toml
+++ b/pytrustfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pytrustfall"
-version = "0.1.6"
+version = "0.1.7"
 rust-version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Fixes #649.