### PR TITLE
Add repeatable on output, tag and transform.

### DIFF
--- a/experiments/schemaless/src/schema_inference.rs
+++ b/experiments/schemaless/src/schema_inference.rs
@@ -641,12 +641,12 @@ schema {
 }
 
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type GitHubActionsImportedStep implements _AnonType5 {
   _AnonField: String
@@ -713,12 +713,12 @@ schema {
 }
 
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type GitHubActionsImportedStep implements _AnonType5 {
   _AnonField: String
@@ -782,12 +782,12 @@ schema {
 }
 
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type GitHubActionsImportedStep implements _AnonType5 {
   _AnonField: String
@@ -854,12 +854,12 @@ schema {
 }
 
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type GitHubActionsRunStep implements _AnonType5 {
   _AnonField: String
@@ -933,12 +933,12 @@ schema {
 }
 
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type HackerNewsComment implements _AnonType2 {
   _AnonField: String
@@ -989,12 +989,12 @@ schema {
 }
 
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type GitHubRepository implements _AnonType2 {
   _AnonField: String

--- a/trustfall_core/src/schema/mod.rs
+++ b/trustfall_core/src/schema/mod.rs
@@ -92,12 +92,12 @@ const RESERVED_PREFIX: &str = "__";
 impl Schema {
     pub const ALL_DIRECTIVE_DEFINITIONS: &'static str = "
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 ";
 
     pub fn parse(input: impl AsRef<str>) -> Result<Self, InvalidSchemaError> {

--- a/trustfall_core/test_data/tests/valid_schemas/deeply_nested_list_property_field.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/deeply_nested_list_property_field.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/valid_schemas/type_narrowing_edge_nullability.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/type_narrowing_edge_nullability.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/valid_schemas/type_narrowing_edge_subtype.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/type_narrowing_edge_subtype.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/valid_schemas/type_narrowing_list_edge_nullability.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/type_narrowing_list_edge_nullability.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/valid_schemas/type_narrowing_list_edge_subtype.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/type_narrowing_list_edge_subtype.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/valid_schemas/type_narrowing_of_inherited_fields.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/type_narrowing_of_inherited_fields.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/valid_schemas/type_widening_parameterized_field_parameter.graphql
+++ b/trustfall_core/test_data/tests/valid_schemas/type_widening_parameterized_field_parameter.graphql
@@ -2,12 +2,12 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base


### PR DESCRIPTION
This PR runs on the assumption that the ability of trustfall-stubgen to generate code for schemas with those present means it can be added to directives. Why am I doing this:

> hmm now that I look at it, output and tag and transform should probably be repeatable too 🤔
> Predrag Gruevski

There's still some schema tests failing that I'll look at tomorrow. I'm hoping that they add something a bit more rigorous so we can be sure this won't break anything but I figured I'd just put the draft PR up in the meantime.