### PR TITLE
Update weather example for May 2026 CSV format

### DIFF
--- a/trustfall/examples/weather/main.rs
+++ b/trustfall/examples/weather/main.rs
@@ -56,24 +56,15 @@ fn read_metar_data() -> Vec<MetarReport> {
 
     let mut buf = String::new();
 
-    // strip the CSV prefix and the header row
-    let prefix_len = 6;
-    for _ in 0..prefix_len {
-        reader.read_line(&mut buf).unwrap();
-
-        match buf.as_str().trim() {
-            "No errors" | "No warnings" | "data source=metars" | METAR_DOC_HEADER_ROW => {}
-            data => match data.split_once(' ') {
-                Some((left, right)) if right == "ms" || right == "results" => {
-                    assert!(left.chars().all(|x| x.is_ascii_digit()));
-                }
-                _ => unreachable!(),
-            },
-        }
-
-        buf.truncate(0);
+    // Strip header row
+    reader.read_line(&mut buf).unwrap();
+    if buf.as_str().trim() != METAR_DOC_HEADER_ROW {
+        unreachable!("Expected CSV to begin with only the header ROW")
     }
 
+    // We cannot use has_headers(true) because the CSV has duplicate column headers
+    // for sky_cover and cloud_base_ft_agl, which we manually handle.
+    // (See [`crate::metar::CsvMetarReport`])
     let mut csv_reader = csv::ReaderBuilder::new().has_headers(false).from_reader(reader);
 
     let metars: Vec<MetarReport> =

--- a/trustfall/examples/weather/metar.rs
+++ b/trustfall/examples/weather/metar.rs
@@ -79,6 +79,7 @@ pub(crate) struct CsvMetarReport {
     pub(crate) vert_vis_ft: Option<i32>,
 
     pub(crate) metar_type: Option<String>,
+
     // As of May 2026, METAR may contain `null` in this field
     #[serde(deserialize_with = "csv::invalid_option")]
     pub(crate) elevation_m: Option<f64>,

--- a/trustfall/examples/weather/metar.rs
+++ b/trustfall/examples/weather/metar.rs
@@ -79,6 +79,8 @@ pub(crate) struct CsvMetarReport {
     pub(crate) vert_vis_ft: Option<i32>,
 
     pub(crate) metar_type: Option<String>,
+    // As of May 2026, METAR may contain `null` in this field
+    #[serde(deserialize_with = "csv::invalid_option")]
     pub(crate) elevation_m: Option<f64>,
 }
 


### PR DESCRIPTION
Previously, the weather example made the following incorrect assumptions about the CSV from aviationweather.gov:

1. The file would contain a CSV prefix.
2. elevation_m would always be a valid f64

This PR removes handling for the CSV prefix and deserializes `null` to None.

Fixes #927 