### PR TITLE
Fix Python build in CI

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -52,7 +52,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -102,8 +104,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: dist
+          name: wheels-macos-${{ matrix.python-version }}
+          path: dist/*.whl
 
   windows:
     runs-on: windows-latest
@@ -140,8 +142,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: dist
+          name: wheels-windows-${{ matrix.python-version }}
+          path: dist/*.whl
 
   linux:
     runs-on: ubuntu-latest
@@ -179,8 +181,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: dist
+          name: wheels-linux-${{ matrix.python-version }}
+          path: dist/*.whl
 
   # musllinux:
   #   runs-on: ubuntu-latest
@@ -221,8 +223,8 @@ jobs:
   #     - name: Upload wheels
   #       uses: actions/upload-artifact@v4
   #       with:
-  #         name: wheels
-  #         path: /io/dist
+  #         name: wheels-musllinux-${{ matrix.python-version }}
+  #         path: /io/dist/*.whl
 
   should-publish:
     name: Did version change

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -62,7 +62,8 @@ jobs:
           print-hash: true
 
   macos:
-    runs-on: macos-latest
+    # actions/setup-python with Python <3.11 does not work with macos-latest
+    runs-on: macos-13
     needs:
       - should-publish
     if: needs.should-publish.outputs.is_new_version == 'yes'
@@ -87,6 +88,8 @@ jobs:
       - name: Build wheels - x86_64
         uses: messense/maturin-action@v1
         with:
+          # version pinned until https://github.com/PyO3/maturin/issues/2154 is fixed
+          maturin-version: v1.6.0
           target: x86_64
           args: --release --interpreter python --out dist --sdist -m pytrustfall/Cargo.toml
       - name: Install built wheel - x86_64
@@ -96,7 +99,8 @@ jobs:
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --interpreter python --universal2 --out dist -m pytrustfall/Cargo.toml
+          target: universal2
+          args: --release --interpreter python --out dist -m pytrustfall/Cargo.toml
       - name: Install built wheel - universal2
         run: |
           pip install trustfall --no-index --find-links dist --force-reinstall


### PR DESCRIPTION
Looks like #650 didn't work.

The problem with the [Linux build](https://github.com/obi1kenobi/trustfall/actions/runs/10269436367/job/28415126602) and [Windows build](https://github.com/obi1kenobi/trustfall/actions/runs/10269436367/job/28415125301) are the breaking changes in #575. From action/upload-artifact's [README](https://github.com/actions/upload-artifact):

>Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

This PR attempts to fix the problem by uploading multiple artifacts and then downloading them all.

The [macOS build](https://github.com/obi1kenobi/trustfall/actions/runs/10269436367/job/28415125898) has two problems:

- https://github.com/actions/setup-python/issues/906#issuecomment-2210869905: Python <3.11 is not supported on the arm64 macOS runners. It seems to work on the older x64 `macos-13` runner?
- https://github.com/PyO3/maturin/issues/2154

Test run here: https://github.com/miikka/trustfall/actions/runs/10270391220 (the final step obviously fails due to lack of permissions)