### PR TITLE
remove outdated `#[allow]` in `trustfall_wasm`

### DIFF
--- a/trustfall_wasm/src/adapter.rs
+++ b/trustfall_wasm/src/adapter.rs
@@ -1,7 +1,3 @@
-// TODO: Remove this once new `wasm_bindgen` version is released.
-//       The lint is raised inside that macro. The fix is on the main branch but not released yet.
-#![allow(clippy::empty_docs)]
-
 use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
 
 use gloo_utils::format::JsValueSerdeExt;


### PR DESCRIPTION
Was looking at `trustfall_wasm` to see how you made the playground, and I saw this `#[allow]` statement that doesn't seem necessary any more.