### PR TITLE
Disable attestations in Python publishing.

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           verbose: true
           print-hash: true
+          # Attestations don't currently support reusable workflows
+          # so publishing fails if this is enabled: https://github.com/pypi/warehouse/issues/11096
+          attestations: false
 
   macos:
     # actions/setup-python with Python <3.11 does not work with macos-latest


### PR DESCRIPTION
They don't support reusable workflows, and it seems that the action
maintainers have made a breaking change enabling this feature by default:
https://github.com/pypi/warehouse/issues/11096
