### PR TITLE
Fix patio11 query to use submittedUrl instead of url

### DIFF
--- a/trustfall/examples/hackernews/example_queries/patio11_comments_on_own_blog_posts.ron
+++ b/trustfall/examples/hackernews/example_queries/patio11_comments_on_own_blog_posts.ron
@@ -9,7 +9,7 @@ InputQuery (
 
                 parent @recurse(depth: 10) {
                     ... on Story {
-                        url @filter(op: "regex", value: ["$url_pattern"]) @output
+                        submittedUrl @filter(op: "regex", value: ["$url_pattern"]) @output
                         title @output
                         score @output
                         submitted_at: unixTime @output


### PR DESCRIPTION
`url` always contains the news.ycombinator.com link, which will always fail the regex match.