### PR TITLE
Publish Trustfall 0.8.0 in Rust and 0.2.0 in Python.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "pytrustfall"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall_core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall_stubgen"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-graphql-parser",

--- a/pytrustfall/Cargo.toml
+++ b/pytrustfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pytrustfall"
-version = "0.1.7"
+version = "0.2.0"
 rust-version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/trustfall/Cargo.toml
+++ b/trustfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall"
-version = "0.7.1"
+version = "0.8.0"
 license = "Apache-2.0"
 description = "The trustfall query engine, empowering you to query everything."
 repository = "https://github.com/obi1kenobi/trustfall"
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 anyhow = { workspace = true }
-trustfall_core = { version = "=0.7.1", path = "../trustfall_core" }
+trustfall_core = { version = "=0.8.0", path = "../trustfall_core" }
 trustfall_derive = { version = "=0.3.1", path = "../trustfall_derive" }
 
 [dev-dependencies]  # including examples dependencies

--- a/trustfall_core/Cargo.toml
+++ b/trustfall_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall_core"
-version = "0.7.1"
+version = "0.8.0"
 license = "Apache-2.0"
 description = "The trustfall query engine, empowering you to query everything."
 repository = "https://github.com/obi1kenobi/trustfall"

--- a/trustfall_stubgen/Cargo.toml
+++ b/trustfall_stubgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall_stubgen"
-version = "0.4.1"
+version = "0.5.0"
 license = "Apache-2.0"
 description = "Generate a Trustfall adapter stub for a given schema."
 repository = "https://github.com/obi1kenobi/trustfall"
@@ -23,7 +23,7 @@ cli = ["dep:clap"]
 quote = { workspace = true }
 syn = { workspace = true }
 proc-macro2 = { workspace = true }
-trustfall = { path = "../trustfall", version = "0.7.0" }
+trustfall = { path = "../trustfall", version = "0.8.0" }
 maplit = { workspace = true }
 async-graphql-parser = { workspace = true }
 async-graphql-value = { workspace = true }


### PR DESCRIPTION
Includes:
- Fix for incorrect type coercion / filtering inside `@optional` that didn't exist.
- Breaking changes to the representation of exposed Rust error types.
- Lots of small improvements to the quality of diagnostic messages for various kinds of incorrect queries.
- Maintenance release of trustfall_stubgen, to update to the new major Trustfall library dependency version.
