### PR TITLE
Reproduce buggy coercion behavior directly inside `@optional` edge.

### DIFF
--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.output.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.output.ron
@@ -14,6 +14,10 @@ TestInterpreterOutputData(
   },
   results: [
     {
+      "prime": Null,
+      "value": Int64(0),
+    },
+    {
       "prime": Int64(2),
       "value": Int64(3),
     },

--- a/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/coercion_on_optional_edge.trace.ron
@@ -99,57 +99,125 @@ TestInterpreterOutputTrace(
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: None,
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+        )),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: None,
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+        ), Null)),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
-        parent_opid: Some(Opid(1)),
-        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
-      ),
-      Opid(19): TraceOp(
-        opid: Opid(19),
-        parent_opid: Some(Opid(2)),
-        content: YieldInto(SerializableContext(
-          active_vertex: Some(Neither(NeitherNumber(1))),
-          vertices: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        )),
-      ),
-      Opid(20): TraceOp(
-        opid: Opid(20),
-        parent_opid: Some(Opid(2)),
-        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
-          active_vertex: Some(Neither(NeitherNumber(1))),
-          vertices: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
-          },
-        ))),
-      ),
-      Opid(21): TraceOp(
-        opid: Opid(21),
-        parent_opid: Some(Opid(20)),
-        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
-      ),
-      Opid(22): TraceOp(
-        opid: Opid(22),
-        parent_opid: Some(Opid(3)),
+        parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
-            Vid(1): Some(Neither(NeitherNumber(1))),
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
           },
+          values: [
+            Null,
+          ],
         )),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+          values: [
+            Null,
+          ],
+        ), Int64(0))),
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "prime": Null,
+          "value": Int64(0),
+        }),
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
         parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(1)))),
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(1))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        ))),
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(27)),
+        content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(0)))),
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(1))),
+          },
+        )),
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(3)),
         content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(0))),
           vertices: {
@@ -157,28 +225,28 @@ TestInterpreterOutputTrace(
           },
         ), false)),
       ),
-      Opid(24): TraceOp(
-        opid: Opid(24),
+      Opid(31): TraceOp(
+        opid: Opid(31),
         parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(25): TraceOp(
-        opid: Opid(25),
-        parent_opid: Some(Opid(20)),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(27)),
         content: OutputIteratorExhausted,
       ),
-      Opid(26): TraceOp(
-        opid: Opid(26),
+      Opid(33): TraceOp(
+        opid: Opid(33),
         parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(27): TraceOp(
-        opid: Opid(27),
+      Opid(34): TraceOp(
+        opid: Opid(34),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(2)))),
       ),
-      Opid(28): TraceOp(
-        opid: Opid(28),
+      Opid(35): TraceOp(
+        opid: Opid(35),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
@@ -187,8 +255,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(29): TraceOp(
-        opid: Opid(29),
+      Opid(36): TraceOp(
+        opid: Opid(36),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
@@ -197,13 +265,13 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(30): TraceOp(
-        opid: Opid(30),
-        parent_opid: Some(Opid(29)),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(36)),
         content: YieldFrom(ResolveNeighborsInner(0, Neither(NeitherNumber(1)))),
       ),
-      Opid(31): TraceOp(
-        opid: Opid(31),
+      Opid(38): TraceOp(
+        opid: Opid(38),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
@@ -212,8 +280,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(32): TraceOp(
-        opid: Opid(32),
+      Opid(39): TraceOp(
+        opid: Opid(39),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Neither(NeitherNumber(1))),
@@ -222,28 +290,28 @@ TestInterpreterOutputTrace(
           },
         ), false)),
       ),
-      Opid(33): TraceOp(
-        opid: Opid(33),
+      Opid(40): TraceOp(
+        opid: Opid(40),
         parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(34): TraceOp(
-        opid: Opid(34),
-        parent_opid: Some(Opid(29)),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(36)),
         content: OutputIteratorExhausted,
       ),
-      Opid(35): TraceOp(
-        opid: Opid(35),
+      Opid(42): TraceOp(
+        opid: Opid(42),
         parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(36): TraceOp(
-        opid: Opid(36),
+      Opid(43): TraceOp(
+        opid: Opid(43),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(3)))),
       ),
-      Opid(37): TraceOp(
-        opid: Opid(37),
+      Opid(44): TraceOp(
+        opid: Opid(44),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -252,8 +320,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(38): TraceOp(
-        opid: Opid(38),
+      Opid(45): TraceOp(
+        opid: Opid(45),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -262,13 +330,13 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(39): TraceOp(
-        opid: Opid(39),
-        parent_opid: Some(Opid(38)),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(45)),
         content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(2)))),
       ),
-      Opid(40): TraceOp(
-        opid: Opid(40),
+      Opid(47): TraceOp(
+        opid: Opid(47),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
@@ -277,8 +345,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(41): TraceOp(
-        opid: Opid(41),
+      Opid(48): TraceOp(
+        opid: Opid(48),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
@@ -287,8 +355,8 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(42): TraceOp(
-        opid: Opid(42),
+      Opid(49): TraceOp(
+        opid: Opid(49),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
@@ -298,8 +366,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(43): TraceOp(
-        opid: Opid(43),
+      Opid(50): TraceOp(
+        opid: Opid(50),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(2))),
@@ -309,8 +377,8 @@ TestInterpreterOutputTrace(
           },
         ), Int64(2))),
       ),
-      Opid(44): TraceOp(
-        opid: Opid(44),
+      Opid(51): TraceOp(
+        opid: Opid(51),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -323,8 +391,8 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(45): TraceOp(
-        opid: Opid(45),
+      Opid(52): TraceOp(
+        opid: Opid(52),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -337,48 +405,48 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(3))),
       ),
-      Opid(46): TraceOp(
-        opid: Opid(46),
+      Opid(53): TraceOp(
+        opid: Opid(53),
         parent_opid: None,
         content: ProduceQueryResult({
           "prime": Int64(2),
           "value": Int64(3),
         }),
       ),
-      Opid(47): TraceOp(
-        opid: Opid(47),
+      Opid(54): TraceOp(
+        opid: Opid(54),
         parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(48): TraceOp(
-        opid: Opid(48),
+      Opid(55): TraceOp(
+        opid: Opid(55),
         parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(49): TraceOp(
-        opid: Opid(49),
+      Opid(56): TraceOp(
+        opid: Opid(56),
         parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(50): TraceOp(
-        opid: Opid(50),
-        parent_opid: Some(Opid(38)),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(45)),
         content: OutputIteratorExhausted,
       ),
-      Opid(51): TraceOp(
-        opid: Opid(51),
+      Opid(58): TraceOp(
+        opid: Opid(58),
         parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(52): TraceOp(
-        opid: Opid(52),
+      Opid(59): TraceOp(
+        opid: Opid(59),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(53): TraceOp(
-        opid: Opid(53),
+      Opid(60): TraceOp(
+        opid: Opid(60),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
@@ -391,8 +459,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(54): TraceOp(
-        opid: Opid(54),
+      Opid(61): TraceOp(
+        opid: Opid(61),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
@@ -405,13 +473,13 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(55): TraceOp(
-        opid: Opid(55),
-        parent_opid: Some(Opid(54)),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(61)),
         content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(3)))),
       ),
-      Opid(56): TraceOp(
-        opid: Opid(56),
+      Opid(63): TraceOp(
+        opid: Opid(63),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -422,8 +490,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(57): TraceOp(
-        opid: Opid(57),
+      Opid(64): TraceOp(
+        opid: Opid(64),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -434,8 +502,8 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(58): TraceOp(
-        opid: Opid(58),
+      Opid(65): TraceOp(
+        opid: Opid(65),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -447,8 +515,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(59): TraceOp(
-        opid: Opid(59),
+      Opid(66): TraceOp(
+        opid: Opid(66),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(3))),
@@ -460,8 +528,8 @@ TestInterpreterOutputTrace(
           },
         ), Int64(3))),
       ),
-      Opid(60): TraceOp(
-        opid: Opid(60),
+      Opid(67): TraceOp(
+        opid: Opid(67),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
@@ -478,8 +546,8 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(61): TraceOp(
-        opid: Opid(61),
+      Opid(68): TraceOp(
+        opid: Opid(68),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
@@ -496,46 +564,46 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(4))),
       ),
-      Opid(62): TraceOp(
-        opid: Opid(62),
+      Opid(69): TraceOp(
+        opid: Opid(69),
         parent_opid: None,
         content: ProduceQueryResult({
           "prime": Int64(3),
           "value": Int64(4),
         }),
       ),
-      Opid(63): TraceOp(
-        opid: Opid(63),
+      Opid(70): TraceOp(
+        opid: Opid(70),
         parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(64): TraceOp(
-        opid: Opid(64),
+      Opid(71): TraceOp(
+        opid: Opid(71),
         parent_opid: Some(Opid(4)),
         content: AdvanceInputIterator,
       ),
-      Opid(65): TraceOp(
-        opid: Opid(65),
+      Opid(72): TraceOp(
+        opid: Opid(72),
         parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(66): TraceOp(
-        opid: Opid(66),
-        parent_opid: Some(Opid(54)),
+      Opid(73): TraceOp(
+        opid: Opid(73),
+        parent_opid: Some(Opid(61)),
         content: OutputIteratorExhausted,
       ),
-      Opid(67): TraceOp(
-        opid: Opid(67),
+      Opid(74): TraceOp(
+        opid: Opid(74),
         parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(68): TraceOp(
-        opid: Opid(68),
+      Opid(75): TraceOp(
+        opid: Opid(75),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(ResolveStartingVertices(Prime(PrimeNumber(5)))),
       ),
-      Opid(69): TraceOp(
-        opid: Opid(69),
+      Opid(76): TraceOp(
+        opid: Opid(76),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
@@ -544,8 +612,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(70): TraceOp(
-        opid: Opid(70),
+      Opid(77): TraceOp(
+        opid: Opid(77),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
@@ -554,15 +622,15 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(71): TraceOp(
-        opid: Opid(71),
-        parent_opid: Some(Opid(70)),
+      Opid(78): TraceOp(
+        opid: Opid(78),
+        parent_opid: Some(Opid(77)),
         content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
           2,
         ])))),
       ),
-      Opid(72): TraceOp(
-        opid: Opid(72),
+      Opid(79): TraceOp(
+        opid: Opid(79),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
@@ -573,8 +641,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(73): TraceOp(
-        opid: Opid(73),
+      Opid(80): TraceOp(
+        opid: Opid(80),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(4, [
@@ -585,31 +653,31 @@ TestInterpreterOutputTrace(
           },
         ), false)),
       ),
-      Opid(74): TraceOp(
-        opid: Opid(74),
+      Opid(81): TraceOp(
+        opid: Opid(81),
         parent_opid: Some(Opid(3)),
         content: AdvanceInputIterator,
       ),
-      Opid(75): TraceOp(
-        opid: Opid(75),
-        parent_opid: Some(Opid(70)),
+      Opid(82): TraceOp(
+        opid: Opid(82),
+        parent_opid: Some(Opid(77)),
         content: OutputIteratorExhausted,
       ),
-      Opid(76): TraceOp(
-        opid: Opid(76),
+      Opid(83): TraceOp(
+        opid: Opid(83),
         parent_opid: Some(Opid(2)),
         content: AdvanceInputIterator,
       ),
-      Opid(77): TraceOp(
-        opid: Opid(77),
+      Opid(84): TraceOp(
+        opid: Opid(84),
         parent_opid: Some(Opid(1)),
         content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(6, [
           2,
           3,
         ])))),
       ),
-      Opid(78): TraceOp(
-        opid: Opid(78),
+      Opid(85): TraceOp(
+        opid: Opid(85),
         parent_opid: Some(Opid(2)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
@@ -624,8 +692,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(79): TraceOp(
-        opid: Opid(79),
+      Opid(86): TraceOp(
+        opid: Opid(86),
         parent_opid: Some(Opid(2)),
         content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
@@ -640,13 +708,13 @@ TestInterpreterOutputTrace(
           },
         ))),
       ),
-      Opid(80): TraceOp(
-        opid: Opid(80),
-        parent_opid: Some(Opid(79)),
+      Opid(87): TraceOp(
+        opid: Opid(87),
+        parent_opid: Some(Opid(86)),
         content: YieldFrom(ResolveNeighborsInner(0, Prime(PrimeNumber(5)))),
       ),
-      Opid(81): TraceOp(
-        opid: Opid(81),
+      Opid(88): TraceOp(
+        opid: Opid(88),
         parent_opid: Some(Opid(3)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
@@ -658,8 +726,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(82): TraceOp(
-        opid: Opid(82),
+      Opid(89): TraceOp(
+        opid: Opid(89),
         parent_opid: Some(Opid(3)),
         content: YieldFrom(ResolveCoercion(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
@@ -671,8 +739,8 @@ TestInterpreterOutputTrace(
           },
         ), true)),
       ),
-      Opid(83): TraceOp(
-        opid: Opid(83),
+      Opid(90): TraceOp(
+        opid: Opid(90),
         parent_opid: Some(Opid(4)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
@@ -685,8 +753,8 @@ TestInterpreterOutputTrace(
           },
         )),
       ),
-      Opid(84): TraceOp(
-        opid: Opid(84),
+      Opid(91): TraceOp(
+        opid: Opid(91),
         parent_opid: Some(Opid(4)),
         content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Prime(PrimeNumber(5))),
@@ -699,8 +767,8 @@ TestInterpreterOutputTrace(
           },
         ), Int64(5))),
       ),
-      Opid(85): TraceOp(
-        opid: Opid(85),
+      Opid(92): TraceOp(
+        opid: Opid(92),
         parent_opid: Some(Opid(5)),
         content: YieldInto(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
@@ -719,8 +787,8 @@ TestInterpreterOutputTrace(
           ],
         )),
       ),
-      Opid(86): TraceOp(
-        opid: Opid(86),
+      Opid(93): TraceOp(
+        opid: Opid(93),
         parent_opid: Some(Opid(5)),
         content: YieldFrom(ResolveProperty(SerializableContext(
           active_vertex: Some(Composite(CompositeNumber(6, [
@@ -739,81 +807,81 @@ TestInterpreterOutputTrace(
           ],
         ), Int64(6))),
       ),
-      Opid(87): TraceOp(
-        opid: Opid(87),
+      Opid(94): TraceOp(
+        opid: Opid(94),
         parent_opid: None,
         content: ProduceQueryResult({
           "prime": Int64(5),
           "value": Int64(6),
         }),
       ),
-      Opid(88): TraceOp(
-        opid: Opid(88),
+      Opid(95): TraceOp(
+        opid: Opid(95),
         parent_opid: Some(Opid(5)),
         content: AdvanceInputIterator,
       ),
-      Opid(89): TraceOp(
-        opid: Opid(89),
-        parent_opid: Some(Opid(4)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(90): TraceOp(
-        opid: Opid(90),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(91): TraceOp(
-        opid: Opid(91),
-        parent_opid: Some(Opid(79)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(92): TraceOp(
-        opid: Opid(92),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
-      ),
-      Opid(93): TraceOp(
-        opid: Opid(93),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
-      ),
-      Opid(94): TraceOp(
-        opid: Opid(94),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
-      ),
-      Opid(95): TraceOp(
-        opid: Opid(95),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
-      ),
       Opid(96): TraceOp(
         opid: Opid(96),
-        parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(97): TraceOp(
         opid: Opid(97),
         parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
+        content: AdvanceInputIterator,
       ),
       Opid(98): TraceOp(
         opid: Opid(98),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(86)),
+        content: OutputIteratorExhausted,
       ),
       Opid(99): TraceOp(
         opid: Opid(99),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(100): TraceOp(
         opid: Opid(100),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(101): TraceOp(
         opid: Opid(101),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(102): TraceOp(
+        opid: Opid(102),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(103): TraceOp(
+        opid: Opid(103),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(104): TraceOp(
+        opid: Opid(104),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(105): TraceOp(
+        opid: Opid(105),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(106): TraceOp(
+        opid: Opid(106),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(107): TraceOp(
+        opid: Opid(107),
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(108): TraceOp(
+        opid: Opid(108),
         parent_opid: Some(Opid(5)),
         content: OutputIteratorExhausted,
       ),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.graphql-parsed.ron
@@ -1,0 +1,72 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Zero",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Zero",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          alias: Some("zero"),
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          alias: Some("zero"),
+          output: [
+            OutputDirective(),
+          ],
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "predecessor",
+          optional: Some(OptionalDirective()),
+        ), FieldNode(
+          position: Pos(
+            line: 6,
+            column: 9,
+          ),
+          name: "predecessor",
+          coerced_to: Some("Composite"),
+          connections: [
+            (FieldConnection(
+              position: Pos(
+                line: 8,
+                column: 17,
+              ),
+              name: "value",
+            ), FieldNode(
+              position: Pos(
+                line: 8,
+                column: 17,
+              ),
+              name: "value",
+              output: [
+                OutputDirective(),
+              ],
+            )),
+          ],
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.graphql.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.graphql.ron
@@ -1,0 +1,16 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Zero {
+        zero: value @output
+
+        predecessor @optional {
+            ... on Composite {
+                value @output
+            }
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.ir.ron
@@ -1,0 +1,41 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Zero",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Number",
+        ),
+        Vid(2): IRVertex(
+          vid: Vid(2),
+          type_name: "Composite",
+          coerced_from_type: Some("Number"),
+        ),
+      },
+      edges: {
+        Eid(1): IREdge(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "predecessor",
+          optional: true,
+        ),
+      },
+      outputs: {
+        "value": ContextField(
+          vertex_id: Vid(2),
+          field_name: "value",
+          field_type: "Int",
+        ),
+        "zero": ContextField(
+          vertex_id: Vid(1),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.output.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.output.ron
@@ -1,0 +1,16 @@
+TestInterpreterOutputData(
+  schema_name: "numbers",
+  outputs: {
+    "value": Output(
+      name: "value",
+      value_type: "Int",
+      vid: Vid(2),
+    ),
+    "zero": Output(
+      name: "zero",
+      value_type: "Int",
+      vid: Vid(1),
+    ),
+  },
+  results: [],
+)

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.output.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.output.ron
@@ -12,5 +12,10 @@ TestInterpreterOutputData(
       vid: Vid(1),
     ),
   },
-  results: [],
+  results: [
+    {
+      "value": Null,
+      "zero": Int64(0),
+    },
+  ],
 )

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.trace.ron
@@ -99,56 +99,124 @@ TestInterpreterOutputTrace(
       ),
       Opid(16): TraceOp(
         opid: Opid(16),
-        parent_opid: Some(Opid(3)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: None,
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+        )),
       ),
       Opid(17): TraceOp(
         opid: Opid(17),
-        parent_opid: Some(Opid(2)),
-        content: AdvanceInputIterator,
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: None,
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+        ), Null)),
       ),
       Opid(18): TraceOp(
         opid: Opid(18),
-        parent_opid: Some(Opid(1)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+          values: [
+            Null,
+          ],
+        )),
       ),
       Opid(19): TraceOp(
         opid: Opid(19),
-        parent_opid: Some(Opid(2)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+            Vid(2): None,
+          },
+          values: [
+            Null,
+          ],
+        ), Int64(0))),
       ),
       Opid(20): TraceOp(
         opid: Opid(20),
-        parent_opid: Some(Opid(2)),
-        content: OutputIteratorExhausted,
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "value": Null,
+          "zero": Int64(0),
+        }),
       ),
       Opid(21): TraceOp(
         opid: Opid(21),
-        parent_opid: Some(Opid(3)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
       ),
       Opid(22): TraceOp(
         opid: Opid(22),
-        parent_opid: Some(Opid(3)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
       ),
       Opid(23): TraceOp(
         opid: Opid(23),
-        parent_opid: Some(Opid(4)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
       ),
       Opid(24): TraceOp(
         opid: Opid(24),
-        parent_opid: Some(Opid(4)),
-        content: OutputIteratorExhausted,
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
       ),
       Opid(25): TraceOp(
         opid: Opid(25),
-        parent_opid: Some(Opid(5)),
-        content: InputIteratorExhausted,
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
       ),
       Opid(26): TraceOp(
         opid: Opid(26),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
         parent_opid: Some(Opid(5)),
         content: OutputIteratorExhausted,
       ),

--- a/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/nonexistent_optional_with_immediate_coercion.trace.ron
@@ -1,0 +1,195 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(ResolveStartingVertices(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(1), "Number", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ResolveCoercion(Vid(2), "Number", "Composite")),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(1), "Number", "value")),
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Neither(NeitherNumber(0)))),
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Neither(NeitherNumber(0))),
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ))),
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(12)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: None,
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        )),
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveCoercion(SerializableContext(
+          active_vertex: None,
+          vertices: {
+            Vid(1): Some(Neither(NeitherNumber(0))),
+          },
+        ), false)),
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(5)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Zero",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Number",
+          ),
+          Vid(2): IRVertex(
+            vid: Vid(2),
+            type_name: "Composite",
+            coerced_from_type: Some("Number"),
+          ),
+        },
+        edges: {
+          Eid(1): IREdge(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "predecessor",
+            optional: true,
+          ),
+        },
+        outputs: {
+          "value": ContextField(
+            vertex_id: Vid(2),
+            field_name: "value",
+            field_type: "Int",
+          ),
+          "zero": ContextField(
+            vertex_id: Vid(1),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+)


### PR DESCRIPTION
If an edge is `@optional`, it's allowed to not exist in the data we return. The semantics of type coercion and filtering operations within the `@optional` then become conditional: they apply only if the edge exists for a given row. If the edge didn't exist, all outputs within the `@optional` block are `null` and we skip coercions and filters.

We were inappropriately applying type coercions to rows where an `@optional` edge didn't exist. This PR reproduces and fixes that problem.