### PR TITLE
Release Python `trustfall` library v0.3.2 with unsoundness fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "pytrustfall"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",

--- a/pytrustfall/Cargo.toml
+++ b/pytrustfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pytrustfall"
-version = "0.3.1"
+version = "0.3.2"
 rust-version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Primarily looking to get #960 out there.
