### PR TITLE
Test repeatable query directives

### DIFF
--- a/trustfall_core/test_data/tests/valid_queries/repeatable_directives.graphql-parsed.ron
+++ b/trustfall_core/test_data/tests/valid_queries/repeatable_directives.graphql-parsed.ron
@@ -1,0 +1,94 @@
+Ok(TestParsedGraphQLQuery(
+  schema_name: "numbers",
+  query: Query(
+    root_connection: FieldConnection(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Four",
+    ),
+    root_field: FieldNode(
+      position: Pos(
+        line: 3,
+        column: 5,
+      ),
+      name: "Four",
+      connections: [
+        (FieldConnection(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+        ), FieldNode(
+          position: Pos(
+            line: 4,
+            column: 9,
+          ),
+          name: "value",
+          output: [
+            OutputDirective(
+              name: Some("first"),
+            ),
+            OutputDirective(
+              name: Some("second"),
+            ),
+          ],
+          tag: [
+            TagDirective(
+              name: Some("first_tag"),
+            ),
+            TagDirective(
+              name: Some("second_tag"),
+            ),
+          ],
+        )),
+        (FieldConnection(
+          position: Pos(
+            line: 9,
+            column: 9,
+          ),
+          name: "multiple",
+          arguments: {
+            "max": Int64(1),
+          },
+        ), FieldNode(
+          position: Pos(
+            line: 9,
+            column: 9,
+          ),
+          name: "multiple",
+          connections: [
+            (FieldConnection(
+              position: Pos(
+                line: 10,
+                column: 13,
+              ),
+              name: "value",
+            ), FieldNode(
+              position: Pos(
+                line: 10,
+                column: 13,
+              ),
+              name: "value",
+              filter: [
+                FilterDirective(
+                  operation: Equals((), TagRef("first_tag")),
+                ),
+                FilterDirective(
+                  operation: Equals((), TagRef("second_tag")),
+                ),
+              ],
+              output: [
+                OutputDirective(
+                  name: Some("multiple"),
+                ),
+              ],
+            )),
+          ],
+        )),
+      ],
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/repeatable_directives.graphql.ron
+++ b/trustfall_core/test_data/tests/valid_queries/repeatable_directives.graphql.ron
@@ -1,0 +1,19 @@
+TestGraphQLQuery (
+    schema_name: "numbers",
+    query: r#"
+{
+    Four {
+        value @output(name: "first")
+              @output(name: "second")
+              @tag(name: "first_tag")
+              @tag(name: "second_tag")
+
+        multiple(max: 1) {
+            value @filter(op: "=", value: ["%first_tag"])
+                  @filter(op: "=", value: ["%second_tag"])
+                  @output(name: "multiple")
+        }
+    }
+}"#,
+    arguments: {},
+)

--- a/trustfall_core/test_data/tests/valid_queries/repeatable_directives.ir.ron
+++ b/trustfall_core/test_data/tests/valid_queries/repeatable_directives.ir.ron
@@ -1,0 +1,67 @@
+Ok(TestIRQuery(
+  schema_name: "numbers",
+  ir_query: IRQuery(
+    root_name: "Four",
+    root_component: IRQueryComponent(
+      root: Vid(1),
+      vertices: {
+        Vid(1): IRVertex(
+          vid: Vid(1),
+          type_name: "Composite",
+        ),
+        Vid(2): IRVertex(
+          vid: Vid(2),
+          type_name: "Composite",
+          filters: [
+            Equals(LocalField(
+              field_name: "value",
+              field_type: "Int",
+            ), Tag(ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "value",
+              field_type: "Int",
+            )))),
+            Equals(LocalField(
+              field_name: "value",
+              field_type: "Int",
+            ), Tag(ContextField(ContextField(
+              vertex_id: Vid(1),
+              field_name: "value",
+              field_type: "Int",
+            )))),
+          ],
+        ),
+      },
+      edges: {
+        Eid(1): IREdge(
+          eid: Eid(1),
+          from_vid: Vid(1),
+          to_vid: Vid(2),
+          edge_name: "multiple",
+          parameters: EdgeParameters(
+            contents: {
+              "max": Int64(1),
+            },
+          ),
+        ),
+      },
+      outputs: {
+        "first": ContextField(
+          vertex_id: Vid(1),
+          field_name: "value",
+          field_type: "Int",
+        ),
+        "multiple": ContextField(
+          vertex_id: Vid(2),
+          field_name: "value",
+          field_type: "Int",
+        ),
+        "second": ContextField(
+          vertex_id: Vid(1),
+          field_name: "value",
+          field_type: "Int",
+        ),
+      },
+    ),
+  ),
+))

--- a/trustfall_core/test_data/tests/valid_queries/repeatable_directives.output.ron
+++ b/trustfall_core/test_data/tests/valid_queries/repeatable_directives.output.ron
@@ -1,0 +1,27 @@
+TestInterpreterOutputData(
+  schema_name: "numbers",
+  outputs: {
+    "first": Output(
+      name: "first",
+      value_type: "Int",
+      vid: Vid(1),
+    ),
+    "multiple": Output(
+      name: "multiple",
+      value_type: "Int",
+      vid: Vid(2),
+    ),
+    "second": Output(
+      name: "second",
+      value_type: "Int",
+      vid: Vid(1),
+    ),
+  },
+  results: [
+    {
+      "first": Int64(4),
+      "multiple": Int64(4),
+      "second": Int64(4),
+    },
+  ],
+)

--- a/trustfall_core/test_data/tests/valid_queries/repeatable_directives.trace.ron
+++ b/trustfall_core/test_data/tests/valid_queries/repeatable_directives.trace.ron
@@ -1,0 +1,597 @@
+TestInterpreterOutputTrace(
+  schema_name: "numbers",
+  trace: Trace(
+    ops: {
+      Opid(1): TraceOp(
+        opid: Opid(1),
+        parent_opid: None,
+        content: Call(ResolveStartingVertices(Vid(1))),
+      ),
+      Opid(2): TraceOp(
+        opid: Opid(2),
+        parent_opid: None,
+        content: Call(ResolveNeighbors(Vid(1), "Composite", Eid(1))),
+      ),
+      Opid(3): TraceOp(
+        opid: Opid(3),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
+      ),
+      Opid(4): TraceOp(
+        opid: Opid(4),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
+      ),
+      Opid(5): TraceOp(
+        opid: Opid(5),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
+      ),
+      Opid(6): TraceOp(
+        opid: Opid(6),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
+      ),
+      Opid(7): TraceOp(
+        opid: Opid(7),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
+      ),
+      Opid(8): TraceOp(
+        opid: Opid(8),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(2), "Composite", "value")),
+      ),
+      Opid(9): TraceOp(
+        opid: Opid(9),
+        parent_opid: None,
+        content: Call(ResolveProperty(Vid(1), "Composite", "value")),
+      ),
+      Opid(10): TraceOp(
+        opid: Opid(10),
+        parent_opid: Some(Opid(9)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(11): TraceOp(
+        opid: Opid(11),
+        parent_opid: Some(Opid(8)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(12): TraceOp(
+        opid: Opid(12),
+        parent_opid: Some(Opid(7)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(13): TraceOp(
+        opid: Opid(13),
+        parent_opid: Some(Opid(6)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(14): TraceOp(
+        opid: Opid(14),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(15): TraceOp(
+        opid: Opid(15),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(16): TraceOp(
+        opid: Opid(16),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(17): TraceOp(
+        opid: Opid(17),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(18): TraceOp(
+        opid: Opid(18),
+        parent_opid: Some(Opid(1)),
+        content: YieldFrom(ResolveStartingVertices(Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(19): TraceOp(
+        opid: Opid(19),
+        parent_opid: Some(Opid(2)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(20): TraceOp(
+        opid: Opid(20),
+        parent_opid: Some(Opid(2)),
+        content: YieldFrom(ResolveNeighborsOuter(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ))),
+      ),
+      Opid(21): TraceOp(
+        opid: Opid(21),
+        parent_opid: Some(Opid(20)),
+        content: YieldFrom(ResolveNeighborsInner(0, Composite(CompositeNumber(4, [
+          2,
+        ])))),
+      ),
+      Opid(22): TraceOp(
+        opid: Opid(22),
+        parent_opid: Some(Opid(3)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(23): TraceOp(
+        opid: Opid(23),
+        parent_opid: Some(Opid(3)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(24): TraceOp(
+        opid: Opid(24),
+        parent_opid: Some(Opid(4)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+          suspended_vertices: [
+            Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          ],
+        )),
+      ),
+      Opid(25): TraceOp(
+        opid: Opid(25),
+        parent_opid: Some(Opid(4)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+          suspended_vertices: [
+            Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          ],
+        ), Int64(4))),
+      ),
+      Opid(26): TraceOp(
+        opid: Opid(26),
+        parent_opid: Some(Opid(5)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(27): TraceOp(
+        opid: Opid(27),
+        parent_opid: Some(Opid(5)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(28): TraceOp(
+        opid: Opid(28),
+        parent_opid: Some(Opid(6)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+          suspended_vertices: [
+            Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          ],
+        )),
+      ),
+      Opid(29): TraceOp(
+        opid: Opid(29),
+        parent_opid: Some(Opid(6)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+          suspended_vertices: [
+            Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          ],
+        ), Int64(4))),
+      ),
+      Opid(30): TraceOp(
+        opid: Opid(30),
+        parent_opid: Some(Opid(7)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        )),
+      ),
+      Opid(31): TraceOp(
+        opid: Opid(31),
+        parent_opid: Some(Opid(7)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+        ), Int64(4))),
+      ),
+      Opid(32): TraceOp(
+        opid: Opid(32),
+        parent_opid: Some(Opid(8)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+        )),
+      ),
+      Opid(33): TraceOp(
+        opid: Opid(33),
+        parent_opid: Some(Opid(8)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+          ],
+        ), Int64(4))),
+      ),
+      Opid(34): TraceOp(
+        opid: Opid(34),
+        parent_opid: Some(Opid(9)),
+        content: YieldInto(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+            Int64(4),
+          ],
+        )),
+      ),
+      Opid(35): TraceOp(
+        opid: Opid(35),
+        parent_opid: Some(Opid(9)),
+        content: YieldFrom(ResolveProperty(SerializableContext(
+          active_vertex: Some(Composite(CompositeNumber(4, [
+            2,
+          ]))),
+          vertices: {
+            Vid(1): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+            Vid(2): Some(Composite(CompositeNumber(4, [
+              2,
+            ]))),
+          },
+          values: [
+            Int64(4),
+            Int64(4),
+          ],
+        ), Int64(4))),
+      ),
+      Opid(36): TraceOp(
+        opid: Opid(36),
+        parent_opid: None,
+        content: ProduceQueryResult({
+          "first": Int64(4),
+          "multiple": Int64(4),
+          "second": Int64(4),
+        }),
+      ),
+      Opid(37): TraceOp(
+        opid: Opid(37),
+        parent_opid: Some(Opid(9)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(38): TraceOp(
+        opid: Opid(38),
+        parent_opid: Some(Opid(8)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(39): TraceOp(
+        opid: Opid(39),
+        parent_opid: Some(Opid(7)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(40): TraceOp(
+        opid: Opid(40),
+        parent_opid: Some(Opid(6)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(41): TraceOp(
+        opid: Opid(41),
+        parent_opid: Some(Opid(5)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(42): TraceOp(
+        opid: Opid(42),
+        parent_opid: Some(Opid(4)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(43): TraceOp(
+        opid: Opid(43),
+        parent_opid: Some(Opid(3)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(44): TraceOp(
+        opid: Opid(44),
+        parent_opid: Some(Opid(20)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(45): TraceOp(
+        opid: Opid(45),
+        parent_opid: Some(Opid(2)),
+        content: AdvanceInputIterator,
+      ),
+      Opid(46): TraceOp(
+        opid: Opid(46),
+        parent_opid: Some(Opid(1)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(47): TraceOp(
+        opid: Opid(47),
+        parent_opid: Some(Opid(2)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(48): TraceOp(
+        opid: Opid(48),
+        parent_opid: Some(Opid(2)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(49): TraceOp(
+        opid: Opid(49),
+        parent_opid: Some(Opid(3)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(50): TraceOp(
+        opid: Opid(50),
+        parent_opid: Some(Opid(3)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(51): TraceOp(
+        opid: Opid(51),
+        parent_opid: Some(Opid(4)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(52): TraceOp(
+        opid: Opid(52),
+        parent_opid: Some(Opid(4)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(53): TraceOp(
+        opid: Opid(53),
+        parent_opid: Some(Opid(5)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(54): TraceOp(
+        opid: Opid(54),
+        parent_opid: Some(Opid(5)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(55): TraceOp(
+        opid: Opid(55),
+        parent_opid: Some(Opid(6)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(56): TraceOp(
+        opid: Opid(56),
+        parent_opid: Some(Opid(6)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(57): TraceOp(
+        opid: Opid(57),
+        parent_opid: Some(Opid(7)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(58): TraceOp(
+        opid: Opid(58),
+        parent_opid: Some(Opid(7)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(59): TraceOp(
+        opid: Opid(59),
+        parent_opid: Some(Opid(8)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(60): TraceOp(
+        opid: Opid(60),
+        parent_opid: Some(Opid(8)),
+        content: OutputIteratorExhausted,
+      ),
+      Opid(61): TraceOp(
+        opid: Opid(61),
+        parent_opid: Some(Opid(9)),
+        content: InputIteratorExhausted,
+      ),
+      Opid(62): TraceOp(
+        opid: Opid(62),
+        parent_opid: Some(Opid(9)),
+        content: OutputIteratorExhausted,
+      ),
+    },
+    ir_query: IRQuery(
+      root_name: "Four",
+      root_component: IRQueryComponent(
+        root: Vid(1),
+        vertices: {
+          Vid(1): IRVertex(
+            vid: Vid(1),
+            type_name: "Composite",
+          ),
+          Vid(2): IRVertex(
+            vid: Vid(2),
+            type_name: "Composite",
+            filters: [
+              Equals(LocalField(
+                field_name: "value",
+                field_type: "Int",
+              ), Tag(ContextField(ContextField(
+                vertex_id: Vid(1),
+                field_name: "value",
+                field_type: "Int",
+              )))),
+              Equals(LocalField(
+                field_name: "value",
+                field_type: "Int",
+              ), Tag(ContextField(ContextField(
+                vertex_id: Vid(1),
+                field_name: "value",
+                field_type: "Int",
+              )))),
+            ],
+          ),
+        },
+        edges: {
+          Eid(1): IREdge(
+            eid: Eid(1),
+            from_vid: Vid(1),
+            to_vid: Vid(2),
+            edge_name: "multiple",
+            parameters: EdgeParameters(
+              contents: {
+                "max": Int64(1),
+              },
+            ),
+          ),
+        },
+        outputs: {
+          "first": ContextField(
+            vertex_id: Vid(1),
+            field_name: "value",
+            field_type: "Int",
+          ),
+          "multiple": ContextField(
+            vertex_id: Vid(2),
+            field_name: "value",
+            field_type: "Int",
+          ),
+          "second": ContextField(
+            vertex_id: Vid(1),
+            field_name: "value",
+            field_type: "Int",
+          ),
+        },
+      ),
+    ),
+  ),
+)


### PR DESCRIPTION
## Summary

- add a numbers-adapter query that repeats `@output`, `@tag`, and `@filter` directives
- add the generated parsed-query, IR, output, and execution-trace fixtures

## Why

Trustfall already stores and processes every instance of these directives, but the test suite did not have one positive query covering repeated outputs and repeated tags. This locks in the existing runtime behavior independently of the schema-definition cleanup.

## Validation

- `cargo test -p trustfall_core repeatable_directives -- --nocapture` (4 passed)