### PR TITLE
Symlink license file to each crate directory

### DIFF
--- a/trustfall/LICENSE.txt
+++ b/trustfall/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/trustfall_core/LICENSE.txt
+++ b/trustfall_core/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/trustfall_derive/LICENSE.txt
+++ b/trustfall_derive/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/trustfall_filetests_macros/LICENSE.txt
+++ b/trustfall_filetests_macros/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/trustfall_stubgen/LICENSE.txt
+++ b/trustfall_stubgen/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/trustfall_testbin/LICENSE.txt
+++ b/trustfall_testbin/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/trustfall_wasm/LICENSE.txt
+++ b/trustfall_wasm/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt


### PR DESCRIPTION
This allows them to be picked up by `cargo package` so the license text is included in the distributed crate.

```
trustfall on  add-license via 🦀 v1.80.1
⬢ [fedora-packaging] ❯ for crate in trustfall*; cd $crate; echo $crate; cargo package --list | grep LICENSE.txt; cd -; end
trustfall
    Updating crates.io index
LICENSE.txt
trustfall_core
LICENSE.txt
trustfall_derive
LICENSE.txt
trustfall_filetests_macros
LICENSE.txt
trustfall_stubgen
warning: readme `../README.md` appears to be a path outside of the package, but there is already a file named `README.md` in the root of the package. The archived crate will contain the copy in the root of the package. Update the readme to point to the path relative to the root of the package to remove this warning.
LICENSE.txt
trustfall_testbin
warning: manifest has no description, license, license-file, documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
LICENSE.txt
trustfall_wasm
warning: manifest has no description, license, license-file, documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
LICENSE.txt
```