### PR TITLE
Update ron to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,14 +2517,16 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "base64 0.21.7",
  "bitflags 2.13.0",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3686,6 +3688,12 @@ dependencies = [
  "termcolor",
  "toml",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.9.1"
 # The dependencies below are internal-only.
 # Bumping major versions here should be safe.
 itertools = "0.13.0"
-ron = "0.8.0"
+ron = "0.12.1"
 similar-asserts = "1.4.2"
 maplit = "1.0.2"
 syn = "2.0"

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Context as _;
 use std::{
+    borrow::Cow,
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
     env,
@@ -48,14 +49,10 @@ fn get_schema_by_name(schema_name: &str) -> Schema {
 }
 
 fn serialize_to_ron<S: Serialize>(s: &S) -> String {
-    let mut buf = Vec::new();
     let mut config = ron::ser::PrettyConfig::new().struct_names(true);
-    config.new_line = "\n".to_string();
-    config.indentor = "  ".to_string();
-    let mut serializer = ron::ser::Serializer::new(&mut buf, Some(config)).unwrap();
-
-    s.serialize(&mut serializer).unwrap();
-    String::from_utf8(buf).unwrap()
+    config.new_line = Cow::Borrowed("\n");
+    config.indentor = Cow::Borrowed("  ");
+    ron::ser::to_string_pretty(s, config).unwrap()
 }
 
 fn parse(path: &str) {


### PR DESCRIPTION
https://github.com/ron-rs/ron/blob/v0.12.1/CHANGELOG.md

A source-code change was required in `trustfall_testbin` to get from `ron` 0.8 to 0.9. I confirmed that `cargo test --workspace` still passes.