### PR TITLE
Weekly `cargo update` of fuzzing dependencies

### DIFF
--- a/trustfall_core/fuzz/Cargo.lock
+++ b/trustfall_core/fuzz/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -144,15 +144,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",


### PR DESCRIPTION
Automation to keep dependencies in the fuzzing `Cargo.lock` current.

The following is the output from `cargo update`:

```txt
     Locking 3 packages to latest compatible versions
    Updating cc v1.2.59 -> v1.2.60
    Updating hashbrown v0.16.1 -> v0.17.0
    Updating indexmap v2.13.1 -> v2.14.0
note: pass `--verbose` to see 2 unchanged dependencies behind latest
```
