### PR TITLE
Use std::path::Path/PathBuf instead of strings for path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 **/__pycache__/
 **/trustfall.cpython-*.so
 **/.pytest_cache/
-.DS_Store
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 **/__pycache__/
 **/trustfall.cpython-*.so
 **/.pytest_cache/
+.DS_Store

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -61,10 +61,7 @@ struct DirectoryContainsFileIterator {
 }
 
 impl DirectoryContainsFileIterator {
-    pub fn new(
-        origin: Rc<PathBuf>,
-        directory: &DirectoryVertex,
-    ) -> DirectoryContainsFileIterator {
+    pub fn new(origin: Rc<PathBuf>, directory: &DirectoryVertex) -> DirectoryContainsFileIterator {
         let buf = origin.join(&directory.path);
         DirectoryContainsFileIterator {
             origin,
@@ -89,15 +86,9 @@ impl Iterator for DirectoryContainsFileIterator {
                         if metadata.is_file() {
                             let name = dir_entry.file_name().to_str().unwrap().to_owned();
                             let buf = PathBuf::from(&self.directory.path).join(&name);
-                            let extension = buf
-                                .extension()
-                                .map(|x| x.to_str().unwrap().to_owned());
+                            let extension = buf.extension().map(|x| x.to_str().unwrap().to_owned());
                             let path = buf.to_str().unwrap().replace('\\', "/");
-                            let result = FileVertex {
-                                name,
-                                extension,
-                                path,
-                            };
+                            let result = FileVertex { name, extension, path };
                             return Some(FilesystemVertex::File(result));
                         }
                     }

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -84,7 +84,11 @@ impl Iterator for DirectoryContainsFileIterator {
                         _ => continue,
                     };
                     if metadata.is_file() {
-                        let name = dir_entry.file_name().to_string_lossy().into_owned();
+                        let os_name = dir_entry.file_name();
+                        let name = match os_name.to_str() {
+                            Some(s) => s.to_owned(),
+                            None => continue, // skip non-UTF-8 names: can't store them in path: String
+                        };
                         let extension =
                             Path::new(&name).extension().map(|x| x.to_string_lossy().into_owned());
                         let path = join_with_slash(&self.directory.path, &name);
@@ -125,7 +129,11 @@ impl Iterator for SubdirectoryIterator {
                         _ => continue,
                     };
                     if metadata.is_dir() {
-                        let name = dir_entry.file_name().to_string_lossy().into_owned();
+                        let os_name = dir_entry.file_name();
+                        let name = match os_name.to_str() {
+                            Some(s) => s.to_owned(),
+                            None => continue, // skip non-UTF-8 names: can't store them in path: String
+                        };
                         if name == ".git" || name == ".vscode" || name == "target" {
                             continue;
                         }
@@ -377,6 +385,7 @@ mod tests {
     impl TempDir {
         fn new(name: &str) -> Self {
             let path = std::env::temp_dir().join(name);
+            let _ = fs::remove_dir_all(&path); // clean up any leftover from a previous run
             fs::create_dir_all(&path).unwrap();
             Self(path)
         }
@@ -516,5 +525,42 @@ mod tests {
         let origin = std::env::temp_dir().join("trustfall_test_nonexistent_xyz");
         let dirs = collect_dirs(&origin, "");
         assert!(dirs.is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn file_iterator_skips_non_utf8_names() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = TempDir::new("trustfall_test_non_utf8_file");
+        // Create one valid UTF-8 file and one with a non-UTF-8 name (invalid byte 0xFF).
+        fs::write(dir.path().join("valid.txt"), "").unwrap();
+        let bad_name = std::ffi::OsStr::from_bytes(b"bad\xff.txt");
+        fs::write(dir.path().join(bad_name), "").unwrap();
+
+        let files = collect_files(dir.path(), "");
+
+        // Only the valid file should appear; the non-UTF-8 one must be skipped, not mangled.
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, "valid.txt");
+        assert!(!files[0].path.contains('\u{FFFD}'));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn subdir_iterator_skips_non_utf8_names() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = TempDir::new("trustfall_test_non_utf8_dir");
+        fs::create_dir(dir.path().join("valid")).unwrap();
+        let bad_name = std::ffi::OsStr::from_bytes(b"bad\xff");
+        fs::create_dir(dir.path().join(bad_name)).unwrap();
+
+        let dirs = collect_dirs(dir.path(), "");
+
+        // Only the valid directory should appear; the non-UTF-8 one must be skipped.
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].name, "valid");
+        assert!(!dirs[0].path.contains('\u{FFFD}'));
     }
 }

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -2,7 +2,7 @@
 
 use std::fs::{self, ReadDir};
 use std::iter;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -85,9 +85,9 @@ impl Iterator for DirectoryContainsFileIterator {
                     };
                     if metadata.is_file() {
                         let name = dir_entry.file_name().to_string_lossy().into_owned();
-                        let buf = PathBuf::from(&self.directory.path).join(&name);
-                        let extension = buf.extension().map(|x| x.to_string_lossy().into_owned());
-                        let path = buf.to_string_lossy().replace('\\', "/");
+                        let extension =
+                            Path::new(&name).extension().map(|x| x.to_string_lossy().into_owned());
+                        let path = join_with_slash(&self.directory.path, &name);
                         let result = FileVertex { name, extension, path };
                         return Some(FilesystemVertex::File(result));
                     }
@@ -130,8 +130,7 @@ impl Iterator for SubdirectoryIterator {
                             continue;
                         }
 
-                        let buf = PathBuf::from(&self.directory.path).join(&name);
-                        let path = buf.to_string_lossy().replace('\\', "/");
+                        let path = join_with_slash(&self.directory.path, &name);
                         let result = DirectoryVertex { name, path };
                         return Some(FilesystemVertex::Directory(result));
                     }
@@ -361,5 +360,161 @@ impl<'a> Adapter<'a> for FilesystemInterpreter {
         resolve_info: &ResolveInfo,
     ) -> ContextOutcomeIterator<'a, V, bool> {
         todo!()
+    }
+}
+
+fn join_with_slash(base: &str, name: &str) -> String {
+    if base.is_empty() { name.to_owned() } else { format!("{base}/{name}") }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(name);
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn collect_files(origin: &Path, dir_path: &str) -> Vec<FileVertex> {
+        let directory = DirectoryVertex { name: "root".to_owned(), path: dir_path.to_owned() };
+        let mut files: Vec<FileVertex> =
+            DirectoryContainsFileIterator::new(Rc::new(origin.to_path_buf()), &directory)
+                .map(|v| match v {
+                    FilesystemVertex::File(f) => f,
+                    _ => panic!("expected file vertex"),
+                })
+                .collect();
+        files.sort_by(|a, b| a.name.cmp(&b.name));
+        files
+    }
+
+    fn collect_dirs(origin: &Path, dir_path: &str) -> Vec<DirectoryVertex> {
+        let directory = DirectoryVertex { name: "root".to_owned(), path: dir_path.to_owned() };
+        let mut dirs: Vec<DirectoryVertex> =
+            SubdirectoryIterator::new(Rc::new(origin.to_path_buf()), &directory)
+                .map(|v| match v {
+                    FilesystemVertex::Directory(d) => d,
+                    _ => panic!("expected directory vertex"),
+                })
+                .collect();
+        dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        dirs
+    }
+
+    #[test]
+    fn file_iterator_yields_files_with_correct_fields() {
+        let dir = TempDir::new("trustfall_test_file_iter");
+        fs::write(dir.path().join("foo.txt"), "").unwrap();
+        fs::write(dir.path().join("bar.rs"), "").unwrap();
+        fs::create_dir(dir.path().join("subdir")).unwrap();
+
+        let files = collect_files(dir.path(), "");
+
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].name, "bar.rs");
+        assert_eq!(files[0].extension, Some("rs".to_owned()));
+        assert_eq!(files[0].path, "bar.rs");
+        assert_eq!(files[1].name, "foo.txt");
+        assert_eq!(files[1].extension, Some("txt".to_owned()));
+        assert_eq!(files[1].path, "foo.txt");
+    }
+
+    #[test]
+    fn file_iterator_paths_use_forward_slashes() {
+        let dir = TempDir::new("trustfall_test_file_slash");
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("sub").join("deep.txt"), "").unwrap();
+
+        let files = collect_files(dir.path(), "sub");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "sub/deep.txt");
+        assert!(!files[0].path.contains('\\'));
+    }
+
+    #[test]
+    fn file_iterator_handles_no_extension() {
+        let dir = TempDir::new("trustfall_test_no_ext");
+        fs::write(dir.path().join("Makefile"), "").unwrap();
+
+        let files = collect_files(dir.path(), "");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, "Makefile");
+        assert_eq!(files[0].extension, None);
+    }
+
+    #[test]
+    fn file_iterator_empty_on_missing_directory() {
+        let origin = std::env::temp_dir().join("trustfall_test_nonexistent_xyz");
+        let files = collect_files(&origin, "");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn subdir_iterator_yields_directories_with_correct_fields() {
+        let dir = TempDir::new("trustfall_test_subdir_iter");
+        fs::create_dir(dir.path().join("alpha")).unwrap();
+        fs::create_dir(dir.path().join("beta")).unwrap();
+        fs::write(dir.path().join("file.txt"), "").unwrap();
+
+        let dirs = collect_dirs(dir.path(), "");
+
+        assert_eq!(dirs.len(), 2);
+        assert_eq!(dirs[0].name, "alpha");
+        assert_eq!(dirs[0].path, "alpha");
+        assert_eq!(dirs[1].name, "beta");
+        assert_eq!(dirs[1].path, "beta");
+    }
+
+    #[test]
+    fn subdir_iterator_paths_use_forward_slashes() {
+        let dir = TempDir::new("trustfall_test_subdir_slash");
+        fs::create_dir(dir.path().join("parent")).unwrap();
+        fs::create_dir(dir.path().join("parent").join("child")).unwrap();
+
+        let dirs = collect_dirs(dir.path(), "parent");
+
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].path, "parent/child");
+        assert!(!dirs[0].path.contains('\\'));
+    }
+
+    #[test]
+    fn subdir_iterator_skips_hidden_and_build_dirs() {
+        let dir = TempDir::new("trustfall_test_skip_dirs");
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        fs::create_dir(dir.path().join(".vscode")).unwrap();
+        fs::create_dir(dir.path().join("target")).unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+
+        let dirs = collect_dirs(dir.path(), "");
+
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].name, "src");
+    }
+
+    #[test]
+    fn subdir_iterator_empty_on_missing_directory() {
+        let origin = std::env::temp_dir().join("trustfall_test_nonexistent_xyz");
+        let dirs = collect_dirs(&origin, "");
+        assert!(dirs.is_empty());
     }
 }

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -2,7 +2,7 @@
 
 use std::fs::{self, ReadDir};
 use std::iter;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -19,11 +19,11 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct FilesystemInterpreter {
-    origin: Rc<String>,
+    origin: Rc<PathBuf>,
 }
 
 impl FilesystemInterpreter {
-    pub fn new(origin: String) -> FilesystemInterpreter {
+    pub fn new(origin: PathBuf) -> FilesystemInterpreter {
         FilesystemInterpreter { origin: Rc::new(origin) }
     }
 }
@@ -55,15 +55,17 @@ impl Iterator for OriginIterator {
 
 #[derive(Debug)]
 struct DirectoryContainsFileIterator {
-    origin: Rc<String>,
+    origin: Rc<PathBuf>,
     directory: DirectoryVertex,
     file_iter: ReadDir,
 }
 
 impl DirectoryContainsFileIterator {
-    pub fn new(origin: Rc<String>, directory: &DirectoryVertex) -> DirectoryContainsFileIterator {
-        let mut buf = PathBuf::new();
-        buf.extend([&*origin, &directory.path]);
+    pub fn new(
+        origin: Rc<PathBuf>,
+        directory: &DirectoryVertex,
+    ) -> DirectoryContainsFileIterator {
+        let buf = origin.join(&directory.path);
         DirectoryContainsFileIterator {
             origin,
             directory: directory.clone(),
@@ -86,15 +88,15 @@ impl Iterator for DirectoryContainsFileIterator {
                         };
                         if metadata.is_file() {
                             let name = dir_entry.file_name().to_str().unwrap().to_owned();
-                            let mut buf = PathBuf::new();
-                            buf.extend([&self.directory.path, &name]);
-                            let extension = Path::new(&name)
+                            let buf = PathBuf::from(&self.directory.path).join(&name);
+                            let extension = buf
                                 .extension()
                                 .map(|x| x.to_str().unwrap().to_owned());
+                            let path = buf.to_str().unwrap().replace('\\', "/");
                             let result = FileVertex {
                                 name,
                                 extension,
-                                path: buf.to_str().unwrap().to_owned(),
+                                path,
                             };
                             return Some(FilesystemVertex::File(result));
                         }
@@ -110,15 +112,14 @@ impl Iterator for DirectoryContainsFileIterator {
 
 #[derive(Debug)]
 struct SubdirectoryIterator {
-    origin: Rc<String>,
+    origin: Rc<PathBuf>,
     directory: DirectoryVertex,
     dir_iter: ReadDir,
 }
 
 impl SubdirectoryIterator {
-    pub fn new(origin: Rc<String>, directory: &DirectoryVertex) -> Self {
-        let mut buf = PathBuf::new();
-        buf.extend([&*origin, &directory.path]);
+    pub fn new(origin: Rc<PathBuf>, directory: &DirectoryVertex) -> Self {
+        let buf = origin.join(&directory.path);
         Self { origin, directory: directory.clone(), dir_iter: fs::read_dir(buf).unwrap() }
     }
 }
@@ -141,10 +142,9 @@ impl Iterator for SubdirectoryIterator {
                                 continue;
                             }
 
-                            let mut buf = PathBuf::new();
-                            buf.extend([&self.directory.path, &name]);
-                            let result =
-                                DirectoryVertex { name, path: buf.to_str().unwrap().to_owned() };
+                            let buf = PathBuf::from(&self.directory.path).join(&name);
+                            let path = buf.to_str().unwrap().replace('\\', "/");
+                            let result = DirectoryVertex { name, path };
                             return Some(FilesystemVertex::Directory(result));
                         }
                     }
@@ -160,18 +160,18 @@ impl Iterator for SubdirectoryIterator {
 pub type ContextAndValue = (DataContext<FilesystemVertex>, FieldValue);
 
 type IndividualEdgeResolver<'a> =
-    fn(Rc<String>, &FilesystemVertex) -> VertexIterator<'a, FilesystemVertex>;
+    fn(Rc<PathBuf>, &FilesystemVertex) -> VertexIterator<'a, FilesystemVertex>;
 type ContextAndIterableOfEdges<'a, V> = (DataContext<V>, VertexIterator<'a, FilesystemVertex>);
 
 struct EdgeResolverIterator<'a, V: AsVertex<FilesystemVertex>> {
-    origin: Rc<String>,
+    origin: Rc<PathBuf>,
     contexts: VertexIterator<'a, DataContext<V>>,
     edge_resolver: IndividualEdgeResolver<'a>,
 }
 
 impl<'a, V: AsVertex<FilesystemVertex>> EdgeResolverIterator<'a, V> {
     pub fn new(
-        origin: Rc<String>,
+        origin: Rc<PathBuf>,
         contexts: VertexIterator<'a, DataContext<V>>,
         edge_resolver: IndividualEdgeResolver<'a>,
     ) -> Self {
@@ -217,7 +217,7 @@ pub struct FileVertex {
 }
 
 fn directory_contains_file_handler<'a>(
-    origin: Rc<String>,
+    origin: Rc<PathBuf>,
     vertex: &FilesystemVertex,
 ) -> VertexIterator<'a, FilesystemVertex> {
     let directory_vertex = match vertex {
@@ -228,7 +228,7 @@ fn directory_contains_file_handler<'a>(
 }
 
 fn directory_subdirectory_handler<'a>(
-    origin: Rc<String>,
+    origin: Rc<PathBuf>,
     vertex: &FilesystemVertex,
 ) -> VertexIterator<'a, FilesystemVertex> {
     let directory_vertex = match vertex {

--- a/trustfall_core/src/filesystem_interpreter.rs
+++ b/trustfall_core/src/filesystem_interpreter.rs
@@ -57,7 +57,7 @@ impl Iterator for OriginIterator {
 struct DirectoryContainsFileIterator {
     origin: Rc<PathBuf>,
     directory: DirectoryVertex,
-    file_iter: ReadDir,
+    file_iter: Option<ReadDir>,
 }
 
 impl DirectoryContainsFileIterator {
@@ -66,7 +66,7 @@ impl DirectoryContainsFileIterator {
         DirectoryContainsFileIterator {
             origin,
             directory: directory.clone(),
-            file_iter: fs::read_dir(buf).unwrap(),
+            file_iter: fs::read_dir(buf).ok(),
         }
     }
 }
@@ -75,27 +75,24 @@ impl Iterator for DirectoryContainsFileIterator {
     type Item = FilesystemVertex;
 
     fn next(&mut self) -> Option<FilesystemVertex> {
+        let file_iter = self.file_iter.as_mut()?;
         loop {
-            if let Some(outcome) = self.file_iter.next() {
-                match outcome {
-                    Ok(dir_entry) => {
-                        let metadata = match dir_entry.metadata() {
-                            Ok(res) => res,
-                            _ => continue,
-                        };
-                        if metadata.is_file() {
-                            let name = dir_entry.file_name().to_str().unwrap().to_owned();
-                            let buf = PathBuf::from(&self.directory.path).join(&name);
-                            let extension = buf.extension().map(|x| x.to_str().unwrap().to_owned());
-                            let path = buf.to_str().unwrap().replace('\\', "/");
-                            let result = FileVertex { name, extension, path };
-                            return Some(FilesystemVertex::File(result));
-                        }
+            match file_iter.next()? {
+                Ok(dir_entry) => {
+                    let metadata = match dir_entry.metadata() {
+                        Ok(res) => res,
+                        _ => continue,
+                    };
+                    if metadata.is_file() {
+                        let name = dir_entry.file_name().to_string_lossy().into_owned();
+                        let buf = PathBuf::from(&self.directory.path).join(&name);
+                        let extension = buf.extension().map(|x| x.to_string_lossy().into_owned());
+                        let path = buf.to_string_lossy().replace('\\', "/");
+                        let result = FileVertex { name, extension, path };
+                        return Some(FilesystemVertex::File(result));
                     }
-                    _ => continue,
                 }
-            } else {
-                return None;
+                _ => continue,
             }
         }
     }
@@ -105,13 +102,13 @@ impl Iterator for DirectoryContainsFileIterator {
 struct SubdirectoryIterator {
     origin: Rc<PathBuf>,
     directory: DirectoryVertex,
-    dir_iter: ReadDir,
+    dir_iter: Option<ReadDir>,
 }
 
 impl SubdirectoryIterator {
     pub fn new(origin: Rc<PathBuf>, directory: &DirectoryVertex) -> Self {
         let buf = origin.join(&directory.path);
-        Self { origin, directory: directory.clone(), dir_iter: fs::read_dir(buf).unwrap() }
+        Self { origin, directory: directory.clone(), dir_iter: fs::read_dir(buf).ok() }
     }
 }
 
@@ -119,30 +116,27 @@ impl Iterator for SubdirectoryIterator {
     type Item = FilesystemVertex;
 
     fn next(&mut self) -> Option<FilesystemVertex> {
+        let dir_iter = self.dir_iter.as_mut()?;
         loop {
-            if let Some(outcome) = self.dir_iter.next() {
-                match outcome {
-                    Ok(dir_entry) => {
-                        let metadata = match dir_entry.metadata() {
-                            Ok(res) => res,
-                            _ => continue,
-                        };
-                        if metadata.is_dir() {
-                            let name = dir_entry.file_name().to_str().unwrap().to_owned();
-                            if name == ".git" || name == ".vscode" || name == "target" {
-                                continue;
-                            }
-
-                            let buf = PathBuf::from(&self.directory.path).join(&name);
-                            let path = buf.to_str().unwrap().replace('\\', "/");
-                            let result = DirectoryVertex { name, path };
-                            return Some(FilesystemVertex::Directory(result));
+            match dir_iter.next()? {
+                Ok(dir_entry) => {
+                    let metadata = match dir_entry.metadata() {
+                        Ok(res) => res,
+                        _ => continue,
+                    };
+                    if metadata.is_dir() {
+                        let name = dir_entry.file_name().to_string_lossy().into_owned();
+                        if name == ".git" || name == ".vscode" || name == "target" {
+                            continue;
                         }
+
+                        let buf = PathBuf::from(&self.directory.path).join(&name);
+                        let path = buf.to_string_lossy().replace('\\', "/");
+                        let result = DirectoryVertex { name, path };
+                        return Some(FilesystemVertex::Directory(result));
                     }
-                    _ => continue,
                 }
-            } else {
-                return None;
+                _ => continue,
             }
         }
     }

--- a/trustfall_filetests_macros/src/lib.rs
+++ b/trustfall_filetests_macros/src/lib.rs
@@ -82,7 +82,7 @@ pub fn parameterize(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let fn_ident = item_fn.sig.ident.clone();
         let base_ident = Ident::new("base", Span::call_site());
-        let base_ident_value = base.to_str().unwrap();
+        let base_ident_value = base.display().to_string();
         let stem_ident = Ident::new("stem", Span::call_site());
         let test_function_body = quote! {
             let #base_ident = ::std::path::PathBuf::from(#base_ident_value);

--- a/trustfall_filetests_macros/src/lib.rs
+++ b/trustfall_filetests_macros/src/lib.rs
@@ -82,7 +82,10 @@ pub fn parameterize(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let fn_ident = item_fn.sig.ident.clone();
         let base_ident = Ident::new("base", Span::call_site());
-        let base_ident_value = base.display().to_string();
+        let base_ident_value = base.to_str().expect(
+            "base path is built exclusively from UTF-8 sources \
+             (env!(\"CARGO_MANIFEST_DIR\") and string literals), so it must be valid UTF-8",
+        );
         let stem_ident = Ident::new("stem", Span::call_site());
         let test_function_body = quote! {
             let #base_ident = ::std::path::PathBuf::from(#base_ident_value);

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -39,8 +39,9 @@ use trustfall_core::{
 };
 
 fn get_schema_by_name(schema_name: &str) -> Schema {
-    let schema_path: PathBuf =
-        ["..","trustfall_core", "test_data", "schemas"].iter().collect::<PathBuf>()
+    let schema_path: PathBuf = ["..", "trustfall_core", "test_data", "schemas"]
+        .iter()
+        .collect::<PathBuf>()
         .join(format!("{schema_name}.graphql"));
     let schema_text = fs::read_to_string(&schema_path)
         .context(format!("failed to read schema from {}", schema_path.display()))

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -10,9 +10,8 @@ use std::{
     env,
     fmt::Debug,
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::Rc,
-    str::FromStr,
     sync::Arc,
 };
 
@@ -40,9 +39,11 @@ use trustfall_core::{
 };
 
 fn get_schema_by_name(schema_name: &str) -> Schema {
-    let schema_path = format!("../trustfall_core/test_data/schemas/{schema_name}.graphql",);
+    let schema_path: PathBuf =
+        ["..","trustfall_core", "test_data", "schemas"].iter().collect::<PathBuf>()
+        .join(format!("{schema_name}.graphql"));
     let schema_text = fs::read_to_string(&schema_path)
-        .context(format!("failed to read schema from {schema_path}"))
+        .context(format!("failed to read schema from {}", schema_path.display()))
         .unwrap();
     let schema_document = parse_schema(schema_text).unwrap();
     Schema::new(schema_document).unwrap()
@@ -55,7 +56,7 @@ fn serialize_to_ron<S: Serialize>(s: &S) -> String {
     ron::ser::to_string_pretty(s, config).unwrap()
 }
 
-fn parse(path: &str) {
+fn parse(path: &Path) {
     let input_data = fs::read_to_string(path).unwrap();
     let test_query: TestGraphQLQuery = ron::from_str(&input_data).unwrap();
 
@@ -72,7 +73,7 @@ fn parse(path: &str) {
     println!("{}", serialize_to_ron(&result));
 }
 
-fn frontend(path: &str) {
+fn frontend(path: &Path) {
     let input_data = fs::read_to_string(path).unwrap();
     let test_query_result: TestParsedGraphQLQueryResult = ron::from_str(&input_data).unwrap();
     let test_query = test_query_result.unwrap();
@@ -90,7 +91,7 @@ fn frontend(path: &str) {
     println!("{}", serialize_to_ron(&result));
 }
 
-fn check_fuzzed(path: &str, schema_name: &str) {
+fn check_fuzzed(path: &Path, schema_name: &str) {
     let schema = get_schema_by_name(schema_name);
 
     let query_string = fs::read_to_string(path).unwrap();
@@ -143,14 +144,14 @@ where
     }
 }
 
-fn outputs(path: &str) {
+fn outputs(path: &Path) {
     let input_data = fs::read_to_string(path).unwrap();
     let test_query_result: TestIRQueryResult = ron::from_str(&input_data).unwrap();
     let test_query = test_query_result.unwrap();
 
     match test_query.schema_name.as_str() {
         "filesystem" => {
-            let adapter = FilesystemInterpreter::new(".".to_owned());
+            let adapter = FilesystemInterpreter::new(PathBuf::from("."));
             outputs_with_adapter(adapter, test_query);
         }
         "numbers" => {
@@ -203,12 +204,12 @@ fn trace_with_adapter<'a, AdapterT>(
     }
 }
 
-fn trace(path: &str) {
+fn trace(path: &Path) {
     let input_data = fs::read_to_string(path).unwrap();
     let test_query_result: TestIRQueryResult = ron::from_str(&input_data).unwrap();
     let test_query = test_query_result.unwrap();
 
-    let mut outputs_path = PathBuf::from_str(path).unwrap();
+    let mut outputs_path = path.to_path_buf();
     let ir_file_name = outputs_path.file_name().expect("not a file").to_str().unwrap();
     let outputs_file_name = ir_file_name.replace(".ir.ron", ".output.ron");
     outputs_path.pop();
@@ -224,7 +225,7 @@ fn trace(path: &str) {
 
     match test_query.schema_name.as_str() {
         "filesystem" => {
-            let adapter = FilesystemInterpreter::new(".".to_owned());
+            let adapter = FilesystemInterpreter::new(PathBuf::from("."));
             trace_with_adapter(adapter, test_query, expected_results_func);
         }
         "numbers" => {
@@ -239,31 +240,33 @@ fn trace(path: &str) {
     };
 }
 
-fn reserialize(path: &str) {
+fn reserialize(path: &Path) {
     let input_data = fs::read_to_string(path).unwrap();
 
-    let (prefix, last_extension) = path.rsplit_once('.').unwrap();
-    assert_eq!(last_extension, "ron");
+    // Strip the outer ".ron" extension, then inspect the next extension.
+    assert_eq!(path.extension().and_then(|e| e.to_str()), Some("ron"));
+    let stem = path.file_stem().unwrap(); // e.g. "query.graphql"
+    let inner_ext = Path::new(stem).extension().and_then(|e| e.to_str());
 
-    let output_data = match prefix.rsplit_once('.') {
-        Some((_, "graphql")) => {
+    let output_data = match inner_ext {
+        Some("graphql") => {
             let test_query: TestGraphQLQuery = ron::from_str(&input_data).unwrap();
             serialize_to_ron(&test_query)
         }
-        Some((_, "graphql-parsed" | "parse-error")) => {
+        Some("graphql-parsed" | "parse-error") => {
             let test_query_result: TestParsedGraphQLQueryResult =
                 ron::from_str(&input_data).unwrap();
             serialize_to_ron(&test_query_result)
         }
-        Some((_, "ir" | "frontend-error")) => {
+        Some("ir" | "frontend-error") => {
             let test_query_result: TestIRQueryResult = ron::from_str(&input_data).unwrap();
             serialize_to_ron(&test_query_result)
         }
-        Some((_, "output")) => {
+        Some("output") => {
             let test_output_data: TestInterpreterOutputData = ron::from_str(&input_data).unwrap();
             serialize_to_ron(&test_output_data)
         }
-        Some((_, "trace")) => {
+        Some("trace") => {
             if let Ok(test_trace) =
                 ron::from_str::<TestInterpreterOutputTrace<NumbersVertex>>(&input_data)
             {
@@ -276,22 +279,22 @@ fn reserialize(path: &str) {
                 unreachable!()
             }
         }
-        Some((_, "schema-error")) => {
+        Some("schema-error") => {
             let schema_error: InvalidSchemaError = ron::from_str(&input_data).unwrap();
             serialize_to_ron(&schema_error)
         }
-        Some((_, "exec-error")) => {
+        Some("exec-error") => {
             let exec_error: QueryArgumentsError = ron::from_str(&input_data).unwrap();
             serialize_to_ron(&exec_error)
         }
-        Some((_, ext)) => unreachable!("{}", ext),
-        None => unreachable!("{}", path),
+        Some(ext) => unreachable!("{}", ext),
+        None => unreachable!("{}", path.display()),
     };
 
     println!("{output_data}");
 }
 
-fn schema_error(path: &str) {
+fn schema_error(path: &Path) {
     let schema_text = fs::read_to_string(path).unwrap();
 
     let result = Schema::parse(schema_text);
@@ -299,26 +302,27 @@ fn schema_error(path: &str) {
         Err(e) => {
             println!("{}", serialize_to_ron(&e))
         }
-        Ok(_) => unreachable!("expected schema error but got valid schema: {}", path),
+        Ok(_) => unreachable!("expected schema error but got valid schema: {}", path.display()),
     }
 }
 
-fn corpus_graphql(path: &str, schema_name: &str) {
+fn corpus_graphql(path: &Path, schema_name: &str) {
     let input_data = fs::read_to_string(path).unwrap();
 
-    let (prefix, last_extension) = path.rsplit_once('.').unwrap();
-    assert_eq!(last_extension, "ron");
+    assert_eq!(path.extension().and_then(|e| e.to_str()), Some("ron"));
+    let stem = path.file_stem().unwrap();
+    let inner_ext = Path::new(stem).extension().and_then(|e| e.to_str());
 
-    let output_data = match prefix.rsplit_once('.') {
-        Some((_, "graphql")) => {
+    let output_data = match inner_ext {
+        Some("graphql") => {
             let test_query: TestGraphQLQuery = ron::from_str(&input_data).unwrap();
             if test_query.schema_name != schema_name {
                 return;
             }
             test_query.query.replace("    ", " ")
         }
-        Some((_, ext)) => unreachable!("{}", ext),
-        None => unreachable!("{}", path),
+        Some(ext) => unreachable!("{}", ext),
+        None => unreachable!("{}", path.display()),
     };
 
     println!("{output_data}");
@@ -338,42 +342,42 @@ fn main() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                parse(path)
+                parse(Path::new(path))
             }
         },
         Some("frontend") => match reversed_args.pop() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                frontend(path)
+                frontend(Path::new(path))
             }
         },
         Some("outputs") => match reversed_args.pop() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                outputs(path)
+                outputs(Path::new(path))
             }
         },
         Some("trace") => match reversed_args.pop() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                trace(path)
+                trace(Path::new(path))
             }
         },
         Some("schema_error") => match reversed_args.pop() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                schema_error(path)
+                schema_error(Path::new(path))
             }
         },
         Some("reserialize") => match reversed_args.pop() {
             None => panic!("No filename provided"),
             Some(path) => {
                 assert!(reversed_args.is_empty());
-                reserialize(path)
+                reserialize(Path::new(path))
             }
         },
         Some("corpus_graphql") => match reversed_args.pop() {
@@ -382,7 +386,7 @@ fn main() {
                 let schema_name = reversed_args.pop().expect("schema name");
 
                 assert!(reversed_args.is_empty());
-                corpus_graphql(path, schema_name)
+                corpus_graphql(Path::new(path), schema_name)
             }
         },
         Some("check_fuzzed") => match reversed_args.pop() {
@@ -391,7 +395,7 @@ fn main() {
                 let schema_name = reversed_args.pop().expect("schema name");
 
                 assert!(reversed_args.is_empty());
-                check_fuzzed(path, schema_name)
+                check_fuzzed(Path::new(path), schema_name)
             }
         },
         Some(cmd) => panic!("Unrecognized command given: {cmd}"),

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -211,7 +211,7 @@ fn trace(path: &Path) {
     let test_query = test_query_result.unwrap();
 
     let mut outputs_path = path.to_path_buf();
-    let ir_file_name = outputs_path.file_name().expect("not a file").to_str().unwrap();
+    let ir_file_name = outputs_path.file_name().expect("not a file").to_string_lossy();
     let outputs_file_name = ir_file_name.replace(".ir.ron", ".output.ron");
     outputs_path.pop();
     outputs_path.push(&outputs_file_name);

--- a/trustfall_testbin/src/main.rs
+++ b/trustfall_testbin/src/main.rs
@@ -211,7 +211,11 @@ fn trace(path: &Path) {
     let test_query = test_query_result.unwrap();
 
     let mut outputs_path = path.to_path_buf();
-    let ir_file_name = outputs_path.file_name().expect("not a file").to_string_lossy();
+    let ir_file_name = outputs_path
+        .file_name()
+        .expect("not a file")
+        .to_str()
+        .expect("test corpus file names are valid UTF-8");
     let outputs_file_name = ir_file_name.replace(".ir.ron", ".output.ron");
     outputs_path.pop();
     outputs_path.push(&outputs_file_name);


### PR DESCRIPTION
## Summary

- `FilesystemInterpreter` now takes `PathBuf` for its origin and propagates
  `Rc<PathBuf>` through all internal iterators; vertex path strings are
  normalized to forward slashes to keep serialized test data consistent
  across platforms.
- `trustfall_testbin` command functions accept `&Path` instead of `&str`;
  `get_schema_by_name` builds its path with `PathBuf`; `reserialize` and
  `corpus_graphql` use `Path::extension`/`file_stem` instead of `rsplit_once('.')`.
- `trustfall_filetests_macros` uses `display()` instead of `to_str().unwrap()`
  to avoid panicking on non-UTF-8 paths on Windows.

## Test plan

- [x] `cargo build -p trustfall_core -p trustfall_testbin -p trustfall_stubgen -p trustfall_filetests_macros` passes cleanly
- [x] `cargo test -p trustfall_core -p trustfall_stubgen` — 902 tests pass, 0 failed