### PR TITLE
add `repeatable` to all `@transform` definitions

### DIFF
--- a/demo-hytradboi/schema.graphql
+++ b/demo-hytradboi/schema.graphql
@@ -10,11 +10,11 @@ directive @filter(
 directive @tag(
     """Name to apply to the given property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """What to designate the output field generated from this property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/demo-hytradboi/schema.graphql
+++ b/demo-hytradboi/schema.graphql
@@ -29,7 +29,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 type RootSchemaQuery {
     MostDownloadedCrates: [Crate!]!

--- a/experiments/browser_based_querying/src/hackernews/schema.graphql
+++ b/experiments/browser_based_querying/src/hackernews/schema.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/experiments/browser_based_querying/src/hackernews/schema.graphql
+++ b/experiments/browser_based_querying/src/hackernews/schema.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/experiments/trustfall_rustdoc/src/rustdoc_schema.graphql
+++ b/experiments/trustfall_rustdoc/src/rustdoc_schema.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 type RootSchemaQuery {
   Crate: Crate!

--- a/pytrustfall/numbers.graphql
+++ b/pytrustfall/numbers.graphql
@@ -10,11 +10,11 @@ directive @filter(
 directive @tag(
     """Name to apply to the given property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """What to designate the output field generated from this property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/pytrustfall/numbers.graphql
+++ b/pytrustfall/numbers.graphql
@@ -29,7 +29,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 type RootSchemaQuery {
     Number(max: Int!): [Number!]

--- a/trustfall/examples/feeds/feeds.graphql
+++ b/trustfall/examples/feeds/feeds.graphql
@@ -37,7 +37,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 type RootSchemaQuery {
     Feed: [Feed!]!

--- a/trustfall/examples/feeds/feeds.graphql
+++ b/trustfall/examples/feeds/feeds.graphql
@@ -16,13 +16,13 @@ directive @tag(
     Name to apply to the given property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """
     What to designate the output field generated from this property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall/examples/hackernews/hackernews.graphql
+++ b/trustfall/examples/hackernews/hackernews.graphql
@@ -10,11 +10,11 @@ directive @filter(
 directive @tag(
     """Name to apply to the given property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """What to designate the output field generated from this property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall/examples/hackernews/hackernews.graphql
+++ b/trustfall/examples/hackernews/hackernews.graphql
@@ -29,7 +29,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 type RootSchemaQuery {
     FrontPage: [Item!]!

--- a/trustfall/examples/weather/metar_weather.graphql
+++ b/trustfall/examples/weather/metar_weather.graphql
@@ -10,11 +10,11 @@ directive @filter(
 directive @tag(
     """Name to apply to the given property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """What to designate the output field generated from this property field."""
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall/examples/weather/metar_weather.graphql
+++ b/trustfall/examples/weather/metar_weather.graphql
@@ -29,7 +29,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 type RootSchemaQuery {
     MetarReport: [MetarReport]

--- a/trustfall/tests/helper_macros.rs
+++ b/trustfall/tests/helper_macros.rs
@@ -85,7 +85,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Person: Vertex!

--- a/trustfall/tests/helper_macros.rs
+++ b/trustfall/tests/helper_macros.rs
@@ -80,8 +80,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/src/interpreter/helpers/tests.rs
+++ b/trustfall_core/src/interpreter/helpers/tests.rs
@@ -30,7 +30,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Vertex: Vertex!

--- a/trustfall_core/src/interpreter/helpers/tests.rs
+++ b/trustfall_core/src/interpreter/helpers/tests.rs
@@ -25,8 +25,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/schemas/filesystem.graphql
+++ b/trustfall_core/test_data/schemas/filesystem.graphql
@@ -13,7 +13,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 # This is an old and DEPRECATED schema.
 #

--- a/trustfall_core/test_data/schemas/filesystem.graphql
+++ b/trustfall_core/test_data/schemas/filesystem.graphql
@@ -8,8 +8,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/schemas/nullables.graphql
+++ b/trustfall_core/test_data/schemas/nullables.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     MainType: MainType

--- a/trustfall_core/test_data/schemas/nullables.graphql
+++ b/trustfall_core/test_data/schemas/nullables.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/schemas/numbers.graphql
+++ b/trustfall_core/test_data/schemas/numbers.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/schemas/numbers.graphql
+++ b/trustfall_core/test_data/schemas/numbers.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Number(min: Int! = 0, max: Int!): [Number!]

--- a/trustfall_core/test_data/schemas/parameterized_edges.graphql
+++ b/trustfall_core/test_data/schemas/parameterized_edges.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/schemas/parameterized_edges.graphql
+++ b/trustfall_core/test_data/schemas/parameterized_edges.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Vertex: Vertex!

--- a/trustfall_core/test_data/schemas/recurses.graphql
+++ b/trustfall_core/test_data/schemas/recurses.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/schemas/recurses.graphql
+++ b/trustfall_core/test_data/schemas/recurses.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/ambiguous_field_origin.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/ambiguous_field_origin.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/ambiguous_field_origin.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/ambiguous_field_origin.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Derived: Derived

--- a/trustfall_core/test_data/tests/schema_errors/circular_implements_relationship.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/circular_implements_relationship.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     A: A

--- a/trustfall_core/test_data/tests/schema_errors/circular_implements_relationship.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/circular_implements_relationship.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/completely_different_field_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/completely_different_field_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/completely_different_field_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/completely_different_field_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/edge_to_root_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/edge_to_root_query_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/edge_to_root_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/edge_to_root_query_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/explicit_null_default_for_non_nullable_edge_param.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/explicit_null_default_for_non_nullable_edge_param.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Vertex(param: Int! = null): Vertex

--- a/trustfall_core/test_data/tests/schema_errors/explicit_null_default_for_non_nullable_edge_param.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/explicit_null_default_for_non_nullable_edge_param.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/implementing_non_existent_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/implementing_non_existent_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Derived: Derived!

--- a/trustfall_core/test_data/tests/schema_errors/implementing_non_existent_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/implementing_non_existent_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/implementing_object_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/implementing_object_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/implementing_object_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/implementing_object_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base!

--- a/trustfall_core/test_data/tests/schema_errors/implementing_self_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/implementing_self_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/implementing_self_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/implementing_self_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base!

--- a/trustfall_core/test_data/tests/schema_errors/incorrect_default_value_type_for_edge_param.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/incorrect_default_value_type_for_edge_param.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/incorrect_default_value_type_for_edge_param.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/incorrect_default_value_type_for_edge_param.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Vertex(param: String = 123): Vertex

--- a/trustfall_core/test_data/tests/schema_errors/interface_with_same_field_twice.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/interface_with_same_field_twice.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_core/test_data/tests/schema_errors/interface_with_same_field_twice.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/interface_with_same_field_twice.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_core/test_data/tests/schema_errors/list_of_list_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/list_of_list_edge.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/list_of_list_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/list_of_list_edge.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/list_of_list_root_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/list_of_list_root_edge.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: [[Base]]

--- a/trustfall_core/test_data/tests/schema_errors/list_of_list_root_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/list_of_list_root_edge.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/missing_field_and_illegal_type_widening.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/missing_field_and_illegal_type_widening.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/missing_field_and_illegal_type_widening.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/missing_field_and_illegal_type_widening.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/missing_required_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/missing_required_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/missing_required_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/missing_required_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/one_type_one_interface_both_same_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/one_type_one_interface_both_same_name.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_core/test_data/tests/schema_errors/one_type_one_interface_both_same_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/one_type_one_interface_both_same_name.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_core/test_data/tests/schema_errors/parameterized_field_missing_parameter_in_subtype.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/parameterized_field_missing_parameter_in_subtype.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/parameterized_field_missing_parameter_in_subtype.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/parameterized_field_missing_parameter_in_subtype.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/parameters_in_property_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/parameters_in_property_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/parameters_in_property_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/parameters_in_property_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/property_on_root_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/property_on_root_query_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/property_on_root_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/property_on_root_query_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_edge_defined.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_edge_defined.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_edge_defined.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_edge_defined.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Foo: Foo

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_property_defined.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_property_defined.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_property_defined.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_property_defined.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Foo: Foo

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_query_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: __RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_query_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type __RootSchemaQuery {
     Foo: Foo

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_top_level_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_top_level_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_top_level_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_top_level_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     __Foo: Foo

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_type_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_type_name.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/reserved_prefix_type_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/reserved_prefix_type_name.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Foo: __Foo

--- a/trustfall_core/test_data/tests/schema_errors/root_edge_to_root_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/root_edge_to_root_query_type.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/root_edge_to_root_query_type.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/root_edge_to_root_query_type.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/subtype_adds_parameter_to_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/subtype_adds_parameter_to_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/subtype_adds_parameter_to_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/subtype_adds_parameter_to_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/transitive_interface_not_implemented.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/transitive_interface_not_implemented.graphql
@@ -2,8 +2,8 @@ schema {
   query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/transitive_interface_not_implemented.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/transitive_interface_not_implemented.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
   Final: Final

--- a/trustfall_core/test_data/tests/schema_errors/triple_list_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/triple_list_edge.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/triple_list_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/triple_list_edge.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/triple_list_root_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/triple_list_root_edge.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/triple_list_root_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/triple_list_root_edge.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: [[[Base]]]

--- a/trustfall_core/test_data/tests/schema_errors/two_interface_same_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/two_interface_same_name.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_core/test_data/tests/schema_errors/two_interface_same_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/two_interface_same_name.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_core/test_data/tests/schema_errors/two_types_same_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/two_types_same_name.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_core/test_data/tests/schema_errors/two_types_same_name.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/two_types_same_name.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge_list_param.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge_list_param.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge_list_param.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_narrowing_parameterized_edge_list_param.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_edge_supertype.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_edge_supertype.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_edge_supertype.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_edge_supertype.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_list_edge_supertype.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_list_edge_supertype.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_list_edge_supertype.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_list_edge_supertype.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_edge_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_edge_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_edge_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_edge_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_list_edge_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_list_edge_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_list_edge_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_nullability_on_list_edge_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_list_fields.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_list_fields.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_list_fields.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_list_fields.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_scalar_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_scalar_field.graphql
@@ -2,8 +2,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_scalar_field.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_widening_of_inherited_scalar_field.graphql
@@ -7,7 +7,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Base: Base

--- a/trustfall_core/test_data/tests/schema_errors/type_with_same_field_twice.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_with_same_field_twice.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_core/test_data/tests/schema_errors/type_with_same_field_twice.graphql
+++ b/trustfall_core/test_data/tests/schema_errors/type_with_same_field_twice.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/schema.graphql
@@ -16,13 +16,13 @@ directive @tag(
     Name to apply to the given property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """
     What to designate the output field generated from this property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/hackernews/adapter/schema.graphql
@@ -37,7 +37,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_stubgen/test_data/expected_outputs/no_edges/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/no_edges/adapter/schema.graphql
@@ -16,13 +16,13 @@ directive @tag(
     Name to apply to the given property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """
     What to designate the output field generated from this property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall_stubgen/test_data/expected_outputs/no_edges/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/no_edges/adapter/schema.graphql
@@ -37,7 +37,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_stubgen/test_data/expected_outputs/use_reserved_rust_names_in_schema/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/use_reserved_rust_names_in_schema/adapter/schema.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_stubgen/test_data/expected_outputs/use_reserved_rust_names_in_schema/adapter/schema.graphql
+++ b/trustfall_stubgen/test_data/expected_outputs/use_reserved_rust_names_in_schema/adapter/schema.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/hackernews.graphql
+++ b/trustfall_stubgen/test_data/hackernews.graphql
@@ -16,13 +16,13 @@ directive @tag(
     Name to apply to the given property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """
     What to designate the output field generated from this property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall_stubgen/test_data/hackernews.graphql
+++ b/trustfall_stubgen/test_data/hackernews.graphql
@@ -37,7 +37,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_stubgen/test_data/no_edges.graphql
+++ b/trustfall_stubgen/test_data/no_edges.graphql
@@ -16,13 +16,13 @@ directive @tag(
     Name to apply to the given property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
     """
     What to designate the output field generated from this property field.
     """
     name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
     """

--- a/trustfall_stubgen/test_data/no_edges.graphql
+++ b/trustfall_stubgen/test_data/no_edges.graphql
@@ -37,7 +37,7 @@ directive @transform(
     Name of the transformation operation to perform.
     """
     op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_stubgen/test_data/use_reserved_rust_names_in_schema.graphql
+++ b/trustfall_stubgen/test_data/use_reserved_rust_names_in_schema.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 All the possible data types where querying can begin in this API.

--- a/trustfall_stubgen/test_data/use_reserved_rust_names_in_schema.graphql
+++ b/trustfall_stubgen/test_data/use_reserved_rust_names_in_schema.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/use_type_and_typeunderscore_edge_names.graphql
+++ b/trustfall_stubgen/test_data/use_type_and_typeunderscore_edge_names.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/use_type_and_typeunderscore_edge_names.graphql
+++ b/trustfall_stubgen/test_data/use_type_and_typeunderscore_edge_names.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 Stubgen should panic if you have a type called {keyword} and another type called {keyword}_ since we rename {keyword}'s to {keyword}_ ourselves.

--- a/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edge_and_property.graphql
+++ b/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edge_and_property.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edge_and_property.graphql
+++ b/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edge_and_property.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 Stubgen should panic if you have a type called {keyword} and another type called {keyword}_ since we rename {keyword}'s to {keyword}_ ourselves.

--- a/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edges.graphql
+++ b/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edges.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edges.graphql
+++ b/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_edges.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 Stubgen should panic if you have a type called {keyword} and another type called {keyword}_ since we rename {keyword}'s to {keyword}_ ourselves.

--- a/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_properties.graphql
+++ b/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_properties.graphql
@@ -16,13 +16,13 @@ directive @tag(
   Name to apply to the given property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @output(
   """
   What to designate the output field generated from this property field.
   """
   name: String
-) on FIELD
+) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(
   """

--- a/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_properties.graphql
+++ b/trustfall_stubgen/test_data/vertextype_with_type_and_typeunderscore_properties.graphql
@@ -37,7 +37,7 @@ directive @transform(
   Name of the transformation operation to perform.
   """
   op: String!
-) on FIELD
+) repeatable on FIELD
 
 """
 Stubgen should panic if you have a type called {keyword} and another type called {keyword}_ since we rename {keyword}'s to {keyword}_ ourselves.

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -174,8 +174,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_wasm/tests/common.rs
+++ b/trustfall_wasm/tests/common.rs
@@ -179,7 +179,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Number(max: Int!): [Number!]

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -37,8 +37,8 @@ schema {
     query: RootSchemaQuery
 }
 directive @filter(op: String!, value: [String!]) repeatable on FIELD | INLINE_FRAGMENT
-directive @tag(name: String) on FIELD
-directive @output(name: String) on FIELD
+directive @tag(name: String) repeatable on FIELD
+directive @output(name: String) repeatable on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD

--- a/trustfall_wasm/tests/web.rs
+++ b/trustfall_wasm/tests/web.rs
@@ -42,7 +42,7 @@ directive @output(name: String) on FIELD
 directive @optional on FIELD
 directive @recurse(depth: Int!) on FIELD
 directive @fold on FIELD
-directive @transform(op: String!) on FIELD
+directive @transform(op: String!) repeatable on FIELD
 
 type RootSchemaQuery {
     Number(min: Int = 0, max: Int!): [Number!]


### PR DESCRIPTION
As discussed on the discord, some of the `@transform` definitions (and corresponding test outputs) were missing `repeatable`. I'm not getting any problems running `cargo test` locally.